### PR TITLE
Avoid to use NSAttributedString

### DIFF
--- a/Website/Sources/Components/SectionListComponent.swift
+++ b/Website/Sources/Components/SectionListComponent.swift
@@ -46,15 +46,14 @@ struct SectionListComponent: HTML {
 
 private extension String {
   func displayedCharacterCount() -> Int {
-    guard let data = self.data(using: .utf8) else {
-      return .zero
-    }
-    let options: [NSAttributedString.DocumentReadingOptionKey: Any] = [
-      .documentType: NSAttributedString.DocumentType.html,
-      .characterEncoding: String.Encoding.utf8.rawValue
-    ]
-    let attributedString = try? NSAttributedString(data: data, options: options, documentAttributes: nil)
-
-    return attributedString?.string.count ?? .zero
+    // Strip HTML tags to get approximate displayed character count
+    // This is a simple regex-based approach that works on Linux
+    let htmlTagPattern = "<[^>]+>"
+    let strippedString = self.replacingOccurrences(
+      of: htmlTagPattern,
+      with: "",
+      options: .regularExpression
+    )
+    return strippedString.count
   }
 }


### PR DESCRIPTION
## Summary

This PR fixes the Website build failure on GitHub Actions (Linux/Ubuntu) by removing the remaining AppKit dependency in `SectionListComponent.swift`.

## Problem

The `tryswift.jp/cfp` path was returning a 404 error because the Website deployment to GitHub Pages was failing. The root cause was that `NSAttributedString(data:options:documentAttributes:)` API requires AppKit/UIKit and is not available on Linux, causing the build to fail on GitHub Actions.

## Changes

- **`Website/Sources/Components/SectionListComponent.swift`**: Replaced the `displayedCharacterCount()` function that used `NSAttributedString` with a simple regex-based HTML tag stripping approach that works cross-platform

## Implementation Details

The original implementation used `NSAttributedString` to parse HTML and count the displayed characters:

```swift
let attributedString = try? NSAttributedString(data: data, options: options, documentAttributes: nil)
return attributedString?.string.count ?? .zero
```

This was replaced with a cross-platform regex approach:

```swift
let htmlTagPattern = "<[^>]+>"
let strippedString = self.replacingOccurrences(of: htmlTagPattern, with: "", options: .regularExpression)
return strippedString.count
```

This provides an approximate character count by stripping HTML tags, which is sufficient for the layout decision (center vs leading alignment based on text length).

---

This PR was written using [Vibe Kanban](https://vibekanban.com)