### PR TITLE
Remove Edit Profile button from Submit page (Vibe Kanban)

### DIFF
--- a/Server/Sources/Server/CfP/Pages/SubmitPage.swift
+++ b/Server/Sources/Server/CfP/Pages/SubmitPage.swift
@@ -241,16 +241,8 @@ struct SubmitPageView: HTML, Sendable {
   }
 
   private var speakerInfoHeader: some HTML {
-    div(.class("d-flex justify-content-between align-items-center mb-3")) {
-      h5(.class("card-title mb-0")) {
-        language == .ja ? "スピーカー情報" : "Speaker Information"
-      }
-      a(
-        .class("btn btn-sm btn-outline-secondary"),
-        .href("/profile?returnTo=\(language.path(for: "/submit"))")
-      ) {
-        language == .ja ? "プロフィールを編集" : "Edit Profile"
-      }
+    h5(.class("card-title mb-3")) {
+      language == .ja ? "スピーカー情報" : "Speaker Information"
     }
   }
 


### PR DESCRIPTION
## Summary

Submit ページから「Edit Profile」ボタンを削除しました。

## Changes

- `SubmitPage.swift` の `speakerInfoHeader` から「プロフィールを編集」/「Edit Profile」ボタンを削除
- ヘッダーをシンプルな `h5` 見出しのみに簡素化

## Why

Submit ページでプロポーザルのタイトルや概要を入力中に「Edit Profile」ボタンをクリックすると、プロフィール編集ページに遷移し、保存後に戻ってきた際に入力済みのフォームデータが消えてしまう問題がありました。

この UX の問題を解決するため、Submit ページから Edit Profile ボタンを完全に削除しました。ユーザーはプロポーザル提出前にプロフィールページで直接プロフィールを編集できます。

---

This PR was written using [Vibe Kanban](https://vibekanban.com)