### PR TITLE
Improve CfP error handling when no open conference exists (Vibe Kanban)

### DIFF
--- a/Server/Sources/Server/CfP/Pages/SubmitPage.swift
+++ b/Server/Sources/Server/CfP/Pages/SubmitPage.swift
@@ -5,6 +5,14 @@ struct SubmitPageView: HTML, Sendable {
   let user: UserDTO?
   let success: Bool
   let errorMessage: String?
+  let openConference: ConferencePublicInfo?
+
+  init(user: UserDTO?, success: Bool, errorMessage: String?, openConference: ConferencePublicInfo? = nil) {
+    self.user = user
+    self.success = success
+    self.errorMessage = errorMessage
+    self.openConference = openConference
+  }
 
   var body: some HTML {
     div(.class("container py-5")) {
@@ -13,7 +21,19 @@ struct SubmitPageView: HTML, Sendable {
         "Share your Swift expertise with developers from around the world."
       }
 
-      if user != nil {
+      if openConference == nil {
+        // No open conference - show friendly message
+        div(.class("card")) {
+          div(.class("card-body text-center p-5")) {
+            p(.class("fs-1 mb-3")) { "📅" }
+            h3(.class("fw-bold mb-2")) { "Call for Proposals Not Open" }
+            p(.class("text-muted mb-4")) {
+              "The Call for Proposals is not currently open. Please check back later for the next conference."
+            }
+            a(.class("btn btn-outline-primary"), .href("/cfp/")) { "Back to Home" }
+          }
+        }
+      } else if user != nil {
         if success {
           // Success message
           div(.class("card")) {

--- a/Server/Sources/Server/Controllers/ProposalController.swift
+++ b/Server/Sources/Server/Controllers/ProposalController.swift
@@ -116,7 +116,7 @@ struct ProposalController: RouteCollection {
         .filter(\.$isOpen == true)
         .sort(\.$year, .descending)
         .first() else {
-        throw Abort(.badRequest, reason: "No open conference for submissions")
+        throw Abort(.badRequest, reason: "The Call for Proposals is not currently open. Please check back later for the next conference.")
       }
       conference = current
     }

--- a/Server/Sources/Server/Models/Conference.swift
+++ b/Server/Sources/Server/Models/Conference.swift
@@ -129,4 +129,18 @@ final class Conference: Model, Content, @unchecked Sendable {
       updatedAt: updatedAt
     )
   }
+
+  /// Convert to public info for SSR pages
+  func toPublicInfo() -> ConferencePublicInfo {
+    ConferencePublicInfo(
+      displayName: displayName,
+      deadline: deadline
+    )
+  }
+}
+
+/// Public conference info for SSR pages
+struct ConferencePublicInfo: Sendable {
+  let displayName: String
+  let deadline: Date?
 }


### PR DESCRIPTION
## Summary

This PR improves the user experience when attempting to submit a proposal while no conference has Call for Proposals open.

### Changes Made

- **Friendly error message on submit page**: When visiting `/cfp/submit` with no open conference, users now see a friendly card with a calendar emoji, clear heading, helpful message, and a "Back to Home" button instead of being able to fill out a form that would fail on submission
- **Improved API error messages**: Changed the cryptic "No open conference for submissions" error to a more user-friendly message: "The Call for Proposals is not currently open. Please check back later for the next conference."
- **New `ConferencePublicInfo` struct**: Added a lightweight struct for passing minimal conference info to SSR pages

### Files Changed

| File | Change |
|------|--------|
| `Server/Sources/Server/CfP/CfPRoutes.swift` | Check for open conference before rendering submit page |
| `Server/Sources/Server/CfP/Pages/SubmitPage.swift` | Show friendly message when no conference is open |
| `Server/Sources/Server/Controllers/ProposalController.swift` | Improve API error message |
| `Server/Sources/Server/Models/Conference.swift` | Add `ConferencePublicInfo` struct and `toPublicInfo()` method |

### Why These Changes

Previously, when no conference had `isOpen = true` in the database:
1. Users could access the submit form and fill it out
2. Upon submission, they would see a confusing "No open conference for submissions" error
3. The API returned a technical error message that wasn't helpful

Now:
1. The submit page proactively checks for an open conference
2. Users see a friendly message before attempting to fill out the form
3. Error messages are clear and actionable

---

This PR was written using [Vibe Kanban](https://vibekanban.com)