### PR TITLE
Use built-in swift format from Swift 6.2 toolchain (Vibe Kanban)

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,8 +12,6 @@ jobs:
     container: swift:6.2
     steps:
       - uses: actions/checkout@v4
-      - name: Install
-        run: apt-get update && apt-get install -y swift-format
       - name: Format
         run: make format
       - uses: stefanzweifel/git-auto-commit-action@v5

--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,10 @@ format:
 		--in-place \
 		--recursive \
 		./App/ \
-		./MyLibrary/
+		./CfPWebsite/ \
+		./DataClient/ \
+		./iOS/ \
+		./LocalizationGenerated/ \
+		./Server/ \
+		./SharedModels/ \
+		./Website/


### PR DESCRIPTION
## Summary

This PR updates the GitHub Actions formatting workflow to use the built-in `swift format` command from the Swift 6.2 toolchain, removing the need for a separate package installation.

## Changes

- **Removed unnecessary apt install step**: The `apt-get install swift-format` step in the CI workflow has been removed since Swift 6.2 includes `swift format` as a built-in subcommand
- **Updated Makefile targets**: Expanded the format target to include all Swift directories in the project instead of the non-existent `./MyLibrary/` directory:
  - `./App/`
  - `./CfPWebsite/`
  - `./DataClient/`
  - `./iOS/`
  - `./LocalizationGenerated/`
  - `./Server/`
  - `./SharedModels/`
  - `./Website/`

## Why

- Simplifies the CI workflow by removing an unnecessary installation step
- Reduces CI execution time by eliminating the `apt-get update && apt-get install` overhead
- Ensures all Swift code in the repository is properly formatted, not just a subset

---

This PR was written using [Vibe Kanban](https://vibekanban.com)