### PR TITLE
Fix Export CSV returning "Proposal Not Found" error (Vibe Kanban)

### DIFF
--- a/Server/Sources/Server/CfP/CfPRoutes.swift
+++ b/Server/Sources/Server/CfP/CfPRoutes.swift
@@ -624,7 +624,8 @@ struct CfPRoutes: RouteCollection {
     let dbProposals = try await query.all()
 
     // Build CSV
-    var csv = "ID,Title,Abstract,Talk Details,Duration,Speaker Name,Speaker Email,Speaker Username,Bio,Icon URL,Notes,Conference,Submitted At\n"
+    var csv =
+      "ID,Title,Abstract,Talk Details,Duration,Speaker Name,Speaker Email,Speaker Username,Bio,Icon URL,Notes,Conference,Submitted At\n"
 
     let dateFormatter = ISO8601DateFormatter()
 


### PR DESCRIPTION
## Summary

Fixes a bug where clicking the "Export CSV" button on the organizer proposals page displayed "Proposal Not Found" instead of downloading a CSV file.

## Problem

The Export CSV button was linking to `/cfp/organizer/proposals/export`, but no route handler existed for this endpoint. Due to Vapor's route matching order, "export" was being interpreted as the `:proposalID` parameter in the existing `/cfp/organizer/proposals/:proposalID` route. Since "export" is not a valid UUID, the proposal lookup failed and the "Proposal Not Found" error page was displayed.

## Solution

1. **Added new route** for `/cfp/organizer/proposals/export` before the `:proposalID` route to ensure proper matching
2. **Implemented `organizerExportProposalsCSV` handler** that:
   - Requires admin authentication
   - Supports optional conference filtering via `?conference=` query parameter
   - Exports all proposal data to CSV format
   - Properly escapes CSV fields containing commas, quotes, and newlines
   - Sets appropriate HTTP headers for file download

## CSV Output Fields

- ID, Title, Abstract, Talk Details, Duration, Speaker Name, Speaker Email, Speaker Username, Bio, Icon URL, Notes, Conference, Submitted At

---

This PR was written using [Vibe Kanban](https://vibekanban.com)