### PR TITLE
Fix: Extract filename from namespace path for website sponsor images

### DIFF
--- a/Website/Sources/Components/SponsorComponent.swift
+++ b/Website/Sources/Components/SponsorComponent.swift
@@ -38,6 +38,9 @@ extension Sponsor {
   }
 
   fileprivate var imageFilename: String {
-    ImagePath.resolve(imageName)
+    // Extract filename from namespace path (e.g., "Sponsor/2026/2026_RevenueCat" -> "2026_RevenueCat")
+    // or keep as-is if no namespace (for backward compatibility)
+    let filename = imageName.components(separatedBy: "/").last ?? imageName
+    return ImagePath.resolve(filename)
   }
 }


### PR DESCRIPTION
## Summary
- PR #202でiOS側のスポンサーJSONファイルの`imageName`がネームスペース付きパス（例：`Sponsor/2026/2026_RevenueCat`）に変更されました
- Webサイトのビルドプロセスは画像ファイル名のみ（例：`2026_RevenueCat.png`）を`Assets/images/from_app/`にコピーします
- Webサイトがネームスペース付きパスで画像を探すと見つからないため、パスからファイル名部分のみを抽出するように修正しました

## Changes
- `Website/Sources/Components/SponsorComponent.swift`の`imageFilename`プロパティを修正
- `imageName`からファイル名部分のみを抽出（例：`Sponsor/2026/2026_RevenueCat` → `2026_RevenueCat`）
- 後方互換性を保持（ネームスペースなしの画像名はそのまま使用）

## Related
- Related to PR #202

## Test plan
- [ ] Webサイトをビルドし、2026年スポンサー画像が正しく表示されることを確認
- [ ] 個人スポンサー画像も正しく表示されることを確認
- [ ] 過去の年のスポンサー画像（ネームスペースなし）も引き続き正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)