### PR TITLE
Try to add retry feature of live translating

### DIFF
--- a/MyLibrary/Sources/LiveTranslationFeature/LiveTranslationView.swift
+++ b/MyLibrary/Sources/LiveTranslationFeature/LiveTranslationView.swift
@@ -5,17 +5,17 @@ public struct LiveTranslationView: View {
   let viewModel: ViewModel
   @State var isSelectedLanguageSheet: Bool = false
   @State var isShowingLastChat: Bool = false
-
+  
   private let scrollContentBottomID: String = "atBottom"
-
+  
   public init(
     roomNumber: String = ProcessInfo.processInfo.environment["LIVE_TRANSLATION_KEY"]
-      ?? (Bundle.main.infoDictionary?["Live translation room number"] as? String) ?? ""
+    ?? (Bundle.main.infoDictionary?["Live translation room number"] as? String) ?? ""
   ) {
     print(roomNumber)
     self.viewModel = ViewModel(roomNumber: roomNumber)
   }
-
+  
   public var body: some View {
     NavigationStack {
       VStack {
@@ -45,7 +45,7 @@ public struct LiveTranslationView: View {
                 }
               }
             }
-
+            
             HStack {
               Spacer()
               Text("Powered by", bundle: .module)
@@ -66,9 +66,9 @@ public struct LiveTranslationView: View {
               reader.scrollTo(scrollContentBottomID, anchor: .bottom)
               return
             }
-
+            
             guard isShowingLastChat else { return }
-
+            
             guard new != .none else { return }
             withAnimation(.interactiveSpring) {
               reader.scrollTo(scrollContentBottomID, anchor: .center)
@@ -82,12 +82,21 @@ public struct LiveTranslationView: View {
       }
       .navigationTitle(Text("Live translation", bundle: .module))
       .toolbar {
-        ToolbarItem(placement: .navigationBarTrailing) {
+        if !viewModel.isConnected {
+          ToolbarItem(placement: .topBarLeading) {
+            Button {
+              viewModel.send(.connectChatStream)
+            } label: {
+              Image(systemName: "arrow.trianglehead.2.clockwise")
+            }
+          }
+        }
+        ToolbarItem(placement: .topBarTrailing) {
           Button {
             isSelectedLanguageSheet.toggle()
           } label: {
             let selectedLanguage =
-              viewModel.langSet?.langCodingKey(viewModel.selectedLangCode) ?? ""
+            viewModel.langSet?.langCodingKey(viewModel.selectedLangCode) ?? ""
             Text(selectedLanguage)
             Image(systemName: "globe")
           }

--- a/MyLibrary/Sources/LiveTranslationFeature/ViewModel.swift
+++ b/MyLibrary/Sources/LiveTranslationFeature/ViewModel.swift
@@ -23,6 +23,10 @@ public final class ViewModel {
   var updateChatWaitingQueue: [RealTimeEntity.Chat.Response] = []
   var updateTrWaitingQueue: [RealTimeEntity.Translation.Response] = []
   var latestListType: RealTimeEntity.ListType? = .none
+  
+  /// # isConnected
+  ///  connecting state with LiveTranslationService
+  var isConnected: Bool = false
 }
 
 extension ViewModel {
@@ -84,8 +88,12 @@ extension ViewModel {
       let stream = service.chatConnection(.init(interactionKey: roomNumber))
       for try await action in stream {
         switch action {
-        case .connect: break
-        case .disconnect: break
+        case .connect:
+          self.isConnected = true
+          break
+        case .disconnect:
+          self.isConnected = false
+          break
         case .peerClosed:
           send(.connectChatStream)
         case .responseChat(let chatItem):


### PR DESCRIPTION
I tried to implement a retrying feature for live translating.

On the first day, I encountered a problem where the live translating feature sometimes stopped, and I couldn’t return to it by myself.

So, I tried to make the app store the current connection state and show a retry button when the connection closes.
However, I couldn’t reproduce the closed connection, and I’m not sure if this code can prevent the situation I faced on the first day. Could you please check it?