### PR TITLE
Add workshop section for 2026 conference website (Vibe Kanban)

### DIFF
--- a/Website/Sources/Components/WorkshopComponent.swift
+++ b/Website/Sources/Components/WorkshopComponent.swift
@@ -1,0 +1,72 @@
+import Ignite
+import SharedModels
+
+struct WorkshopComponent: HTML {
+  let workshops: [Session]
+  let year: ConferenceYear
+  let language: SupportedLanguage
+
+  var body: some HTML {
+    ForEach(workshops) { workshop in
+      Section {
+        Section {
+          HStack {
+            contents(workshop: workshop)
+          }
+        }
+        .hidden(.responsive(true, medium: true, large: false, xLarge: false, xxLarge: false))
+
+        Section {
+          VStack(spacing: .small) {
+            contents(workshop: workshop)
+          }
+        }
+        .hidden(.responsive(false, medium: false, large: true, xLarge: true, xxLarge: true))
+      }
+      .padding(.bottom, .px(32))
+    }
+
+    let speakers = workshops.flatMap { $0.speakers! }
+    Alert {
+      ForEach(speakers) { speaker in
+        SpeakerModal(year: year, speaker: speaker, language: language)
+      }
+    }
+  }
+
+  @HTMLBuilder
+  private func contents(workshop: Session) -> some HTML {
+    HStack(spacing: 0) {
+      let speakerImageSize = workshop.speakers!.count > 1 ? 115 : 230
+      ForEach(workshop.speakers!) { speaker in
+        Image(speaker.imageFilename, description: speaker.name)
+          .resizable()
+          .frame(maxWidth: speakerImageSize, maxHeight: speakerImageSize)
+          .cornerRadius(speakerImageSize / 2)
+          .onClick {
+            ShowModal(id: speaker.modalId)
+          }
+      }
+    }
+    Section {
+      Text(workshop.localizedTitle(for: language))
+        .font(.title4)
+        .fontWeight(.medium)
+        .foregroundStyle(.orangeRed)
+
+      Text(workshop.speakers!.map(\.name).joined(separator: ", "))
+        .font(.lead)
+        .fontWeight(.thin)
+        .foregroundStyle(.dimGray)
+
+      if let description = workshop.localizedDescription(for: language) {
+        Text(markdown: description.convertNewlines())
+          .font(.lead)
+          .fontWeight(.thin)
+          .foregroundStyle(.dimGray)
+          .padding(.leading, .px(16))
+      }
+    }
+    .horizontalAlignment(.leading)
+  }
+}

--- a/Website/Sources/Pages/HomeSections.swift
+++ b/Website/Sources/Pages/HomeSections.swift
@@ -9,6 +9,7 @@ enum HomeSectionType: String, CaseIterable {
   case tickets = "Tickets"
   case cfp = "Call for Proposals"
   case speaker = "Speaker"
+  case workshop = "Workshop"
   case timetable = "Timetable"
   case sponsor = "Sponsor"
   case meetTheHosts = "Meet the Hosts"
@@ -27,7 +28,7 @@ extension HomeSectionType {
     switch year {
     case .year2024: [.about, .outline, .speaker, .timetable, .access].contains(self)
     case .year2025: [.about, .outline, .speaker, .timetable, .sponsor, .meetTheHosts, .meetTheOrganizers, .access].contains(self)
-    case .year2026: [.about, .outline, .tickets, .cfp, .speaker, .sponsor, .meetTheHosts, .meetTheOrganizers, .access].contains(self)
+    case .year2026: [.about, .outline, .tickets, .cfp, .speaker, .workshop, .sponsor, .meetTheHosts, .meetTheOrganizers, .access].contains(self)
     }
   }
 
@@ -95,6 +96,21 @@ extension HomeSectionType {
           SpeakerModal(year: year, speaker: speaker, language: language)
         }
       }
+    case .workshop:
+      SectionHeader(type: self, language: language)
+
+      let workshops = try! dataClient.fetchDay1(year: .year2026)
+        .schedules
+        .flatMap(\.sessions)
+        .filter { $0.speakers?.isEmpty == false }
+
+      WorkshopComponent(workshops: workshops, year: year, language: language)
+
+      Text(String("And more...!", language: language))
+        .horizontalAlignment(.center)
+        .font(.title3)
+        .foregroundStyle(.dimGray)
+        .margin(.top, .px(32))
     case .cfp:
       SectionHeader(type: self, language: language)
       CallForProposalComponent(language: language)


### PR DESCRIPTION
## Summary

This PR adds a Workshop section to the try! Swift Tokyo 2026 conference website by applying changes from the `feature/workshop-dp-only` branch, adapted to work with the main branch's data structures and localization system.

## Changes Made

### New Files
- **`Website/Sources/Components/WorkshopComponent.swift`** - A new SwiftUI-like component that displays workshop sessions with:
  - Responsive layout (horizontal for large screens, vertical for small screens)
  - Speaker images with click-to-open modal functionality
  - Workshop title, speaker names, and description
  - Support for multiple speakers per workshop

### Modified Files
- **`Website/Sources/Pages/HomeSections.swift`**:
  - Added `workshop` case to the `HomeSectionType` enum
  - Added workshop to the available sections for year 2026
  - Implemented the workshop section handler that fetches sessions with speakers from day 1 data

## Implementation Details

The original `feature/workshop-dp-only` branch used a bundle-based localization system with `NSLocalizedString`. Since the main branch uses a different approach with extension methods (`localizedTitle`, `localizedDescription`, etc.) defined in `LocalizedContent.swift`, the `WorkshopComponent` was adapted to use these existing localization patterns for consistency.

The workshop section filters sessions that have speakers attached, displaying them in a visually appealing format with responsive design for different screen sizes.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)