### PR TITLE
[Web] Fix Code of Conduct and Privacy Policy not showing Japanese translations

### DIFF
--- a/LocalizationGenerated/Plugins/LocalizationCodegenPlugin/Plugin.swift
+++ b/LocalizationGenerated/Plugins/LocalizationCodegenPlugin/Plugin.swift
@@ -15,10 +15,11 @@ struct LocalizationCodegenPlugin: BuildToolPlugin {
     let packageDirectory = context.package.directory
     var commands: [Command] = []
 
-    // Known .xcstrings file paths in the iOS package (sibling directory)
+    // Known .xcstrings file paths in the iOS and Website packages (sibling directories)
     let xcstringsConfigs: [(path: String, featureName: String)] = [
       ("../iOS/Sources/ScheduleFeature/Localizable.xcstrings", "Schedule"),
       ("../iOS/Sources/trySwiftFeature/Localizable.xcstrings", "TrySwift"),
+      ("../Website/Sources/Resources/Localizable.xcstrings", "Website"),
     ]
 
     for config in xcstringsConfigs {

--- a/Website/Sources/Pages/Localization.swift
+++ b/Website/Sources/Pages/Localization.swift
@@ -17,10 +17,12 @@ extension LocalizedString {
 }
 
 // Extension for String literals used in UI
-// Looks up from trySwiftFeature Localizable.xcstrings, falls back to literal if not found
+// Looks up from Website, then trySwiftFeature Localizable.xcstrings, falls back to literal if not found
 extension String {
   init(_ literal: String, language: SupportedLanguage) {
-    if let localized = TrySwiftStrings[literal] {
+    if let localized = WebsiteStrings[literal] {
+      self = localized.localized(for: language)
+    } else if let localized = TrySwiftStrings[literal] {
       self = localized.localized(for: language)
     } else {
       // Fallback to literal if not found in localizations


### PR DESCRIPTION
## Summary
- LocalizationGenerated プラグインが iOS 側の `Localizable.xcstrings` のみをコード生成対象としており、Website 側の翻訳リソースが無視されていた問題を修正
- 行動規範・プライバシーポリシーページの全セクション（タイトル・本文）が日本語で正しく表示されるようになった
- `WebsiteStrings` を優先的に検索し、見つからない場合に `TrySwiftStrings` にフォールバックするように変更

## Test plan
- [ ] `swift build` が成功すること
- [ ] `swift run` でサイト生成後、`/code-of-conduct/index.html` が日本語で表示されること
- [ ] `swift run` でサイト生成後、`/privacy-policy/index.html` が日本語で表示されること
- [ ] 英語版 `/code-of-conduct_en/index.html` および `/privacy-policy_en/index.html` が英語のまま表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)