### PR TITLE
Fix OpenMapButton button style in Guidance.swift

### DIFF
--- a/iOS/Sources/GuidanceFeature/Guidance.swift
+++ b/iOS/Sources/GuidanceFeature/Guidance.swift
@@ -203,10 +203,11 @@ public struct GuidanceView: View {
           } icon: {
             Image(systemName: "map")
           }
-          .padding(.horizontal, 20)
-          .padding(.vertical, 12)
+          .padding(.horizontal, 12)
+          .padding(.vertical, 8)
         }
-        .glassEffect(.regular.tint(.accentColor).interactive(), in: .capsule)
+        .buttonStyle(.glassProminent)
+        .buttonBorderShape(.capsule)
         .padding(.horizontal)
         directions
         venueInfo


### PR DESCRIPTION
## Summary

This PR fixes a readability issue with the "Open Map Button" in `GuidanceView`.

Currently, "Open Map Button" uses the default `DefaultButtonStyle`, which applies `foregroundStyle(.link) -> foregroundStyle(.accentColor)` internally.  
After adding the Glass Effect, the button background also becomes `accentColor`, causing insufficient contrast and making the label text hard to read.

To address this, the button style has been updated to use `.glassProminent`.

## Screenshots

| Before (Current) | After (Improved) |
| --- | --- |
| ![IMG_8155](https://github.com/user-attachments/assets/af131431-b75f-4f17-a6f3-bed3edf13957) | ![IMG_8157](https://github.com/user-attachments/assets/fd7cd214-a883-4632-9b93-7dc7787c75de) |

## Changes

- Switched the button style to `.buttonStyle(.glassProminent)`
- Adjusted the `Label` padding to compensate for the **automatic 7pt padding** applied by `.glassProminent` on iOS

## Rationale

An alternative solution would be to explicitly set: `.foregroundStyle(.white)` on the label. However, this approach was avoided for the following reasons:

- There is an existing issue where the border alignment becomes incorrect while pressing the button in iOS 26.x
- In the Accessibility → Button Shapes (“Show Button Shapes”) environment, this approach can introduce unexpected extra padding
- Using .glassProminent provides better consistency with system behavior and avoids these edge cases

For these reasons, .glassProminent was chosen as the more robust solution.

## Reference

This pull request makes minor UI adjustments to the GuidanceView in Guidance.swift, focusing on button padding and style for a more consistent appearance.

Switched from a custom glass effect to .buttonStyle(.glassProminent) and .buttonBorderShape(.capsule)