### PR TITLE
Fix: Increase request body size limit for PaperCall.io CSV imports

### DIFF
--- a/Server/Sources/Server/configure.swift
+++ b/Server/Sources/Server/configure.swift
@@ -62,6 +62,12 @@ enum AppConfiguration {
     // Configure JWT with HS256 algorithm
     await app.jwt.keys.add(hmac: HMACKey(from: jwtSecret), digestAlgorithm: .sha256)
 
+    // MARK: - Request Body Size Configuration
+
+    // Increase max body size for CSV file uploads (default is 16KB)
+    // Set to 10MB to support large PaperCall.io CSV exports
+    app.routes.defaultMaxBodySize = "10mb"
+
     // MARK: - Middleware
 
     // Enable CORS for frontend and iOS client


### PR DESCRIPTION
## Summary
- Fixes "Payload too large" error when importing large CSV files from PaperCall.io
- Increases Vapor's request body size limit from default 16KB to 10MB

## Changes
- Added `app.routes.defaultMaxBodySize = "10mb"` configuration in `configure.swift`
- Allows importing CSV files containing hundreds of proposals without hitting payload limits

## Test plan
- [ ] Test importing a large PaperCall.io CSV file (>16KB)
- [ ] Verify no "Payload too large" error occurs
- [ ] Confirm proposals are imported successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)