### PR TITLE
Apply Liquid Glass effect to Organizers list cells

### DIFF
--- a/iOS/Sources/trySwiftFeature/Organizers.swift
+++ b/iOS/Sources/trySwiftFeature/Organizers.swift
@@ -1,5 +1,6 @@
 import ComposableArchitecture
 import DataClient
+import DependencyExtra
 import SharedModels
 import SwiftUI
 
@@ -68,22 +69,29 @@ public struct OrganizersView: View {
   public var store: StoreOf<Organizers>
 
   public var body: some View {
-    List {
-      ForEach(store.organizers) { organizer in
-        Button {
-          send(._organizerTapped(organizer))
-        } label: {
-          Label {
-            Text(LocalizedStringKey(organizer.name), bundle: .module)
-          } icon: {
-            Image(organizer.imageName, bundle: .module)
-              .resizable()
-              .aspectRatio(contentMode: .fit)
-              .clipShape(Circle())
-              .accessibilityIgnoresInvertColors()
+    ScrollView {
+      LazyVStack(spacing: 12) {
+        ForEach(store.organizers) { organizer in
+          Button {
+            send(._organizerTapped(organizer))
+          } label: {
+            HStack(spacing: 12) {
+              Image(organizer.imageName, bundle: .module)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+                .frame(width: 60, height: 60)
+                .clipShape(Circle())
+                .accessibilityIgnoresInvertColors()
+              Text(LocalizedStringKey(organizer.name), bundle: .module)
+                .font(.body)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding()
           }
+          .glassEffectIfAvailable(.regular.interactive(), in: .rect(cornerRadius: 16))
         }
       }
+      .padding()
     }
     .onAppear {
       send(.onAppear)


### PR DESCRIPTION
## Summary
- OrganizersViewのセルレイアウトを`List`+`Label`から`ScrollView`+`LazyVStack`+`HStack`に変更
- `.glassEffectIfAvailable(.regular.interactive(), in: .rect(cornerRadius: 16))`を適用し、ScheduleやSponsorsと統一されたLiquid Glassスタイルに
- `DependencyExtra`のimportを追加

## Test plan
- [ ] iOS 26シミュレータでOrganizers画面を開き、セルにLiquid Glass効果が表示されることを確認
- [ ] セルタップ時のインタラクティブなglass効果が動作することを確認
- [ ] iOS 26未満のシミュレータでクラッシュせずフォールバックされることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)