### PR TITLE
Fix: Handle BOM and CR in PaperCall CSV header detection

### DIFF
--- a/Server/Sources/Server/Services/PaperCallCSVParser.swift
+++ b/Server/Sources/Server/Services/PaperCallCSVParser.swift
@@ -30,7 +30,7 @@ enum PaperCallCSVParser {
       switch self {
       case .invalidHeader(let actual):
         return
-          "Invalid CSV header. Expected: ID,Title,Abstract,Talk Details,Duration,Speaker Name,Speaker Email,Speaker Username,Bio,Icon URL,Notes,Conference,Submitted At. Got: \(actual)"
+          "Invalid CSV header. Expected: \(expectedCustomHeader) or \(expectedStandardHeader). Got: \(actual)"
       case .missingRequiredField(let field, let row):
         return "Missing required field '\(field)' at row \(row)"
       case .invalidFormat(let reason):
@@ -42,11 +42,11 @@ enum PaperCallCSVParser {
   }
 
   /// Expected CSV header for custom format
-  private static let expectedCustomHeader =
+  static let expectedCustomHeader =
     "ID,Title,Abstract,Talk Details,Duration,Speaker Name,Speaker Email,Speaker Username,Bio,Icon URL,Notes,Conference,Submitted At"
 
   /// Expected CSV header for PaperCall standard export
-  private static let expectedStandardHeader =
+  static let expectedStandardHeader =
     "name,email,avatar,location,bio,twitter,url,organization,shirt_size,talk_format,title,abstract,description,notes,audience_level,tags,rating,state,confirmed,created_at,additional_info"
 
   /// CSV format type
@@ -62,8 +62,10 @@ enum PaperCallCSVParser {
       throw ParseError.emptyFile
     }
 
-    // Detect format
-    let header = lines[0].trimmingCharacters(in: .whitespaces)
+    // Detect format (strip BOM and carriage return for compatibility)
+    let header = lines[0]
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .replacingOccurrences(of: "\u{FEFF}", with: "")
     let format: CSVFormat
     if header == expectedCustomHeader {
       format = .custom


### PR DESCRIPTION
## Summary
- Strip BOM (`\u{FEFF}`) and carriage return characters from CSV header before format detection, fixing import failures with PaperCall.io standard export files
- Update error message to display both supported CSV formats (custom and PaperCall standard) instead of only the custom format

## Test plan
- [ ] Upload a PaperCall.io standard CSV export file (with BOM/Windows line endings) and verify it imports successfully
- [ ] Upload a custom format CSV and verify it still works
- [ ] Upload an invalid CSV and verify the error message shows both expected formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)