### PR TITLE
Remove AppKit dependency from Website by preserving original image formats

### DIFF
--- a/Website/Sources/Components/OrganizerComponent.swift
+++ b/Website/Sources/Components/OrganizerComponent.swift
@@ -69,7 +69,7 @@ struct OrganizerModel: HTML {
 
 extension Organizer {
   var imageFilename: String {
-    "/images/from_app/\(imageName).png"
+    ImagePath.resolve(imageName)
   }
 
   var modalId: String {

--- a/Website/Sources/Components/SpeakerComponent.swift
+++ b/Website/Sources/Components/SpeakerComponent.swift
@@ -42,7 +42,7 @@ struct SpeakerModal: HTML {
 
 extension Speaker {
   var imageFilename: String {
-    "/images/from_app/\(imageName).png"
+    ImagePath.resolve(imageName)
   }
 
   var modalId: String {

--- a/Website/Sources/Components/SponsorComponent.swift
+++ b/Website/Sources/Components/SponsorComponent.swift
@@ -38,6 +38,6 @@ extension Sponsor {
     }
 
     fileprivate var imageFilename: String {
-        "/images/from_app/\(imageName).png"
+        ImagePath.resolve(imageName)
     }
 }

--- a/Website/Sources/ConferenceWebsite.swift
+++ b/Website/Sources/ConferenceWebsite.swift
@@ -1,4 +1,3 @@
-import Cocoa
 import Foundation
 import Ignite
 import SharedModels
@@ -18,6 +17,9 @@ struct ConferenceWebsite {
     }
   }
 
+  /// Supported image extensions for web
+  private static let supportedImageExtensions: Set<String> = ["png", "jpg", "jpeg", "gif", "webp", "svg"]
+
   private static func copyAssets() throws {
     let fileManager = FileManager.default
 
@@ -36,7 +38,15 @@ struct ConferenceWebsite {
 
     try [sponsorMediaEnumerator, scheduleMediaEnumerator, trySwiftMediaEnumerator].forEach {
       while let file = $0?.nextObject() as? URL {
-        let destURL = websiteAssetsDirectory.appendingPathComponent("images/from_app/\(file.deletingPathExtension().lastPathComponent).png")
+        let fileExtension = file.pathExtension.lowercased()
+
+        // Skip non-image files (e.g., Contents.json)
+        guard supportedImageExtensions.contains(fileExtension) else {
+          continue
+        }
+
+        // Keep original extension instead of forcing PNG conversion
+        let destURL = websiteAssetsDirectory.appendingPathComponent("images/from_app/\(file.lastPathComponent)")
 
         let destinationDirectory = destURL.deletingLastPathComponent()
         if !fileManager.fileExists(atPath: destinationDirectory.path) {
@@ -51,15 +61,7 @@ struct ConferenceWebsite {
           try fileManager.removeItem(at: destURL)
         }
 
-        if file.pathExtension == "png" {
-          try fileManager.copyItem(at: file, to: destURL)
-        } else if let image = NSImage(contentsOf: file) {
-          let pngData = NSBitmapImageRep(data: image.tiffRepresentation!)!
-            .representation(using: .png, properties: [:])!
-          try pngData.write(to: destURL)
-        } else {
-          continue
-        }
+        try fileManager.copyItem(at: file, to: destURL)
       }
     }
   }

--- a/Website/Sources/Extensions/ImagePath.swift
+++ b/Website/Sources/Extensions/ImagePath.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+/// Helper to resolve image paths with various extensions
+enum ImagePath {
+  /// Supported image extensions in order of preference
+  private static let supportedExtensions = ["png", "jpg", "jpeg", "gif", "webp", "svg"]
+
+  /// Assets directory URL
+  private static let assetsDirectory: URL? = {
+    // Try to find the Assets directory relative to the source file
+    guard let sourceDir = try? URL.selectDirectories(from: #file).source else {
+      return nil
+    }
+    return sourceDir.deletingLastPathComponent().appending(path: "Assets/images/from_app")
+  }()
+
+  /// Resolve image path for a given image name (without extension)
+  /// Returns the web path (e.g., "/images/from_app/speaker.jpg")
+  static func resolve(_ imageName: String) -> String {
+    // Try to find the file with various extensions
+    if let assetsDir = assetsDirectory {
+      for ext in supportedExtensions {
+        let filePath = assetsDir.appendingPathComponent("\(imageName).\(ext)")
+        if FileManager.default.fileExists(atPath: filePath.path) {
+          return "/images/from_app/\(imageName).\(ext)"
+        }
+      }
+    }
+
+    // Fallback to PNG if file not found (will show broken image, but that's informative)
+    return "/images/from_app/\(imageName).png"
+  }
+}


### PR DESCRIPTION
## Summary

Remove the AppKit dependency from Website generation, allowing it to build on both macOS and Linux (GitHub Actions).

## Problem

The Website build was failing on Linux (Ubuntu) GitHub Actions runners because it used macOS-only APIs:
- `NSImage(contentsOf:)`
- `NSBitmapImageRep`
- `image.tiffRepresentation`

These were used to convert JPG/JPEG images from xcassets to PNG format.

## Solution

Instead of converting images to PNG, simply copy them with their original file extensions. Web browsers can display both PNG and JPG natively, so there's no need for conversion.

### Changes

| File | Change |
|------|--------|
| `ConferenceWebsite.swift` | Remove AppKit import and image conversion logic; copy images with original extensions |
| `ImagePath.swift` | New helper to resolve image paths with various extensions at build time |
| `SpeakerComponent.swift` | Use `ImagePath.resolve()` instead of hardcoded `.png` |
| `SponsorComponent.swift` | Use `ImagePath.resolve()` instead of hardcoded `.png` |
| `OrganizerComponent.swift` | Use `ImagePath.resolve()` instead of hardcoded `.png` |

### How it works

1. `copyAssets()` now copies images with their original extensions (PNG, JPG, JPEG, etc.)
2. `ImagePath.resolve(imageName)` checks the filesystem at build time to find the actual file extension
3. The generated HTML uses the correct path (e.g., `/images/from_app/speaker.jpg`)

## Testing

- Verified build succeeds on macOS with `swift build`
- Verified `swift run Website` generates correct HTML with proper image paths
- PNG files remain as `.png`, JPG files remain as `.jpg`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)