### PR TITLE
Bump MARKETING_VERSION to 26.2.0

### DIFF
--- a/App/App.xcodeproj/project.pbxproj
+++ b/App/App.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MARKETING_VERSION = 1.3.5;
+				MARKETING_VERSION = 26.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.tryswift.tokyo.App;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -485,7 +485,7 @@
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
-				MARKETING_VERSION = 1.3.5;
+				MARKETING_VERSION = 26.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.tryswift.tokyo.App;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = auto;
@@ -520,7 +520,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.5;
+				MARKETING_VERSION = 26.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.tryswift.tokyo.App.Clip;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
@@ -552,7 +552,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.5;
+				MARKETING_VERSION = 26.2.0;
 				PRODUCT_BUNDLE_IDENTIFIER = jp.tryswift.tokyo.App.Clip;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;


### PR DESCRIPTION
## Summary
- App および Clip ターゲットの `MARKETING_VERSION` を `26.2.0` に更新（Debug/Release 全構成）

## Test plan
- [ ] Xcode でプロジェクトを開き、各ターゲットの General タブでバージョンが `26.2.0` になっていることを確認
- [ ] ビルドが正常に通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)