### PR TITLE
Localize navigation title for organizer's profile

### DIFF
--- a/MyLibrary/Sources/trySwiftFeature/Profile.swift
+++ b/MyLibrary/Sources/trySwiftFeature/Profile.swift
@@ -86,7 +86,7 @@ public struct ProfileView: View {
           .padding()
           .frame(maxWidth: 700)
       }
-      .navigationTitle(store.organizer.name)
+      .navigationTitle(Text(LocalizedStringKey(store.organizer.name), bundle: .module))
     }
     .sheet(item: $store.scope(state: \.destination?.safari, action: \.destination.safari)) { sheetStore in
       SafariViewRepresentation(url: sheetStore.url)


### PR DESCRIPTION
## やったこと

- 主催者プロフィールのナビゲーションタイトルをローカライズしました。

## スクショ

| before | after |
| -- | -- |
| <img src="https://github.com/tryswift/trySwiftTokyoApp/assets/35392604/46db1812-ba30-47d7-8b0b-36ad315260a2" width=300>| <img src="https://github.com/tryswift/trySwiftTokyoApp/assets/35392604/dc634505-bfad-4de3-9db3-2497f7fe168c" width=300>| 


