### PR TITLE
Fix GitHub OAuth signin from CFP submit page (Vibe Kanban)

### DIFF
--- a/Server/Sources/Server/Controllers/AuthController.swift
+++ b/Server/Sources/Server/Controllers/AuthController.swift
@@ -448,6 +448,11 @@ struct AuthController: RouteCollection {
 
   /// Validate that returnTo URL is allowed (prevent open redirect)
   private func isValidReturnURL(_ urlString: String) -> Bool {
+    // Allow relative paths (same-origin redirects are safe)
+    if urlString.hasPrefix("/") && !urlString.hasPrefix("//") {
+      return true
+    }
+
     guard let url = URL(string: urlString),
       let host = url.host?.lowercased()
     else {


### PR DESCRIPTION
## Summary

Fixes the "Invalid returnTo URL" error that occurred when clicking the GitHub Signin button on the CFP submit page (`/cfp/submit`).

## Problem

When users tried to sign in via GitHub from the CFP submit page, they received an error:
```json
{"error":true,"reason":"Invalid returnTo URL"}
```

The root cause was in the `isValidReturnURL()` function in `AuthController.swift`. This function validates the `returnTo` parameter to prevent open redirect vulnerabilities, but it was incorrectly rejecting **relative paths** like `/cfp/submit`.

The issue: when `URL(string: "/cfp/submit")` is called, the resulting URL has no `host` component (it's `nil`), causing the validation to fail.

## Solution

Added a check at the beginning of `isValidReturnURL()` to allow relative paths:

```swift
// Allow relative paths (same-origin redirects are safe)
if urlString.hasPrefix("/") && !urlString.hasPrefix("//") {
  return true
}
```

This allows:
- ✅ `/cfp/submit` - relative path (safe, same-origin)
- ✅ `/cfp/profile` - relative path (safe, same-origin)
- ✅ `https://tryswift.jp/...` - allowed host
- ❌ `//evil.com/path` - protocol-relative URL (blocked, potential attack vector)
- ❌ `https://evil.com/path` - external host (blocked)

## Files Changed

- `Server/Sources/Server/Controllers/AuthController.swift` - Updated `isValidReturnURL()` function

---

This PR was written using [Vibe Kanban](https://vibekanban.com)