### PR TITLE
Add favicon to CfP pages (Vibe Kanban)

### DIFF
--- a/Server/Sources/Server/CfP/Layouts/CfPLayout.swift
+++ b/Server/Sources/Server/CfP/Layouts/CfPLayout.swift
@@ -20,6 +20,7 @@ struct CfPLayout<Content: HTML & Sendable>: HTMLDocument, Sendable {
       .rel(.stylesheet),
       .href("https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css")
     )
+    link(.rel(.icon), .custom(name: "type", value: "image/png"), .href("https://tryswift.jp/images/favicon.png"))
     // OGP Meta tags
     meta(.property("og:title"), .content("\(title) - try! Swift Tokyo 2026"))
     meta(


### PR DESCRIPTION
## Summary

Adds a favicon to the CfP (Call for Papers) pages so they display the try! Swift Tokyo icon in the browser tab.

## Changes

- Added favicon link tag to `CfPLayout.swift` in the HTML `<head>` section
- Uses the same favicon as the main try! Swift Tokyo website (`https://tryswift.jp/images/favicon.png`)
- Ensures consistent branding across both the main conference website and the CfP submission portal

## Implementation Details

The CfP pages were recently migrated from Ignite static site generation to Vapor server-side rendering with vapor-elementary. During this migration, the favicon configuration was not carried over. This PR adds the missing favicon link using Elementary's `.custom()` attribute method to set the `type="image/png"` attribute on the link element.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)