### PR TITLE
Fix: Display timestamps in user's local timezone on CfP pages

### DIFF
--- a/Server/Sources/Server/CfP/Layouts/CfPLayout.swift
+++ b/Server/Sources/Server/CfP/Layouts/CfPLayout.swift
@@ -70,5 +70,26 @@ struct CfPLayout<Content: HTML & Sendable>: HTMLDocument, Sendable {
     script(
       .src("https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js")
     ) {}
+
+    HTMLRaw(
+      """
+      <script>
+      document.querySelectorAll("time.local-time").forEach(function(el) {
+        var dt = new Date(el.getAttribute("datetime"));
+        if (isNaN(dt)) return;
+        var lang = document.documentElement.lang || navigator.language;
+        var style = el.getAttribute("data-style") || "medium";
+        var opts = {};
+        if (style === "short") {
+          opts = { year: "numeric", month: "numeric", day: "numeric", hour: "numeric", minute: "numeric" };
+        } else if (style === "medium") {
+          opts = { year: "numeric", month: "short", day: "numeric", hour: "numeric", minute: "numeric" };
+        } else if (style === "date") {
+          opts = { year: "numeric", month: "short", day: "numeric" };
+        }
+        el.textContent = dt.toLocaleString(lang, opts);
+      });
+      </script>
+      """)
   }
 }

--- a/Server/Sources/Server/CfP/Pages/MyProposalDetailPage.swift
+++ b/Server/Sources/Server/CfP/Pages/MyProposalDetailPage.swift
@@ -170,7 +170,9 @@ struct MyProposalDetailPageView: HTML, Sendable {
                 dt(.class("col-sm-3")) { language == .ja ? "提出日" : "Submitted" }
                 dd(.class("col-sm-9")) {
                   if let createdAt = proposal.createdAt {
-                    HTMLText(formatDate(createdAt))
+                    HTMLRaw(
+                      "<time class=\"local-time\" datetime=\"\(formatISO(createdAt))\" data-style=\"medium\"></time>"
+                    )
                   } else {
                     language == .ja ? "不明" : "Unknown"
                   }
@@ -178,7 +180,9 @@ struct MyProposalDetailPageView: HTML, Sendable {
                 dt(.class("col-sm-3")) { language == .ja ? "最終更新" : "Last Updated" }
                 dd(.class("col-sm-9")) {
                   if let updatedAt = proposal.updatedAt {
-                    HTMLText(formatDate(updatedAt))
+                    HTMLRaw(
+                      "<time class=\"local-time\" datetime=\"\(formatISO(updatedAt))\" data-style=\"medium\"></time>"
+                    )
                   } else {
                     language == .ja ? "なし" : "Never"
                   }
@@ -232,14 +236,9 @@ struct MyProposalDetailPageView: HTML, Sendable {
     }
   }
 
-  private func formatDate(_ date: Date) -> String {
-    let formatter = DateFormatter()
-    formatter.dateStyle = .medium
-    formatter.timeStyle = .short
-    formatter.timeZone = TimeZone(identifier: "Asia/Tokyo")
-    if language == .ja {
-      formatter.locale = Locale(identifier: "ja_JP")
-    }
+  private func formatISO(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
     return formatter.string(from: date)
   }
 

--- a/Server/Sources/Server/CfP/Pages/MyProposalsPage.swift
+++ b/Server/Sources/Server/CfP/Pages/MyProposalsPage.swift
@@ -175,7 +175,9 @@ struct ProposalCard: HTML, Sendable {
             }
             if let createdAt = proposal.createdAt {
               small(.class("text-muted")) {
-                HTMLText(formatDate(createdAt))
+                HTMLRaw(
+                  "<time class=\"local-time\" datetime=\"\(formatISO(createdAt))\" data-style=\"date\"></time>"
+                )
               }
             }
           }
@@ -187,13 +189,9 @@ struct ProposalCard: HTML, Sendable {
     }
   }
 
-  private func formatDate(_ date: Date) -> String {
-    let formatter = DateFormatter()
-    formatter.dateStyle = .medium
-    formatter.timeZone = TimeZone(identifier: "Asia/Tokyo")
-    if language == .ja {
-      formatter.locale = Locale(identifier: "ja_JP")
-    }
+  private func formatISO(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
     return formatter.string(from: date)
   }
 }

--- a/Server/Sources/Server/CfP/Pages/OrganizerProposalsPage.swift
+++ b/Server/Sources/Server/CfP/Pages/OrganizerProposalsPage.swift
@@ -171,7 +171,9 @@ struct OrganizerProposalRow: HTML, Sendable {
       td(.class("align-middle")) {
         if let createdAt = proposal.createdAt {
           small(.class("text-muted")) {
-            HTMLText(formatDate(createdAt))
+            HTMLRaw(
+              "<time class=\"local-time\" datetime=\"\(formatISO(createdAt))\" data-style=\"short\"></time>"
+            )
           }
         }
       }
@@ -186,11 +188,9 @@ struct OrganizerProposalRow: HTML, Sendable {
     }
   }
 
-  private func formatDate(_ date: Date) -> String {
-    let formatter = DateFormatter()
-    formatter.dateStyle = .short
-    formatter.timeStyle = .short
-    formatter.timeZone = TimeZone(identifier: "Asia/Tokyo")
+  private func formatISO(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime]
     return formatter.string(from: date)
   }
 }


### PR DESCRIPTION
## Summary
- Display timestamps on MyProposal and All Proposals (Organizer) pages in the user's local timezone instead of the server's timezone
- Uses client-side JavaScript with `<time>` elements and `Date.toLocaleString()` to convert UTC timestamps to the user's browser locale and timezone

## Changes
- **MyProposalsPage.swift**: Output `<time class="local-time">` with ISO 8601 UTC datetime attribute (date-only style)
- **OrganizerProposalsPage.swift**: Output `<time class="local-time">` with ISO 8601 UTC datetime attribute (short date+time style)
- **MyProposalDetailPage.swift**: Output `<time class="local-time">` for both submitted and last updated timestamps (medium date+time style)
- **CfPLayout.swift**: Add inline script to convert all `<time class="local-time">` elements to the user's local timezone using `toLocaleString()`

## Test plan
- [ ] Verify timestamps on My Proposals list page display in the user's local timezone
- [ ] Verify timestamps on All Proposals (Organizer) page display in the user's local timezone
- [ ] Verify submitted and last updated timestamps on Proposal Detail page display in the user's local timezone
- [ ] Confirm correct formatting for both English and Japanese locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)