### PR TITLE
Changed the position of the Flitto logo to improve the scroll animation.

### DIFF
--- a/iOS/Sources/LiveTranslationFeature/LiveTranslation.swift
+++ b/iOS/Sources/LiveTranslationFeature/LiveTranslation.swift
@@ -368,6 +368,8 @@ public struct LiveTranslationView: View {
       VStack {
         ScrollViewReader { proxy in
           ScrollView {
+            flittoLogo
+
             if store.roomNumber.isEmpty {
               ContentUnavailableView("Room is unavailable", systemImage: "text.page.slash.fill")
               Spacer()
@@ -378,11 +380,9 @@ public struct LiveTranslationView: View {
               translationContents
             }
 
-            flittoLogo
+            Spacer()
+              .frame(height: 28)
               .id(scrollContentBottomID)
-              .padding(.bottom, 16)
-              .accessibilityElement(children: .ignore)
-              .accessibilityLabel(Text(verbatim: "Powered by Flitto"))
           }
           .onChange(of: store.chatList.last) { old, new in
             guard old != .none else {
@@ -556,6 +556,8 @@ public struct LiveTranslationView: View {
     .padding(.vertical, 8)
     .glassEffect(.clear, in: .capsule)
     .padding(.horizontal)
+    .accessibilityElement(children: .ignore)
+    .accessibilityLabel(Text(verbatim: "Powered by Flitto"))
   }
 }
 


### PR DESCRIPTION
ライブ翻訳の自動スクロール機能において、自動スクロールされる際にFlittoロゴも大きく動いてしまい視覚ノイズになっていた現象を改善するためにFlittoロゴの位置を変更しました。本実装は #222 の改善案①に相当します。詳しくは #222 を参照してください。

(実際のFlitto SDKでの動作確認はできていませんので、お手数ですが動作確認よろしくお願いします。)