### PR TITLE
Fix organizer images not displaying on website (Vibe Kanban)

### DIFF
--- a/Website/Sources/Extensions/ImagePath.swift
+++ b/Website/Sources/Extensions/ImagePath.swift
@@ -11,7 +11,7 @@ enum ImagePath {
     guard let sourceDir = try? URL.selectDirectories(from: #file).source else {
       return nil
     }
-    return sourceDir.deletingLastPathComponent().appending(path: "Assets/images/from_app")
+    return sourceDir.appending(path: "Assets/images/from_app")
   }()
 
   /// Resolve image path for a given image name (without extension)


### PR DESCRIPTION
## Summary

Fixed an issue where some organizer images were not displaying on the website:
- Daiki Matsudate
- Yoichiro Sakurai
- Akio Itaya
- Maya Yamada

## Changes

- Fixed incorrect assets directory path calculation in `ImagePath.swift`

## Root Cause

The `ImagePath.resolve()` function was looking for images in the wrong directory due to an unnecessary `deletingLastPathComponent()` call when constructing the assets directory path.

**Before (incorrect):**
```
/try-swift-tokyo/Assets/images/from_app
```

**After (correct):**
```
/try-swift-tokyo/Website/Assets/images/from_app
```

Because the images couldn't be found at the incorrect path, the resolver fell back to using `.png` extension, but the actual image files have `.jpg` or `.jpeg` extensions (e.g., `Daiki.jpg`, `saku.jpeg`, `akkey.jpg`, `mayama.jpeg`).

## Test Plan

- [x] Verified that `swift run` in the Website directory completes successfully
- [x] Verified that generated HTML now references correct image extensions (`.jpg`, `.jpeg` instead of `.png`)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)