### PR TITLE
Update CfP footer social link from Twitter to X (Vibe Kanban)

### DIFF
--- a/Server/Sources/Server/CfP/Components/CfPFooter.swift
+++ b/Server/Sources/Server/CfP/Components/CfPFooter.swift
@@ -29,8 +29,8 @@ struct CfPFooter: HTML, Sendable {
         div(.class("mb-3")) {
           a(
             .class("text-white text-decoration-none me-3"),
-            .href("https://twitter.com/tryswiftconf")
-          ) { "Twitter" }
+            .href("https://x.com/tryswiftconf")
+          ) { "X" }
           a(.class("text-white text-decoration-none"), .href("https://github.com/tryswift")) {
             "GitHub"
           }


### PR DESCRIPTION
## Summary

This PR updates the Call for Proposals (CfP) page footer to reflect the rebranding of Twitter to X.

## Changes Made

- Updated the social media link URL from `https://twitter.com/tryswiftconf` to `https://x.com/tryswiftconf`
- Changed the display label from "Twitter" to "X"

## Why

Twitter rebranded to X in 2023. This update ensures the CfP page reflects the current platform name and URL, providing a better experience for users clicking through to the try! Swift conference's social media presence.

## Files Changed

- `Server/Sources/Server/CfP/Components/CfPFooter.swift`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)