### PR TITLE
CfPWebsite: Migrate from Ignite to vapor-elementary SSR

### DIFF
--- a/Server/Package.resolved
+++ b/Server/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fd9b2faa62aea67bc96cd1c9cdd7024bc9807a529ccb710b953bfb7dc38f2e9e",
+  "originHash" : "26da217de5521b74404cb9cbc29209300ba2856d627fe363b3d46afd460780a3",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -26,6 +26,15 @@
       "state" : {
         "revision" : "742f624a998cba2a9e653d9b1e91ad3f3a5dff6b",
         "version" : "4.15.2"
+      }
+    },
+    {
+      "identity" : "elementary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/elementary-swift/elementary.git",
+      "state" : {
+        "revision" : "65803c4770b6c8b6452c6ce83ab570c1b7042528",
+        "version" : "0.6.1"
       }
     },
     {
@@ -314,6 +323,15 @@
       "state" : {
         "revision" : "6f3db7122ccffb28e11e121c3797a176fcb88796",
         "version" : "4.121.1"
+      }
+    },
+    {
+      "identity" : "vapor-elementary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/vapor-community/vapor-elementary.git",
+      "state" : {
+        "revision" : "e1326d2439a9d4bd271c24b9765c195f7f793e77",
+        "version" : "0.2.2"
       }
     },
     {

--- a/Server/Package.swift
+++ b/Server/Package.swift
@@ -13,6 +13,7 @@ let package = Package(
     .package(url: "https://github.com/vapor/fluent.git", from: "4.12.0"),
     .package(url: "https://github.com/vapor/fluent-postgres-driver.git", from: "2.10.0"),
     .package(url: "https://github.com/vapor/jwt.git", from: "5.1.0"),
+    .package(url: "https://github.com/vapor-community/vapor-elementary.git", from: "0.2.0"),
     .package(name: "SharedModels", path: "../SharedModels"),
   ],
   targets: [
@@ -24,6 +25,7 @@ let package = Package(
         .product(name: "Fluent", package: "fluent"),
         .product(name: "FluentPostgresDriver", package: "fluent-postgres-driver"),
         .product(name: "JWT", package: "jwt"),
+        .product(name: "VaporElementary", package: "vapor-elementary"),
       ],
       swiftSettings: [
         .swiftLanguageMode(.v6)

--- a/Server/Sources/Server/CfP/CfPRoutes.swift
+++ b/Server/Sources/Server/CfP/CfPRoutes.swift
@@ -1,0 +1,240 @@
+import Fluent
+import JWT
+import SharedModels
+import Vapor
+import VaporElementary
+
+/// Routes for CfP SSR pages
+struct CfPRoutes: RouteCollection {
+  func boot(routes: RoutesBuilder) throws {
+    let cfp = routes.grouped("cfp")
+
+    // Public pages
+    cfp.get(use: homePage)
+    cfp.get("guidelines", use: guidelinesPage)
+    cfp.get("login", use: loginPage)
+    cfp.get("login-page", use: loginPage)  // Backward compatibility
+
+    // Auth-aware pages (check auth but don't require it)
+    cfp.get("submit", use: submitPage)
+    cfp.get("submit-page", use: submitPage)  // Backward compatibility
+    cfp.get("my-proposals", use: myProposalsPage)
+    cfp.get("my-proposals-page", use: myProposalsPage)  // Backward compatibility
+
+    // Form submission (POST)
+    cfp.post("submit", use: handleSubmitProposal)
+
+    // Logout
+    cfp.get("logout", use: logout)
+  }
+
+  // MARK: - Page Handlers
+
+  @Sendable
+  func homePage(req: Request) async throws -> HTMLResponse {
+    let user = try? await getAuthenticatedUser(req: req)
+    return HTMLResponse {
+      CfPLayout(title: "Call for Proposals", user: user) {
+        CfPHomePage(user: user)
+      }
+    }
+  }
+
+  @Sendable
+  func guidelinesPage(req: Request) async throws -> HTMLResponse {
+    let user = try? await getAuthenticatedUser(req: req)
+    return HTMLResponse {
+      CfPLayout(title: "Submission Guidelines", user: user) {
+        GuidelinesPageView(user: user)
+      }
+    }
+  }
+
+  @Sendable
+  func loginPage(req: Request) async throws -> HTMLResponse {
+    let user = try? await getAuthenticatedUser(req: req)
+    let error = req.query[String.self, at: "error"]
+    return HTMLResponse {
+      CfPLayout(title: "Login", user: user) {
+        LoginPageView(user: user, error: error)
+      }
+    }
+  }
+
+  @Sendable
+  func submitPage(req: Request) async throws -> HTMLResponse {
+    let user = try? await getAuthenticatedUser(req: req)
+    let success = req.query[String.self, at: "success"] == "true"
+    return HTMLResponse {
+      CfPLayout(title: "Submit Proposal", user: user) {
+        SubmitPageView(user: user, success: success, errorMessage: nil)
+      }
+    }
+  }
+
+  @Sendable
+  func myProposalsPage(req: Request) async throws -> HTMLResponse {
+    let user = try? await getAuthenticatedUser(req: req)
+    var proposals: [ProposalDTO] = []
+
+    if let user {
+      let dbProposals = try await Proposal.query(on: req.db)
+        .filter(\.$speaker.$id == user.id)
+        .with(\.$conference)
+        .sort(\.$createdAt, .descending)
+        .all()
+      proposals = try dbProposals.map {
+        try $0.toDTO(speakerUsername: user.username, conference: $0.conference)
+      }
+    }
+
+    return HTMLResponse {
+      CfPLayout(title: "My Proposals", user: user) {
+        MyProposalsPageView(user: user, proposals: proposals)
+      }
+    }
+  }
+
+  // MARK: - Form Handlers
+
+  @Sendable
+  func handleSubmitProposal(req: Request) async throws -> Response {
+    guard let user = try? await getAuthenticatedUser(req: req) else {
+      return req.redirect(to: "/api/v1/auth/github?returnTo=/cfp/submit")
+    }
+
+    // Decode form data
+    struct ProposalFormData: Content {
+      var title: String
+      var abstract: String
+      var talkDetails: String
+      var talkDuration: String
+      var bio: String
+      var iconUrl: String?
+      var notesToOrganizers: String?
+    }
+
+    let formData: ProposalFormData
+    do {
+      formData = try req.content.decode(ProposalFormData.self)
+    } catch {
+      return try await renderSubmitPageWithError(
+        req: req, user: user, error: "Invalid form data")
+    }
+
+    // Validate
+    guard !formData.title.isEmpty else {
+      return try await renderSubmitPageWithError(req: req, user: user, error: "Title is required")
+    }
+    guard !formData.abstract.isEmpty else {
+      return try await renderSubmitPageWithError(
+        req: req, user: user, error: "Abstract is required")
+    }
+    guard !formData.talkDetails.isEmpty else {
+      return try await renderSubmitPageWithError(
+        req: req, user: user, error: "Talk details are required")
+    }
+    guard !formData.bio.isEmpty else {
+      return try await renderSubmitPageWithError(
+        req: req, user: user, error: "Speaker bio is required")
+    }
+
+    guard let talkDuration = TalkDuration(rawValue: formData.talkDuration) else {
+      return try await renderSubmitPageWithError(
+        req: req, user: user, error: "Please select a talk duration")
+    }
+
+    // Find current open conference
+    guard
+      let conference = try await Conference.query(on: req.db)
+        .filter(\.$isOpen == true)
+        .sort(\.$year, .descending)
+        .first()
+    else {
+      return try await renderSubmitPageWithError(
+        req: req, user: user, error: "No open conference for submissions")
+    }
+
+    guard let conferenceID = conference.id else {
+      return try await renderSubmitPageWithError(
+        req: req, user: user, error: "Conference configuration error")
+    }
+
+    // Create proposal
+    let proposal = Proposal(
+      conferenceID: conferenceID,
+      title: formData.title,
+      abstract: formData.abstract,
+      talkDetail: formData.talkDetails,
+      talkDuration: talkDuration,
+      bio: formData.bio,
+      iconURL: formData.iconUrl?.isEmpty == true ? nil : formData.iconUrl,
+      notes: formData.notesToOrganizers?.isEmpty == true ? nil : formData.notesToOrganizers,
+      speakerID: user.id
+    )
+
+    try await proposal.save(on: req.db)
+
+    // Redirect to success page
+    return req.redirect(to: "/cfp/submit?success=true")
+  }
+
+  private func renderSubmitPageWithError(req: Request, user: UserDTO, error: String) async throws
+    -> Response
+  {
+    let html = HTMLResponse {
+      CfPLayout(title: "Submit Proposal", user: user) {
+        SubmitPageView(user: user, success: false, errorMessage: error)
+      }
+    }
+    return try await html.encodeResponse(for: req)
+  }
+
+  // MARK: - Logout
+
+  @Sendable
+  func logout(req: Request) async throws -> Response {
+    let response = req.redirect(to: "/cfp/")
+
+    // Clear auth cookies
+    response.cookies["cfp_token"] = HTTPCookies.Value(
+      string: "",
+      expires: Date(timeIntervalSince1970: 0),
+      maxAge: 0,
+      path: "/",
+      isHTTPOnly: true
+    )
+    response.cookies["cfp_username"] = HTTPCookies.Value(
+      string: "",
+      expires: Date(timeIntervalSince1970: 0),
+      maxAge: 0,
+      path: "/",
+      isHTTPOnly: false
+    )
+
+    return response
+  }
+
+  // MARK: - Helper Methods
+
+  /// Get authenticated user from cookie or authorization header
+  func getAuthenticatedUser(req: Request) async throws -> UserDTO? {
+    // Try to get token from cookie first, then Authorization header
+    let token: String?
+    if let cookieToken = req.cookies["cfp_token"]?.string, !cookieToken.isEmpty {
+      token = cookieToken
+    } else if let authHeader = req.headers.bearerAuthorization?.token {
+      token = authHeader
+    } else {
+      return nil
+    }
+
+    guard let token else { return nil }
+
+    let payload = try await req.jwt.verify(token, as: UserJWTPayload.self)
+    guard let userID = payload.userID else { return nil }
+    guard let user = try await User.find(userID, on: req.db) else { return nil }
+
+    return try user.toDTO()
+  }
+}

--- a/Server/Sources/Server/CfP/Components/CfPFooter.swift
+++ b/Server/Sources/Server/CfP/Components/CfPFooter.swift
@@ -1,0 +1,28 @@
+import Elementary
+
+struct CfPFooter: HTML, Sendable {
+  var body: some HTML {
+    footer(.class("py-5 text-center"), .style("background: #00203f;")) {
+      div(.class("container")) {
+        div(.class("mb-3")) {
+          a(.class("text-white text-decoration-none me-3"), .href("https://tryswift.jp")) { "Main Website" }
+          a(.class("text-white text-decoration-none me-3"), .href("https://tryswift.jp/code-of-conduct")) {
+            "Code of Conduct"
+          }
+          a(.class("text-white text-decoration-none"), .href("https://tryswift.jp/privacy-policy")) {
+            "Privacy Policy"
+          }
+        }
+
+        div(.class("mb-3")) {
+          a(.class("text-white text-decoration-none me-3"), .href("https://twitter.com/tryswiftconf")) { "Twitter" }
+          a(.class("text-white text-decoration-none"), .href("https://github.com/tryswift")) { "GitHub" }
+        }
+
+        p(.class("text-white-50 mb-0")) {
+          "© 2026 try! Swift Tokyo. All rights reserved."
+        }
+      }
+    }
+  }
+}

--- a/Server/Sources/Server/CfP/Components/CfPNavigation.swift
+++ b/Server/Sources/Server/CfP/Components/CfPNavigation.swift
@@ -1,0 +1,60 @@
+import Elementary
+import SharedModels
+
+struct CfPNavigation: HTML, Sendable {
+  let user: UserDTO?
+
+  var body: some HTML {
+    nav(
+      .class("navbar navbar-expand-lg navbar-dark fixed-top"),
+      .style("background: rgba(0, 32, 63, 0.95);")
+    ) {
+      div(.class("container")) {
+        a(.class("navbar-brand fw-bold text-white"), .href("/cfp/")) { "try! Swift Tokyo CfP" }
+
+        button(
+          .class("navbar-toggler"),
+          .type(.button),
+          .data("bs-toggle", value: "collapse"),
+          .data("bs-target", value: "#navbarNav")
+        ) {
+          span(.class("navbar-toggler-icon")) {}
+        }
+
+        div(.class("collapse navbar-collapse"), .id("navbarNav")) {
+          ul(.class("navbar-nav ms-auto align-items-center")) {
+            li(.class("nav-item")) {
+              a(.class("nav-link text-white"), .href("/cfp/")) { "Home" }
+            }
+            li(.class("nav-item")) {
+              a(.class("nav-link text-white"), .href("/cfp/guidelines")) { "Guidelines" }
+            }
+            li(.class("nav-item")) {
+              a(.class("nav-link text-white"), .href("/cfp/submit")) { "Submit" }
+            }
+
+            if let user {
+              li(.class("nav-item")) {
+                a(.class("nav-link text-white"), .href("/cfp/my-proposals")) { "My Proposals" }
+              }
+              li(.class("nav-item")) {
+                span(.class("nav-link text-white fw-bold")) {
+                  HTMLText("👤 \(user.username)")
+                }
+              }
+              li(.class("nav-item ms-2")) {
+                a(.class("btn btn-sm btn-danger"), .href("/cfp/logout")) { "Sign Out" }
+              }
+            } else {
+              li(.class("nav-item ms-2")) {
+                a(.class("btn btn-sm btn-light"), .href("/api/v1/auth/github")) {
+                  "Login with GitHub"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Server/Sources/Server/CfP/Layouts/CfPLayout.swift
+++ b/Server/Sources/Server/CfP/Layouts/CfPLayout.swift
@@ -1,0 +1,61 @@
+import Elementary
+import SharedModels
+
+struct CfPLayout<Content: HTML & Sendable>: HTMLDocument, Sendable {
+  var title: String
+  let user: UserDTO?
+  let pageContent: Content
+
+  init(title: String, user: UserDTO?, @HTMLBuilder pageContent: () -> Content) {
+    self.title = title
+    self.user = user
+    self.pageContent = pageContent()
+  }
+
+  var head: some HTML {
+    meta(.charset(.utf8))
+    meta(.name(.viewport), .content("width=device-width, initial-scale=1"))
+    HTMLRaw("<title>\(title) - try! Swift Tokyo CfP</title>")
+    link(
+      .rel(.stylesheet),
+      .href("https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css")
+    )
+    // OGP Meta tags
+    meta(.property("og:title"), .content("\(title) - try! Swift Tokyo 2026"))
+    meta(
+      .property("og:description"),
+      .content(
+        "Submit your talk proposal for try! Swift Tokyo 2026. Share your Swift expertise with developers from around the world."
+      )
+    )
+    meta(.property("og:image"), .content("https://tryswift.jp/cfp/images/ogp.png"))
+    meta(.name("twitter:card"), .content("summary_large_image"))
+    meta(.name("twitter:title"), .content("\(title) - try! Swift Tokyo 2026"))
+    meta(.name("twitter:image"), .content("https://tryswift.jp/cfp/images/ogp.png"))
+    // Custom styles
+    HTMLRaw(
+      """
+      <style>
+        .hero-section { background: #00203f; }
+        .purple-text { color: #7952b3; }
+        .btn-purple { background-color: #7952b3; border-color: #7952b3; color: white; }
+        .btn-purple:hover { background-color: #5e3d8f; border-color: #5e3d8f; color: white; }
+        .bg-purple { background-color: #7952b3; }
+      </style>
+      """)
+  }
+
+  var body: some HTML {
+    CfPNavigation(user: user)
+
+    main(.style("padding-top: 70px;")) {
+      pageContent
+    }
+
+    CfPFooter()
+
+    script(
+      .src("https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js")
+    ) {}
+  }
+}

--- a/Server/Sources/Server/CfP/Pages/CfPHomePage.swift
+++ b/Server/Sources/Server/CfP/Pages/CfPHomePage.swift
@@ -1,0 +1,121 @@
+import Elementary
+import SharedModels
+
+struct CfPHomePage: HTML, Sendable {
+  let user: UserDTO?
+
+  var body: some HTML {
+    // Hero Section
+    section(.class("hero-section text-center py-5")) {
+      div(.class("container py-5")) {
+        p(.class("text-white-50 fs-5 mb-2")) { "try! Swift Tokyo 2026" }
+        h1(.class("display-3 fw-bold text-white mb-3")) { "Call for Proposals" }
+        p(.class("lead text-white-50 mb-4 mx-auto"), .style("max-width: 600px;")) {
+          "Share your Swift expertise with developers from around the world. Submit your talk proposal for try! Swift Tokyo 2026!"
+        }
+        div(.class("d-flex gap-3 justify-content-center flex-wrap")) {
+          a(.class("btn btn-light btn-lg fw-bold"), .href("/cfp/submit")) { "Submit Your Proposal" }
+          a(.class("btn btn-outline-light btn-lg"), .href("/cfp/guidelines")) { "View Guidelines" }
+        }
+      }
+    }
+
+    // Important Dates Section
+    section(.class("py-5")) {
+      div(.class("container")) {
+        h2(.class("text-center fw-bold purple-text mb-5")) { "Important Dates" }
+        div(.class("row g-4")) {
+          dateCard(emoji: "📅", title: "CfP Opens", date: "January 15, 2026")
+          dateCard(emoji: "⏰", title: "Submission Deadline", date: "February 28, 2026")
+          dateCard(emoji: "📣", title: "Notifications", date: "March 15, 2026")
+          dateCard(emoji: "🎤", title: "Conference", date: "April 12-14, 2026")
+        }
+      }
+    }
+
+    // Talk Formats Section
+    section(.class("py-5 bg-light")) {
+      div(.class("container")) {
+        h2(.class("text-center fw-bold purple-text mb-5")) { "Talk Formats" }
+        div(.class("row g-4")) {
+          div(.class("col-md-6")) {
+            div(.class("card h-100")) {
+              div(.class("card-body text-center p-4")) {
+                h3(.class("fw-bold")) { "🎯 Regular Talk" }
+                p(.class("lead text-muted")) { "20 minutes" }
+                p(.class("mt-3")) {
+                  "Deep dive into a specific topic with detailed examples and live demos. Perfect for sharing comprehensive knowledge about Swift development."
+                }
+              }
+            }
+          }
+          div(.class("col-md-6")) {
+            div(.class("card h-100")) {
+              div(.class("card-body text-center p-4")) {
+                h3(.class("fw-bold")) { "⚡ Lightning Talk" }
+                p(.class("lead text-muted")) { "5 minutes" }
+                p(.class("mt-3")) {
+                  "Quick, focused presentation on a single idea, tip, or tool. Great for first-time speakers or sharing quick wins!"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    // Topics Section
+    section(.class("py-5")) {
+      div(.class("container")) {
+        h2(.class("text-center fw-bold purple-text mb-5")) { "Topics We're Looking For" }
+        div(.class("row g-4")) {
+          topicCard(title: "Swift Language", description: "New features, best practices, and language evolution")
+          topicCard(title: "SwiftUI", description: "Modern UI development, animations, and architecture")
+          topicCard(
+            title: "iOS/macOS/visionOS", description: "Platform-specific development and APIs")
+          topicCard(
+            title: "Server-Side Swift", description: "Vapor, backend development, and cloud deployment")
+          topicCard(title: "Testing & Quality", description: "Unit testing, UI testing, and code quality")
+          topicCard(
+            title: "Tools & Productivity", description: "Xcode, debugging, and developer experience")
+        }
+      }
+    }
+
+    // CTA Section
+    section(.class("py-5 bg-purple text-center")) {
+      div(.class("container py-4")) {
+        h2(.class("fw-bold text-white mb-3")) { "Ready to Share Your Knowledge?" }
+        p(.class("lead text-white-50 mb-4")) {
+          "We welcome speakers of all experience levels. First-time speakers are encouraged to apply!"
+        }
+        a(.class("btn btn-light btn-lg fw-bold"), .href("/cfp/submit")) { "Submit Your Proposal" }
+      }
+    }
+  }
+
+  @HTMLBuilder
+  private func dateCard(emoji: String, title: String, date: String) -> some HTML {
+    div(.class("col-md-3 col-sm-6")) {
+      div(.class("card text-center h-100")) {
+        div(.class("card-body")) {
+          p(.class("fs-1 mb-2")) { emoji }
+          h5(.class("fw-semibold")) { title }
+          p(.class("text-muted mb-0")) { date }
+        }
+      }
+    }
+  }
+
+  @HTMLBuilder
+  private func topicCard(title: String, description: String) -> some HTML {
+    div(.class("col-md-4 col-sm-6")) {
+      div(.class("card h-100")) {
+        div(.class("card-body text-center")) {
+          h5(.class("fw-semibold")) { title }
+          p(.class("text-muted mb-0")) { description }
+        }
+      }
+    }
+  }
+}

--- a/Server/Sources/Server/CfP/Pages/GuidelinesPage.swift
+++ b/Server/Sources/Server/CfP/Pages/GuidelinesPage.swift
@@ -1,0 +1,127 @@
+import Elementary
+import SharedModels
+
+struct GuidelinesPageView: HTML, Sendable {
+  let user: UserDTO?
+
+  var body: some HTML {
+    div(.class("container py-5")) {
+      h1(.class("fw-bold mb-4")) { "Submission Guidelines" }
+      p(.class("lead text-muted mb-5")) {
+        "Everything you need to know about submitting a talk proposal for try! Swift Tokyo 2026."
+      }
+
+      // What We're Looking For
+      div(.class("card mb-4")) {
+        div(.class("card-body p-4")) {
+          h2(.class("fw-bold mb-3")) { "What We're Looking For" }
+          ul(.class("mb-0")) {
+            li { "Original content that hasn't been presented at other major conferences" }
+            li { "Practical knowledge that attendees can apply in their work" }
+            li { "Clear learning outcomes for the audience" }
+            li { "Well-structured presentations with demos when applicable" }
+            li { "Topics relevant to the Swift community" }
+          }
+        }
+      }
+
+      // Talk Formats
+      div(.class("card mb-4")) {
+        div(.class("card-body p-4")) {
+          h2(.class("fw-bold mb-3")) { "Talk Formats" }
+
+          h4(.class("fw-semibold mt-3")) { "Regular Talk (20 minutes)" }
+          p(.class("text-muted")) {
+            "A comprehensive session covering a topic in depth. Include time for context, examples, and key takeaways. Live coding and demos are welcome!"
+          }
+
+          h4(.class("fw-semibold mt-4")) { "Lightning Talk (5 minutes)" }
+          p(.class("text-muted mb-0")) {
+            "A focused, fast-paced presentation covering a single concept, tool, or tip. Perfect for sharing quick wins or introducing new ideas."
+          }
+        }
+      }
+
+      // Proposal Requirements
+      div(.class("card mb-4")) {
+        div(.class("card-body p-4")) {
+          h2(.class("fw-bold mb-3")) { "Proposal Requirements" }
+
+          h4(.class("fw-semibold mt-3")) { "Title" }
+          p(.class("text-muted")) {
+            "A clear, descriptive title that accurately represents your talk content."
+          }
+
+          h4(.class("fw-semibold mt-3")) { "Abstract" }
+          p(.class("text-muted")) {
+            "A 2-3 sentence summary that will be shown publicly if your talk is accepted. This should explain what attendees will learn."
+          }
+
+          h4(.class("fw-semibold mt-3")) { "Talk Details" }
+          p(.class("text-muted")) {
+            "A detailed description of your talk for reviewers. Include your outline, key points, and any demos you plan to show. This helps us understand your vision."
+          }
+
+          h4(.class("fw-semibold mt-3")) { "Speaker Bio" }
+          p(.class("text-muted")) {
+            "Tell us about yourself! Your background, experience, and what makes you excited about this topic."
+          }
+
+          h4(.class("fw-semibold mt-3")) { "Notes (Optional)" }
+          p(.class("text-muted mb-0")) {
+            "Any additional information for organizers, such as accessibility needs, scheduling constraints, or whether you've given this talk before."
+          }
+        }
+      }
+
+      // Selection Criteria
+      div(.class("card mb-4")) {
+        div(.class("card-body p-4")) {
+          h2(.class("fw-bold mb-3")) { "Selection Criteria" }
+          p { "Our review committee evaluates proposals based on:" }
+          ul(.class("mb-0")) {
+            li { "Relevance to the Swift community" }
+            li { "Originality and uniqueness of content" }
+            li { "Clarity of proposal and learning outcomes" }
+            li { "Speaker's expertise and presentation ability" }
+            li { "Diversity of topics across the conference program" }
+          }
+        }
+      }
+
+      // Tips for Success
+      div(.class("card mb-4")) {
+        div(.class("card-body p-4")) {
+          h2(.class("fw-bold mb-3")) { "Tips for a Great Proposal" }
+          ul(.class("mb-0")) {
+            li { "Be specific about what attendees will learn" }
+            li { "Include a clear outline or structure" }
+            li { "Mention any demos or live coding" }
+            li { "Show your passion for the topic" }
+            li { "Proofread your submission carefully" }
+            li { "Don't be afraid to submit multiple proposals!" }
+          }
+        }
+      }
+
+      // Speaker Benefits
+      div(.class("card mb-4")) {
+        div(.class("card-body p-4")) {
+          h2(.class("fw-bold mb-3")) { "Speaker Benefits" }
+          ul(.class("mb-0")) {
+            li { "Free conference ticket" }
+            li { "Speaker dinner with other speakers and organizers" }
+            li { "Travel support available for international speakers" }
+            li { "Professional video recording of your talk" }
+            li { "Networking opportunities with Swift developers worldwide" }
+          }
+        }
+      }
+
+      // CTA
+      div(.class("text-center mt-5")) {
+        a(.class("btn btn-primary btn-lg"), .href("/cfp/submit")) { "Submit Your Proposal" }
+      }
+    }
+  }
+}

--- a/Server/Sources/Server/CfP/Pages/LoginPage.swift
+++ b/Server/Sources/Server/CfP/Pages/LoginPage.swift
@@ -1,0 +1,61 @@
+import Elementary
+import SharedModels
+
+struct LoginPageView: HTML, Sendable {
+  let user: UserDTO?
+  let error: String?
+
+  var body: some HTML {
+    div(.class("container py-5")) {
+      div(.class("row justify-content-center")) {
+        div(.class("col-md-6 col-lg-5")) {
+          if let error {
+            div(.class("alert alert-danger mb-4")) {
+              strong { "Login failed: " }
+              HTMLText(error)
+            }
+          }
+
+          if let user {
+            // LOGGED IN VIEW - Server-side rendered with correct state
+            div(.class("card")) {
+              div(.class("card-body text-center p-5")) {
+                p(.class("fs-1 mb-3")) { "✅" }
+                h2(.class("fw-bold mb-2")) {
+                  HTMLText("Welcome, \(user.username)!")
+                }
+                p(.class("text-muted mb-4")) {
+                  "You are now signed in. You can submit and manage your talk proposals."
+                }
+                div(.class("d-flex gap-2 justify-content-center flex-wrap")) {
+                  a(.class("btn btn-primary"), .href("/cfp/submit")) { "Submit a Proposal" }
+                  a(.class("btn btn-secondary"), .href("/cfp/my-proposals")) { "My Proposals" }
+                }
+                div(.class("mt-4")) {
+                  a(.class("text-muted text-decoration-none"), .href("/cfp/logout")) { "Logout" }
+                }
+              }
+            }
+          } else {
+            // NOT LOGGED IN VIEW
+            div(.class("card")) {
+              div(.class("card-body text-center p-5")) {
+                p(.class("fs-1 mb-3")) { "🔐" }
+                h2(.class("fw-bold mb-2")) { "Sign in to try! Swift CfP" }
+                p(.class("text-muted mb-4")) {
+                  "Connect your GitHub account to submit and manage your talk proposals."
+                }
+                a(.class("btn btn-dark btn-lg"), .href("/api/v1/auth/github")) {
+                  "Sign in with GitHub"
+                }
+                p(.class("text-muted small mt-4 mb-0")) {
+                  "By signing in, you agree to our terms of service and privacy policy."
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Server/Sources/Server/CfP/Pages/MyProposalsPage.swift
+++ b/Server/Sources/Server/CfP/Pages/MyProposalsPage.swift
@@ -1,0 +1,115 @@
+import Elementary
+import Foundation
+import SharedModels
+
+struct MyProposalsPageView: HTML, Sendable {
+  let user: UserDTO?
+  let proposals: [ProposalDTO]
+
+  var body: some HTML {
+    div(.class("container py-5")) {
+      h1(.class("fw-bold mb-2")) { "My Proposals" }
+      p(.class("lead text-muted mb-4")) {
+        "View and manage your submitted talk proposals."
+      }
+
+      if let user {
+        // User info card
+        div(.class("card mb-4")) {
+          div(.class("card-body")) {
+            div(.class("d-flex align-items-center justify-content-between")) {
+              div(.class("d-flex align-items-center")) {
+                img(
+                  .src(user.avatarURL ?? "https://github.com/identicons/\(user.username).png"),
+                  .alt(user.username),
+                  .class("rounded-circle me-3"),
+                  .style("width: 50px; height: 50px;")
+                )
+                div {
+                  strong { HTMLText(user.username) }
+                  div(.class("text-muted small")) {
+                    HTMLText(user.role == .admin ? "Organizer" : "Speaker")
+                  }
+                }
+              }
+              a(.class("btn btn-outline-danger btn-sm"), .href("/cfp/logout")) { "Logout" }
+            }
+          }
+        }
+
+        // Proposals section
+        h3(.class("fw-bold mb-3")) { "Your Submissions" }
+
+        if proposals.isEmpty {
+          div(.class("card")) {
+            div(.class("card-body text-center p-5")) {
+              p(.class("text-muted mb-3")) { "No proposals yet" }
+              p(.class("text-muted small mb-4")) { "Submit your first proposal to see it here." }
+              a(.class("btn btn-primary"), .href("/cfp/submit")) { "Submit a Proposal" }
+            }
+          }
+        } else {
+          for proposal in proposals {
+            ProposalCard(proposal: proposal)
+          }
+
+          div(.class("text-center mt-4")) {
+            a(.class("btn btn-primary"), .href("/cfp/submit")) { "Submit Another Proposal" }
+          }
+        }
+      } else {
+        // Not logged in - redirect via meta refresh or show login prompt
+        div(.class("card")) {
+          div(.class("card-body text-center p-5")) {
+            p(.class("fs-1 mb-3")) { "🔐" }
+            h3(.class("fw-bold mb-2")) { "Sign In Required" }
+            p(.class("text-muted mb-4")) {
+              "Please sign in to view your proposals."
+            }
+            a(.class("btn btn-dark"), .href("/api/v1/auth/github?returnTo=/cfp/my-proposals")) {
+              "Sign in with GitHub"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+struct ProposalCard: HTML, Sendable {
+  let proposal: ProposalDTO
+
+  var body: some HTML {
+    div(.class("card mb-3")) {
+      div(.class("card-body")) {
+        div(.class("d-flex justify-content-between align-items-start")) {
+          div {
+            h5(.class("card-title mb-1")) { HTMLText(proposal.title) }
+            span(
+              .class(
+                proposal.talkDuration == .regular
+                  ? "badge bg-primary" : "badge bg-warning text-dark"
+              )
+            ) {
+              HTMLText(proposal.talkDuration.rawValue)
+            }
+          }
+          if let createdAt = proposal.createdAt {
+            small(.class("text-muted")) {
+              HTMLText(formatDate(createdAt))
+            }
+          }
+        }
+        p(.class("card-text text-muted mt-2 mb-0")) {
+          HTMLText(proposal.abstract)
+        }
+      }
+    }
+  }
+
+  private func formatDate(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    return formatter.string(from: date)
+  }
+}

--- a/Server/Sources/Server/CfP/Pages/SubmitPage.swift
+++ b/Server/Sources/Server/CfP/Pages/SubmitPage.swift
@@ -1,0 +1,157 @@
+import Elementary
+import SharedModels
+
+struct SubmitPageView: HTML, Sendable {
+  let user: UserDTO?
+  let success: Bool
+  let errorMessage: String?
+
+  var body: some HTML {
+    div(.class("container py-5")) {
+      h1(.class("fw-bold mb-2")) { "Submit Your Proposal" }
+      p(.class("lead text-muted mb-4")) {
+        "Share your Swift expertise with developers from around the world."
+      }
+
+      if user != nil {
+        if success {
+          // Success message
+          div(.class("card")) {
+            div(.class("card-body text-center p-5")) {
+              p(.class("fs-1 mb-3")) { "✅" }
+              h3(.class("fw-bold mb-2")) { "Proposal Submitted!" }
+              p(.class("text-muted mb-4")) {
+                "Your proposal has been submitted successfully. Good luck!"
+              }
+              div(.class("d-flex gap-2 justify-content-center")) {
+                a(.class("btn btn-primary"), .href("/cfp/my-proposals")) { "View My Proposals" }
+                a(.class("btn btn-outline-primary"), .href("/cfp/submit")) { "Submit Another" }
+              }
+            }
+          }
+        } else {
+          // Show proposal form
+          div(.class("card")) {
+            div(.class("card-body p-4")) {
+              if let errorMessage {
+                div(.class("alert alert-danger mb-4")) {
+                  HTMLText(errorMessage)
+                }
+              }
+
+              form(.method(.post), .action("/cfp/submit")) {
+                div(.class("mb-3")) {
+                  label(.class("form-label fw-semibold"), .for("title")) { "Title *" }
+                  input(
+                    .type(.text),
+                    .class("form-control"),
+                    .name("title"),
+                    .id("title"),
+                    .required,
+                    .placeholder("Enter your talk title")
+                  )
+                }
+
+                div(.class("mb-3")) {
+                  label(.class("form-label fw-semibold"), .for("abstract")) { "Abstract *" }
+                  textarea(
+                    .class("form-control"),
+                    .name("abstract"),
+                    .id("abstract"),
+                    .custom(name: "rows", value: "3"),
+                    .required,
+                    .placeholder("A brief summary of your talk (2-3 sentences)")
+                  ) {}
+                  div(.class("form-text")) {
+                    "This will be shown to the audience if your talk is accepted."
+                  }
+                }
+
+                div(.class("mb-3")) {
+                  label(.class("form-label fw-semibold"), .for("talkDetails")) { "Talk Details *" }
+                  textarea(
+                    .class("form-control"),
+                    .name("talkDetails"),
+                    .id("talkDetails"),
+                    .custom(name: "rows", value: "5"),
+                    .required,
+                    .placeholder("Detailed description for reviewers")
+                  ) {}
+                  div(.class("form-text")) {
+                    "Include outline, key points, and what attendees will learn. For reviewers only."
+                  }
+                }
+
+                div(.class("mb-3")) {
+                  label(.class("form-label fw-semibold"), .for("talkDuration")) { "Talk Duration *" }
+                  select(.class("form-select"), .name("talkDuration"), .id("talkDuration"), .required)
+                  {
+                    option(.value("")) { "Choose duration..." }
+                    option(.value("20min")) { "Regular Talk (20 minutes)" }
+                    option(.value("LT")) { "Lightning Talk (5 minutes)" }
+                  }
+                }
+
+                div(.class("mb-3")) {
+                  label(.class("form-label fw-semibold"), .for("bio")) { "Speaker Bio *" }
+                  textarea(
+                    .class("form-control"),
+                    .name("bio"),
+                    .id("bio"),
+                    .custom(name: "rows", value: "3"),
+                    .required,
+                    .placeholder("Tell us about yourself")
+                  ) {}
+                }
+
+                div(.class("mb-3")) {
+                  label(.class("form-label fw-semibold"), .for("iconUrl")) {
+                    "Profile Picture URL (Optional)"
+                  }
+                  input(
+                    .type(.url),
+                    .class("form-control"),
+                    .name("iconUrl"),
+                    .id("iconUrl"),
+                    .placeholder("https://example.com/your-photo.jpg")
+                  )
+                }
+
+                div(.class("mb-4")) {
+                  label(.class("form-label fw-semibold"), .for("notesToOrganizers")) {
+                    "Notes for Organizers (Optional)"
+                  }
+                  textarea(
+                    .class("form-control"),
+                    .name("notesToOrganizers"),
+                    .id("notesToOrganizers"),
+                    .custom(name: "rows", value: "2"),
+                    .placeholder("Any special requirements or additional information")
+                  ) {}
+                }
+
+                div(.class("d-grid")) {
+                  button(.type(.submit), .class("btn btn-primary btn-lg")) { "Submit Proposal" }
+                }
+              }
+            }
+          }
+        }
+      } else {
+        // Not logged in - show login prompt
+        div(.class("card")) {
+          div(.class("card-body text-center p-5")) {
+            p(.class("fs-1 mb-3")) { "🔐" }
+            h3(.class("fw-bold mb-2")) { "Sign In Required" }
+            p(.class("text-muted mb-4")) {
+              "Connect your GitHub account to submit proposals and track your submissions."
+            }
+            a(.class("btn btn-dark"), .href("/api/v1/auth/github?returnTo=/cfp/submit")) {
+              "Sign in with GitHub"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/Server/Sources/Server/routes.swift
+++ b/Server/Sources/Server/routes.swift
@@ -16,9 +16,12 @@ enum AppRoutes {
     // API version prefix
     let api = app.grouped("api", "v1")
 
-    // Register controllers
+    // Register API controllers
     try api.register(collection: AuthController())
     try api.register(collection: ConferenceController())
     try api.register(collection: ProposalController())
+
+    // Register CfP SSR pages
+    try app.register(collection: CfPRoutes())
   }
 }


### PR DESCRIPTION
## Summary
- Migrate CfPWebsite from Ignite (static site generator) to vapor-elementary (SSR)
- Fix the bug where the page doesn't update after GitHub login
- Switch to HTTP-only cookie-based JWT authentication

## Changes
### New Files
- `Server/Sources/Server/CfP/` - SSR pages and components
  - `CfPRoutes.swift` - Route definitions
  - `Components/` - CfPNavigation, CfPFooter
  - `Layouts/CfPLayout.swift` - Shared layout
  - `Pages/` - Home, Guidelines, Login, Submit, MyProposals

### Modified Files
- `Server/Package.swift` - Add vapor-elementary dependency
- `Server/Sources/Server/Controllers/AuthController.swift` - HTTP-only cookie authentication
- `Server/Sources/Server/routes.swift` - Register CfPRoutes

## Problem Solved
**Before**: Ignite generates static HTML → After GitHub login, JavaScript DOM manipulation required → Unreliable

**After**: Server reads JWT from cookie and renders HTML based on authentication state → Correct state displayed immediately

## Test plan
- [ ] Access `/cfp/` and verify home page displays
- [ ] `/cfp/login` → GitHub auth → "Welcome, username!" displays immediately
- [ ] Username appears in navigation bar
- [ ] `/cfp/submit` displays proposal submission form
- [ ] `/cfp/my-proposals` displays user's proposals list
- [ ] `/cfp/logout` logs out and redirects to home page

🤖 Generated with [Claude Code](https://claude.ai/code)