### PR TITLE
Fixed crash in Acknowledgements

### DIFF
--- a/MyLibrary/Sources/trySwiftFeature/Acknowledgements.swift
+++ b/MyLibrary/Sources/trySwiftFeature/Acknowledgements.swift
@@ -30,27 +30,27 @@ public struct Acknowledgements {
 public struct AcknowledgementsView: View {
 
   @Bindable public var store: StoreOf<Acknowledgements>
+    public var body: some View {
+        List {
+            ForEach(LicensesPlugin.licenses) { license in
+                NavigationLink(license.name) {
+                  VStack {
+                    if let licenseText = license.licenseText {
+                      ScrollView {
+                        Text(licenseText)
+                          .padding()
+                      }
+                    } else {
+                      Text("No License Found")
+                    }
+                  }
+                  .navigationTitle(license.name)
+                }
 
-  public var body: some View {
-    List {
-      ForEach(LicensesPlugin.licenses) { license in
-        NavigationStack {
-          Group {
-            if let licenseText = license.licenseText {
-              ScrollView {
-                Text(licenseText)
-                  .padding()
-              }
-            } else {
-              Text("No License Found")
             }
-          }
-          .navigationTitle(license.name)
         }
-      }
+        .navigationTitle(Text("Acknowledgements", bundle: .module))
     }
-    .navigationTitle(Text("Acknowledgements", bundle: .module))
-  }
 }
 
 #Preview {


### PR DESCRIPTION
Resolved a crash when opening the Acknowledgements view.
The design may be different.
I addressed this by guessing what you wanted to do based on last year's design and what you wanted to do based on the code.
If it is different from your image, please let me know.

<details> 
<summary> 日本語 </summary>
謝辞画面を開くとクラッシュする問題を解決しました。
デザインが異なる可能性があります。
昨年のデザインと、コードからやりたいことを推測して対応しました。
イメージと異なっていたら、ご指摘ください。
</details>


| iOS | iPadOS |
| :----: | :----: |
| <img src="https://github.com/user-attachments/assets/acfd2162-c1ea-4fba-9b7e-72a48bcadaf7" width=300> |  <img src="https://github.com/user-attachments/assets/29a2308f-2294-4ff5-a1b4-33f9ddc3de5a" width=300> | 
| <img src="https://github.com/user-attachments/assets/0f8de3b3-fcd0-46f2-8888-78a5253725b0" width=300> |  <img src="https://github.com/user-attachments/assets/e6f9de3b-0b57-48e7-8fea-f41db05a45d5" width=300> | 
| <img src="https://github.com/user-attachments/assets/ed1ff0bf-2641-49f9-8125-14ee66c1355b" width=300> |  <img src="https://github.com/user-attachments/assets/b9d66723-9411-448e-806c-47ceeb8287c3" width=300> | 
