### PR TITLE
Enable auto-migrate in production for CfP database seeding (Vibe Kanban)

### DIFF
--- a/Server/Sources/Server/configure.swift
+++ b/Server/Sources/Server/configure.swift
@@ -45,10 +45,8 @@ enum AppConfiguration {
     app.migrations.add(CreateProposal())
     app.migrations.add(SeedTrySwiftTokyo2026())
 
-    // Auto-migrate in development
-    if app.environment == .development {
-      try await app.autoMigrate()
-    }
+    // Auto-migrate on startup (safe for production as Fluent tracks completed migrations)
+    try await app.autoMigrate()
 
     // MARK: - JWT Configuration
 


### PR DESCRIPTION
## Summary

This PR fixes an issue where the try! Swift Tokyo 2026 CfP (Call for Proposals) was showing "Call for Proposals Not Open" in production, even though the conference was configured with `isOpen: true`.

## Changes

- Removed the development-only guard around `autoMigrate()` in `configure.swift`
- Database migrations now run on startup in all environments (development and production)

## Root Cause

The `SeedTrySwiftTokyo2026` migration creates the 2026 conference record with `isOpen: true`. However, `autoMigrate()` was only being called when `app.environment == .development`. Since fly.io runs in production mode, the seed migration never executed, resulting in no open conference in the database.

## Why This Is Safe

Fluent tracks all completed migrations in the `_fluent_migrations` table. When `autoMigrate()` runs, it only executes migrations that haven't been run yet. This makes it safe to call on every startup, even in production.

---

This PR was written using [Vibe Kanban](https://vibekanban.com)