### PR TITLE
Fix GitHub ID and delete cards not rendering on organizer edit page

### DIFF
--- a/Server/Sources/Server/CfP/Pages/OrganizerEditProposalPage.swift
+++ b/Server/Sources/Server/CfP/Pages/OrganizerEditProposalPage.swift
@@ -34,8 +34,7 @@ struct OrganizerEditProposalPageView: HTML, Sendable {
           githubUpdatedAlert
           errorAlert
           editFormCard(proposal: proposal)
-          githubUpdateCard(proposal: proposal)
-          deleteCard(proposal: proposal)
+          bottomCards(proposal: proposal)
         } else {
           notFoundCard
         }
@@ -336,6 +335,12 @@ struct OrganizerEditProposalPageView: HTML, Sendable {
           """)
       }
     }
+  }
+
+  @HTMLBuilder
+  private func bottomCards(proposal: ProposalDTO) -> some HTML {
+    githubUpdateCard(proposal: proposal)
+    deleteCard(proposal: proposal)
   }
 
   private func githubUpdateCard(proposal: ProposalDTO) -> some HTML {


### PR DESCRIPTION
## Summary
- Organizer編集ページでGitHub AccountカードとDeleteカードが表示されない問題を修正
- ElementaryのHTMLBuilderが`buildBlock`で最大6個の子要素までしか対応していないため、`if let proposal`ブロック内の7個の子要素が正しくレンダリングされなかった
- `githubUpdateCard`と`deleteCard`を`bottomCards`ヘルパーメソッドにグループ化し、子要素数を6個以内に収めた

## Test plan
- [x] `swift build` 成功
- [x] `swift test --filter OrganizerProposal` 全10テスト通過
- [ ] デプロイ後、`/organizer/proposals/{id}/edit`でGitHub AccountカードとDeleteカードが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)