### PR TITLE
Fix references to removed CfPWebsite directory

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -16,7 +16,7 @@ jobs:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Format
-        run: swift format --ignore-unparsable-files --in-place --recursive ./App/ ./Server/ ./SharedModels/ ./iOS/ ./Website/ ./CfPWebsite/
+        run: swift format --ignore-unparsable-files --in-place --recursive ./App/ ./Server/ ./SharedModels/ ./iOS/ ./Website/
       - name: Configure safe directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - uses: stefanzweifel/git-auto-commit-action@v7

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,6 @@ format:
 		--recursive \
 		./Android/ \
 		./App/ \
-		./CfPWebsite/ \
 		./DataClient/ \
 		./iOS/ \
 		./LocalizationGenerated/ \

--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -56,8 +56,8 @@ WORKDIR /app
 
 COPY --from=build /staging /app
 
-# Copy CfP static assets (images)
-COPY ./CfPWebsite/Assets/images ./Public/images
+# Copy static assets (images)
+COPY ./Website/Assets/images ./Public/images
 
 ENV SWIFT_BACKTRACE=enable=yes,sanitize=yes,threads=all,images=all,interactive=no,swift-backtrace=./swift-backtrace-static
 


### PR DESCRIPTION
## Summary
- Dockerfileの画像アセットパスを `CfPWebsite/Assets/images` から `Website/Assets/images` に修正
- Makefile と GitHub Actions format workflow から存在しない `CfPWebsite` ディレクトリへの参照を削除

## Test plan
- [ ] `fly deploy` (Dockerfile のビルド) が成功すること
- [ ] GitHub Actions の format ワークフローが成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)