### PR TITLE
[HP] Modify ticket content display size

### DIFF
--- a/Website/Sources/Components/TicketsComponent.swift
+++ b/Website/Sources/Components/TicketsComponent.swift
@@ -1,60 +1,60 @@
 import Ignite
 
 struct TicketsComponent: HTML {
-    let language: SupportedLanguage
+  let language: SupportedLanguage
 
-    var body: some HTML {
+  var body: some HTML {
+    Section {
+      Text(
+        markdown: String(
+          "You can get ticket from <a href=\"https://luma.com/qydkgwtf\" target=\"_blank\">Luma</a> or get from below.<br>Before getting ticket please read [FAQ](/faq_en).",
+          language: language
+        )
+      )
+      .font(.lead)
+      .foregroundStyle(.dimGray)
+      .margin(.bottom, .px(20))
+
+      Section {
+        // It specifies the optimal size according to the screen size, but since the method to directly specify MediaQuery is unclear, it is being handled by branching.
         Section {
-            Text(
-                markdown: String(
-                    "You can get ticket from <a href=\"https://luma.com/qydkgwtf\" target=\"_blank\">Luma</a> or get from below.<br>Before getting ticket please read [FAQ](/faq_en).",
-                    language: language
-                )
-            )
-            .font(.lead)
-            .foregroundStyle(.dimGray)
-            .margin(.bottom, .px(20))
+          Embed(
+            title: String("Tickets", language: language),
+            url: "https://luma.com/embed/event/evt-WHT17EaVs2of1Gs/simple"
+          )
+          .aspectRatio(1)
+          .frame(height: .px(1300))
+          .margin(.bottom, .px(96))
+        }
+        .hidden(.responsive(small: true))
 
-            Section {
-                // It specifies the optimal size according to the screen size, but since the method to directly specify MediaQuery is unclear, it is being handled by branching.
-                Section {
-                    Embed(
-                        title: String("Tickets", language: language),
-                        url: "https://luma.com/embed/event/evt-WHT17EaVs2of1Gs/simple"
-                    )
-                    .aspectRatio(1)
-                    .frame(height: .px(1300))
-                    .margin(.bottom, .px(96))
-                }
-                .hidden(.responsive(small: true))
+        Section {
+          Embed(
+            title: String("Tickets", language: language),
+            url: "https://luma.com/embed/event/evt-WHT17EaVs2of1Gs/simple"
+          )
+          .aspectRatio(1)
+          .frame(height: .px(1000))
+          .margin(.bottom, .px(96))
+        }
+        .hidden(.responsive(true, small: false))
+      }
 
-                Section {
-                    Embed(
-                        title: String("Tickets", language: language),
-                        url: "https://luma.com/embed/event/evt-WHT17EaVs2of1Gs/simple"
-                    )
-                    .aspectRatio(1)
-                    .frame(height: .px(1000))
-                    .margin(.bottom, .px(96))
-                }
-                .hidden(.responsive(true, small: false))
-            }
+      Text(String("The latest information is announced on X", language: language))
+        .font(.title3)
+        .foregroundStyle(.dimGray)
+        .margin(.bottom, .px(16))
 
-            Text(String("The latest information is announced on X", language: language))
-                .font(.title3)
-                .foregroundStyle(.dimGray)
-                .margin(.bottom, .px(16))
-
-            Link(
-                String("Check updates on X", language: language),
-                target: "https://x.com/tryswiftconf"
-            )
-            .target(.newWindow)
-            .linkStyle(.button)
-            .role(.light)
-            .font(.lead)
-            .fontWeight(.medium)
-            .foregroundStyle(.orangeRed)
-        }.horizontalAlignment(.center)
-    }
+      Link(
+        String("Check updates on X", language: language),
+        target: "https://x.com/tryswiftconf"
+      )
+      .target(.newWindow)
+      .linkStyle(.button)
+      .role(.light)
+      .font(.lead)
+      .fontWeight(.medium)
+      .foregroundStyle(.orangeRed)
+    }.horizontalAlignment(.center)
+  }
 }


### PR DESCRIPTION
# Overview

I have implemented switching of the ticket purchase screen display based on the screen size.

<img width="100%" alt="CleanShot 2025-12-20 at 15 48 39@2x" src="https://github.com/user-attachments/assets/9d9e472a-7f2d-41d1-a075-412a14d7971c" />

<img width="50%" alt="CleanShot 2025-12-20 at 15 48 56@2x" src="https://github.com/user-attachments/assets/3c2abe27-b217-4532-aa14-2cfcb5d5e3ac" />
