### PR TITLE
Use SkipModel instead of Observation in Android ViewModels (Vibe Kanban)

### DIFF
--- a/Android/Sources/AboutFeature/AboutViewModel.swift
+++ b/Android/Sources/AboutFeature/AboutViewModel.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Observation
 import SharedModels
+import SkipModel
 
 @Observable
 public final class AboutViewModel {

--- a/Android/Sources/ScheduleFeature/ScheduleViewModel.swift
+++ b/Android/Sources/ScheduleFeature/ScheduleViewModel.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Observation
 import SharedModels
+import SkipModel
 
 public enum ScheduleDay: String, CaseIterable, Identifiable {
   case day1 = "Day 1"

--- a/Android/Sources/SponsorFeature/SponsorsViewModel.swift
+++ b/Android/Sources/SponsorFeature/SponsorsViewModel.swift
@@ -1,6 +1,6 @@
 import Foundation
-import Observation
 import SharedModels
+import SkipModel
 
 @Observable
 public final class SponsorsViewModel {


### PR DESCRIPTION
## Summary

- Replace `import Observation` with `import SkipModel` in all Android ViewModel files
- Affects `AboutViewModel`, `ScheduleViewModel`, and `SponsorsViewModel`

## Why

The `skip-model` package was already added to `Package.swift` as a dependency, but the ViewModels were still using Swift's `Observation` framework. For Skip to properly transpile the `@Observable` macro to Kotlin for Android builds, the `SkipModel` module needs to be imported instead.

## Changes

| File | Change |
|------|--------|
| `Android/Sources/AboutFeature/AboutViewModel.swift` | `Observation` → `SkipModel` |
| `Android/Sources/ScheduleFeature/ScheduleViewModel.swift` | `Observation` → `SkipModel` |
| `Android/Sources/SponsorFeature/SponsorsViewModel.swift` | `Observation` → `SkipModel` |

---

This PR was written using [Vibe Kanban](https://vibekanban.com)