### PR TITLE
Fix Live Translation not working when app returns to foreground

### DIFF
--- a/MyLibrary/Sources/LiveTranslationFeature/LiveTranslationView.swift
+++ b/MyLibrary/Sources/LiveTranslationFeature/LiveTranslationView.swift
@@ -6,6 +6,8 @@ public struct LiveTranslationView: View {
   @State var isSelectedLanguageSheet: Bool = false
   @State var isShowingLastChat: Bool = false
 
+  @Environment(\.scenePhase) var scenePhase
+
   private let scrollContentBottomID: String = "atBottom"
 
   public init(
@@ -79,6 +81,16 @@ public struct LiveTranslationView: View {
       .task {
         viewModel.send(.onAppearedPage)
         viewModel.send(.connectChatStream)
+      }
+      .onChange(of: scenePhase) {
+        switch scenePhase {
+        case .inactive: break
+        case .active:
+          viewModel.send(.connectChatStream)
+        case .background:
+          viewModel.send(.disconnectChatStream)
+        @unknown default: break
+        }
       }
       .navigationTitle(Text("Live translation", bundle: .module))
       .toolbar {

--- a/MyLibrary/Sources/LiveTranslationFeature/ViewModel.swift
+++ b/MyLibrary/Sources/LiveTranslationFeature/ViewModel.swift
@@ -23,6 +23,7 @@ public final class ViewModel {
   var updateChatWaitingQueue: [RealTimeEntity.Chat.Response] = []
   var updateTrWaitingQueue: [RealTimeEntity.Translation.Response] = []
   var latestListType: RealTimeEntity.ListType? = .none
+  var chatStreamTask: Task<Void, Never>? = nil
 }
 
 extension ViewModel {
@@ -37,9 +38,13 @@ extension ViewModel {
         }
       }
     case .connectChatStream:
-      Task {
+      chatStreamTask = Task {
         await connectChatStream(roomNumber)
       }
+
+    case .disconnectChatStream:
+      chatStreamTask?.cancel()
+
     case .changeLangCode(let newLangCode):
       selectedLangCode = newLangCode
       Task {
@@ -315,6 +320,7 @@ extension ViewModel {
   public enum InputAction {
     case onAppearedPage
     case connectChatStream
+    case disconnectChatStream
     case changeLangCode(String)
   }
 }


### PR DESCRIPTION
別のPR( https://github.com/tryswift/try-swift-tokyo/pull/93 )でも直されていますが、別案として...(タブが切り替わった時にもdisconnectすべきな気がしますが、そこは一旦考慮していません)
