### PR TITLE
Use main website OGP image for CfP site (Vibe Kanban)

### DIFF
--- a/Server/Sources/Server/CfP/Layouts/CfPLayout.swift
+++ b/Server/Sources/Server/CfP/Layouts/CfPLayout.swift
@@ -41,10 +41,10 @@ struct CfPLayout<Content: HTML & Sendable>: HTMLDocument, Sendable {
         "Submit your talk proposal for try! Swift Tokyo 2026. Share your Swift expertise with developers from around the world."
       )
     )
-    meta(.property("og:image"), .content("https://cfp.tryswift.jp/images/ogp.png"))
+    meta(.property("og:image"), .content("https://tryswift.jp/images/ogp.jpg"))
     meta(.name("twitter:card"), .content("summary_large_image"))
     meta(.name("twitter:title"), .content("\(title) - try! Swift Tokyo 2026"))
-    meta(.name("twitter:image"), .content("https://cfp.tryswift.jp/images/ogp.png"))
+    meta(.name("twitter:image"), .content("https://tryswift.jp/images/ogp.jpg"))
     // Custom styles
     HTMLRaw(
       """


### PR DESCRIPTION
## Summary

CfP サイトの OGP（Open Graph Protocol）画像を、メインの try! Swift Tokyo ウェブサイトと同じものを使用するように変更しました。

## Changes

- `og:image` の URL を `https://cfp.tryswift.jp/images/ogp.png` から `https://tryswift.jp/images/ogp.jpg` に変更
- `twitter:image` の URL も同様に変更

## Why

CfP サイトでは独自の OGP 画像（`cfp.tryswift.jp/images/ogp.png`）を参照していましたが、このファイルは実際には存在しませんでした。メインウェブサイトの OGP 画像を共有することで、一貫したブランディングを実現し、SNS でシェアされた際に正しく画像が表示されるようになります。

## Files Changed

- `Server/Sources/Server/CfP/Layouts/CfPLayout.swift`

---

This PR was written using [Vibe Kanban](https://vibekanban.com)