### PR TITLE
Fix missing riko.png image on CfP pages (Vibe Kanban)

### DIFF
--- a/Server/.gitignore
+++ b/Server/.gitignore
@@ -1,1 +1,2 @@
 .env
+Public/

--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -56,6 +56,9 @@ WORKDIR /app
 
 COPY --from=build /staging /app
 
+# Copy CfP static assets (images)
+COPY ./CfPWebsite/Assets/images ./Public/cfp/images
+
 ENV SWIFT_BACKTRACE=enable=yes,sanitize=yes,threads=all,images=all,interactive=no,swift-backtrace=./swift-backtrace-static
 
 EXPOSE 8080

--- a/Server/Sources/Server/routes.swift
+++ b/Server/Sources/Server/routes.swift
@@ -3,6 +3,19 @@ import Vapor
 enum AppRoutes {
   /// Register all routes for the application
   static func register(_ app: Application) throws {
+    // Serve static files for CfP (images, CSS, JS)
+    // FileMiddleware maps request paths directly to filesystem paths
+    // e.g., /cfp/images/riko.png -> Public/cfp/images/riko.png
+    let cfpPublicDirectory = app.directory.workingDirectory + "Public/"
+    app.middleware.use(
+      FileMiddleware(
+        publicDirectory: cfpPublicDirectory,
+        defaultFile: nil,
+        directoryAction: .none,
+        advancedETagComparison: true
+      )
+    )
+
     // Root endpoint
     app.get { req in
       return ["status": "ok", "service": "trySwiftCfP"]


### PR DESCRIPTION
## Summary

This PR fixes the 404 error for `/cfp/images/riko.png` by adding static file serving support to the Vapor server.

## Changes Made

- **Added FileMiddleware** in `routes.swift` to serve static files from the `Public/` directory
- **Updated Dockerfile** to copy CfP image assets from `CfPWebsite/Assets/images` to `Public/cfp/images` during the Docker build
- **Updated `.gitignore`** to exclude the `Public/` directory from version control (avoiding duplication of assets already in `CfPWebsite/Assets`)

## Why

The CfP pages reference images at `/cfp/images/riko.png`, but there was no route configured to serve these static files. The image existed in `CfPWebsite/Assets/images/` but wasn't being served by the Vapor server.

## Implementation Details

- FileMiddleware maps request paths directly to filesystem paths (e.g., `/cfp/images/riko.png` → `Public/cfp/images/riko.png`)
- For local development, run: `mkdir -p Server/Public/cfp/images && cp CfPWebsite/Assets/images/* Server/Public/cfp/images/`
- In production (Docker), the assets are automatically copied during the build process

---

This PR was written using [Vibe Kanban](https://vibekanban.com)