### PR TITLE
Add Organizer UI for reviewing submitted proposals (Vibe Kanban)

### DIFF
--- a/Server/Sources/Server/CfP/Components/CfPNavigation.swift
+++ b/Server/Sources/Server/CfP/Components/CfPNavigation.swift
@@ -64,6 +64,13 @@ struct CfPNavigation: HTML, Sendable {
                   language == .ja ? "マイプロポーザル" : "My Proposals"
                 }
               }
+              if user.role == .admin {
+                li(.class("nav-item")) {
+                  a(.class("nav-link text-warning fw-bold"), .href("/cfp/organizer/proposals")) {
+                    "📋 Organizer"
+                  }
+                }
+              }
               li(.class("nav-item")) {
                 span(.class("nav-link text-white fw-bold")) {
                   HTMLText("👤 \(user.username)")

--- a/Server/Sources/Server/CfP/Pages/OrganizerProposalDetailPage.swift
+++ b/Server/Sources/Server/CfP/Pages/OrganizerProposalDetailPage.swift
@@ -60,7 +60,8 @@ struct OrganizerProposalDetailPageView: HTML, Sendable {
                   )
                 }
                 div {
-                  h5(.class("mb-1")) { HTMLText(proposal.speakerUsername) }
+                  h5(.class("mb-1")) { HTMLText(proposal.speakerName) }
+                  p(.class("text-muted mb-1 small")) { HTMLText(proposal.speakerEmail) }
                   a(
                     .href("https://github.com/\(proposal.speakerUsername)"),
                     .target(.blank),

--- a/Server/Sources/Server/Models/Conference.swift
+++ b/Server/Sources/Server/Models/Conference.swift
@@ -133,6 +133,7 @@ final class Conference: Model, Content, @unchecked Sendable {
   /// Convert to public info for SSR pages
   func toPublicInfo() -> ConferencePublicInfo {
     ConferencePublicInfo(
+      path: path,
       displayName: displayName,
       deadline: deadline
     )
@@ -141,6 +142,7 @@ final class Conference: Model, Content, @unchecked Sendable {
 
 /// Public conference info for SSR pages
 struct ConferencePublicInfo: Sendable {
+  let path: String
   let displayName: String
   let deadline: Date?
 }


### PR DESCRIPTION
## Summary

Add SSR (Server-Side Rendered) pages for organizers to review submitted CfP (Call for Proposals) entries. This enables try! Swift Tokyo organizers to easily browse and review all proposal submissions through a web interface.

## Changes Made

### New Pages
- **Proposals List** (`/cfp/organizer/proposals`) - Displays all submitted proposals in a table format with:
  - Conference filter dropdown to filter by specific conference
  - Statistics cards showing total proposals, regular talks (20min), and lightning talks
  - Speaker avatars and GitHub usernames
  - Submission dates and talk duration badges
  
- **Proposal Detail** (`/cfp/organizer/proposals/:id`) - Shows complete proposal information:
  - Speaker information with GitHub profile link
  - Speaker bio
  - Talk abstract
  - Detailed talk description
  - Notes to organizers (if provided)
  - Metadata (submission date, last updated, IDs)

### Navigation Updates
- Added "📋 Organizer" link in the navigation bar, visible only to users with admin role

### Model Updates
- Extended `ConferencePublicInfo` to include `path` for conference filtering functionality

## Security

- All organizer pages check for authentication and admin role
- Non-admin users see an access denied message with appropriate guidance
- Unauthenticated users are prompted to sign in via GitHub

## Files Changed

- `Server/Sources/Server/CfP/Pages/OrganizerProposalsPage.swift` (new)
- `Server/Sources/Server/CfP/Pages/OrganizerProposalDetailPage.swift` (new)
- `Server/Sources/Server/CfP/CfPRoutes.swift` (added routes and handlers)
- `Server/Sources/Server/CfP/Components/CfPNavigation.swift` (added organizer link)
- `Server/Sources/Server/Models/Conference.swift` (extended ConferencePublicInfo)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)