### PR TITLE
Add Dependabot configuration for iOS, Web, CfP, and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # iOS app - Swift Package Manager
+  - package-ecosystem: "swift"
+    directory: "/iOS"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "iOS"
+
+  # Website - Swift Package Manager
+  - package-ecosystem: "swift"
+    directory: "/Website"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "Web"
+
+  # CfP Server - Swift Package Manager
+  - package-ecosystem: "swift"
+    directory: "/Server"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "CfP"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "CI"


### PR DESCRIPTION
## Summary
- iOS (`/iOS`), Website (`/Website`), CfP Server (`/Server`) の Swift Package Manager 依存関係を毎週自動チェックするよう Dependabot を設定
- GitHub Actions のバージョン更新も毎週自動チェックするよう設定
- 各エコシステムに適切なラベル（`dependencies`, `iOS`/`Web`/`CfP`/`CI`）を付与

## Test plan
- [ ] `.github/dependabot.yml` が正しいYAMLフォーマットであることを確認
- [ ] マージ後、GitHub の Dependabot ダッシュボードで4つのエコシステムが認識されていることを確認
- [ ] Dependabot が各ディレクトリの `Package.swift` / `Package.resolved` を検出できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)