### PR TITLE
✨ Changed the macOS version on which the website is deployed

### DIFF
--- a/.github/workflows/deploy_website.yml
+++ b/.github/workflows/deploy_website.yml
@@ -28,7 +28,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: macos-15
+    runs-on: macos-26
     env:
       DEVELOPER_DIR: /Applications/Xcode.app
     steps:


### PR DESCRIPTION
> Resolve Package Graph
> package 'mylibrary' is using Swift tools version 6.2.0 but the installed version is 6.1.0

https://github.com/tryswift/try-swift-tokyo/actions/runs/20720790355/job/59483703812

ref: https://github.com/actions/runner-images/blob/main/images/macos/macos-26-arm64-Readme.md