### PR TITLE
:bug: Disable package plugin fingerprint validation in Xcode on CI

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -42,6 +42,9 @@ jobs:
           restore-keys: xcode-${{ runner.os }}-
           path: ~/DerivedData/SourcePackages
 
+      - name: Skip Package Plugin Fingerprint Validatation
+        run: defaults write com.apple.dt.Xcode IDESkipPackagePluginFingerprintValidatation -bool YES
+
       - name: Skip Macro Fingerprint Validation
         run: defaults write com.apple.dt.Xcode IDESkipMacroFingerprintValidation -bool YES
 


### PR DESCRIPTION
# Why this is needed

On GitHub Actions, Xcode fail to validate package plugins, leading to interrupted builds.
This workaround ensures that the build proceeds without unnecessary validation failures.

This command was already implemented in our Xcode Cloud configuration, and we are applying the same approach here.

https://github.com/tryswift/try-swift-tokyo/blob/2d8917dcada30a33f8c81ce3cda5d6b0b60bf858/ci_scripts/ci_post_clone.sh#L3-L4

ref: https://github.com/tryswift/try-swift-tokyo/actions/runs/14009833227/job/39228229829
ref: https://github.com/tryswift/try-swift-tokyo/pull/68