### PR TITLE
Show Flitto logo only when no translation is available

### DIFF
--- a/iOS/Sources/LiveTranslationFeature/LiveTranslation.swift
+++ b/iOS/Sources/LiveTranslationFeature/LiveTranslation.swift
@@ -372,18 +372,17 @@ public struct LiveTranslationView: View {
             if store.roomNumber.isEmpty {
               ContentUnavailableView("Room is unavailable", systemImage: "text.page.slash.fill")
               Spacer()
+              flittoLogo
             } else if store.chatList.isEmpty {
               ContentUnavailableView("Not started yet", systemImage: "text.page.slash.fill")
               Spacer()
+              flittoLogo
             } else {
               translationContents
+              Color.clear
+                .id(scrollContentBottomID)
+                .frame(height: 1)
             }
-
-            flittoLogo
-              .id(scrollContentBottomID)
-              .padding(.bottom, 16)
-              .accessibilityElement(children: .ignore)
-              .accessibilityLabel(Text(verbatim: "Powered by Flitto"))
           }
           .onChange(of: store.chatList.last) { old, new in
             guard old != .none else {


### PR DESCRIPTION
## Summary
- Flitto ロゴを翻訳コンテンツがない時（部屋が未設定 or 翻訳未開始）のみ表示するよう変更
- 翻訳コンテンツ表示中はロゴを非表示にし、不可視の `Color.clear` アンカーで自動スクロールを維持
- ロゴが ScrollView の自動スクロールに巻き込まれる問題を解消

Closes #222

## Test plan
- [ ] `roomNumber` が空の場合に Flitto ロゴが表示されることを確認
- [ ] `chatList` が空の場合に Flitto ロゴが表示されることを確認
- [ ] 翻訳コンテンツが流れている時にロゴが非表示であることを確認
- [ ] 自動スクロールが翻訳コンテンツ受信時に正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)