### PR TITLE
Remove Skip-specific configuration from SharedModels

### DIFF
--- a/SharedModels/Package.swift
+++ b/SharedModels/Package.swift
@@ -11,20 +11,12 @@ let package = Package(
       targets: ["SharedModels"]
     )
   ],
-  dependencies: [
-    .package(url: "https://source.skip.tools/skip.git", from: "1.2.0"),
-    .package(url: "https://source.skip.tools/skip-foundation.git", from: "1.0.0"),
-  ],
   targets: [
     .target(
       name: "SharedModels",
-      dependencies: [
-        .product(name: "SkipFoundation", package: "skip-foundation")
-      ],
       swiftSettings: [
         .swiftLanguageMode(.v6)
-      ],
-      plugins: [.plugin(name: "skipstone", package: "skip")]
+      ]
     ),
     .testTarget(
       name: "SharedModelsTests",

--- a/SharedModels/Sources/SharedModels/CfP/ConferenceDTO.swift
+++ b/SharedModels/Sources/SharedModels/CfP/ConferenceDTO.swift
@@ -1,148 +1,143 @@
 import Foundation
 
-// CfP types are iOS-only (not used in Android app)
-#if !SKIP
+/// Localized string supporting multiple languages
+public struct LocalizedString: Codable, Sendable, Equatable {
+  public let en: String
+  public let ja: String
 
-  /// Localized string supporting multiple languages
-  public struct LocalizedString: Codable, Sendable, Equatable {
-    public let en: String
-    public let ja: String
-
-    public init(en: String, ja: String) {
-      self.en = en
-      self.ja = ja
-    }
-
-    /// Get localized string for the given locale
-    public func localized(for locale: String = "en") -> String {
-      locale.starts(with: "ja") ? ja : en
-    }
+  public init(en: String, ja: String) {
+    self.en = en
+    self.ja = ja
   }
 
-  /// Data Transfer Object for Conference
-  /// Represents a conference event that accepts CfP submissions
-  public struct ConferenceDTO: Codable, Sendable, Equatable, Identifiable {
-    /// Unique identifier (hash)
-    public let id: UUID
-    /// URL-friendly path/alias (e.g., "tryswift-tokyo-2026")
-    public let path: String
-    /// Human-readable display name (e.g., "try! Swift Tokyo 2026")
-    public let displayName: String
-    /// Conference description with guidelines (markdown, localized)
-    public let description: LocalizedString?
-    /// Conference year
-    public let year: Int
-    /// Whether CfP is currently open for this conference
-    public let isOpen: Bool
-    /// CfP submission deadline
-    public let deadline: Date?
-    /// Conference start date
-    public let startDate: Date?
-    /// Conference end date
-    public let endDate: Date?
-    /// Conference location
-    public let location: String?
-    /// Conference website URL
-    public let websiteURL: String?
-
-    public let createdAt: Date?
-    public let updatedAt: Date?
-
-    public init(
-      id: UUID,
-      path: String,
-      displayName: String,
-      description: LocalizedString? = nil,
-      year: Int,
-      isOpen: Bool = true,
-      deadline: Date? = nil,
-      startDate: Date? = nil,
-      endDate: Date? = nil,
-      location: String? = nil,
-      websiteURL: String? = nil,
-      createdAt: Date? = nil,
-      updatedAt: Date? = nil
-    ) {
-      self.id = id
-      self.path = path
-      self.displayName = displayName
-      self.description = description
-      self.year = year
-      self.isOpen = isOpen
-      self.deadline = deadline
-      self.startDate = startDate
-      self.endDate = endDate
-      self.location = location
-      self.websiteURL = websiteURL
-      self.createdAt = createdAt
-      self.updatedAt = updatedAt
-    }
+  /// Get localized string for the given locale
+  public func localized(for locale: String = "en") -> String {
+    locale.starts(with: "ja") ? ja : en
   }
+}
 
-  /// Request object for creating a new conference
-  public struct CreateConferenceRequest: Codable, Sendable {
-    public let path: String
-    public let displayName: String
-    public let description: LocalizedString?
-    public let year: Int
-    public let isOpen: Bool
-    public let deadline: Date?
-    public let startDate: Date?
-    public let endDate: Date?
-    public let location: String?
-    public let websiteURL: String?
+/// Data Transfer Object for Conference
+/// Represents a conference event that accepts CfP submissions
+public struct ConferenceDTO: Codable, Sendable, Equatable, Identifiable {
+  /// Unique identifier (hash)
+  public let id: UUID
+  /// URL-friendly path/alias (e.g., "tryswift-tokyo-2026")
+  public let path: String
+  /// Human-readable display name (e.g., "try! Swift Tokyo 2026")
+  public let displayName: String
+  /// Conference description with guidelines (markdown, localized)
+  public let description: LocalizedString?
+  /// Conference year
+  public let year: Int
+  /// Whether CfP is currently open for this conference
+  public let isOpen: Bool
+  /// CfP submission deadline
+  public let deadline: Date?
+  /// Conference start date
+  public let startDate: Date?
+  /// Conference end date
+  public let endDate: Date?
+  /// Conference location
+  public let location: String?
+  /// Conference website URL
+  public let websiteURL: String?
 
-    public init(
-      path: String,
-      displayName: String,
-      description: LocalizedString? = nil,
-      year: Int,
-      isOpen: Bool = true,
-      deadline: Date? = nil,
-      startDate: Date? = nil,
-      endDate: Date? = nil,
-      location: String? = nil,
-      websiteURL: String? = nil
-    ) {
-      self.path = path
-      self.displayName = displayName
-      self.description = description
-      self.year = year
-      self.isOpen = isOpen
-      self.deadline = deadline
-      self.startDate = startDate
-      self.endDate = endDate
-      self.location = location
-      self.websiteURL = websiteURL
-    }
+  public let createdAt: Date?
+  public let updatedAt: Date?
+
+  public init(
+    id: UUID,
+    path: String,
+    displayName: String,
+    description: LocalizedString? = nil,
+    year: Int,
+    isOpen: Bool = true,
+    deadline: Date? = nil,
+    startDate: Date? = nil,
+    endDate: Date? = nil,
+    location: String? = nil,
+    websiteURL: String? = nil,
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil
+  ) {
+    self.id = id
+    self.path = path
+    self.displayName = displayName
+    self.description = description
+    self.year = year
+    self.isOpen = isOpen
+    self.deadline = deadline
+    self.startDate = startDate
+    self.endDate = endDate
+    self.location = location
+    self.websiteURL = websiteURL
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
   }
+}
 
-  /// Default conference description for try! Swift Tokyo
-  public enum ConferenceDescriptions {
-    public static let trySwiftTokyo = LocalizedString(
-      en: """
-        ## Talk Guidelines
+/// Request object for creating a new conference
+public struct CreateConferenceRequest: Codable, Sendable {
+  public let path: String
+  public let displayName: String
+  public let description: LocalizedString?
+  public let year: Int
+  public let isOpen: Bool
+  public let deadline: Date?
+  public let startDate: Date?
+  public let endDate: Date?
+  public let location: String?
+  public let websiteURL: String?
 
-        - All talks will be held in a **single track**. It is a requirement for adoption to be able to finish speaking within each talk's time limit.
-        - All talks include **AI-powered multilingual simultaneous interpretation**.
-        - Many people from all over the world come to Japan to participate in this community. Participants prefer **specialized technical talks**.
-        - Non-technical talks and emotional talks also have room for adoption, but it is preferable that everyone who comes to the conference can enjoy it.
-        - **Introductory content** or content specialized in specific situations is difficult to adopt.
-          - Example: General architecture and accessibility adopted by the product will not be adopted unless your expertise is recognized.
-        - If you are basing on past appearances, please make all or part of this conference **new content**.
-        """,
-      ja: """
-        ## トークガイドライン
-
-        - すべてのトークは**シングルトラック**で実施します。各講演の規定時間以内で話し切れることが採用条件です。
-        - すべてのトークに**AIによる多言語同時通訳**が付きます。
-        - 世界各地から参加者が来日します。参加者は**専門性の高い技術トーク**を好みます。
-        - 技術的ではないものやエモーショナルなトークにも採用の余地はありますが、来場者全員が楽しめる内容が望ましいです。
-        - **入門的な内容**や、特定の状況に特化した内容は採用が難しい傾向です。
-          - 例：製品で採用している一般的なアーキテクチャやアクセシビリティは、あなたの専門性が認められない限り採用されません。
-        - 過去の登壇を基にする場合は、全体または一部を**新規の内容**にしてください。
-        """
-    )
+  public init(
+    path: String,
+    displayName: String,
+    description: LocalizedString? = nil,
+    year: Int,
+    isOpen: Bool = true,
+    deadline: Date? = nil,
+    startDate: Date? = nil,
+    endDate: Date? = nil,
+    location: String? = nil,
+    websiteURL: String? = nil
+  ) {
+    self.path = path
+    self.displayName = displayName
+    self.description = description
+    self.year = year
+    self.isOpen = isOpen
+    self.deadline = deadline
+    self.startDate = startDate
+    self.endDate = endDate
+    self.location = location
+    self.websiteURL = websiteURL
   }
+}
 
-#endif
+/// Default conference description for try! Swift Tokyo
+public enum ConferenceDescriptions {
+  public static let trySwiftTokyo = LocalizedString(
+    en: """
+      ## Talk Guidelines
+
+      - All talks will be held in a **single track**. It is a requirement for adoption to be able to finish speaking within each talk's time limit.
+      - All talks include **AI-powered multilingual simultaneous interpretation**.
+      - Many people from all over the world come to Japan to participate in this community. Participants prefer **specialized technical talks**.
+      - Non-technical talks and emotional talks also have room for adoption, but it is preferable that everyone who comes to the conference can enjoy it.
+      - **Introductory content** or content specialized in specific situations is difficult to adopt.
+        - Example: General architecture and accessibility adopted by the product will not be adopted unless your expertise is recognized.
+      - If you are basing on past appearances, please make all or part of this conference **new content**.
+      """,
+    ja: """
+      ## トークガイドライン
+
+      - すべてのトークは**シングルトラック**で実施します。各講演の規定時間以内で話し切れることが採用条件です。
+      - すべてのトークに**AIによる多言語同時通訳**が付きます。
+      - 世界各地から参加者が来日します。参加者は**専門性の高い技術トーク**を好みます。
+      - 技術的ではないものやエモーショナルなトークにも採用の余地はありますが、来場者全員が楽しめる内容が望ましいです。
+      - **入門的な内容**や、特定の状況に特化した内容は採用が難しい傾向です。
+        - 例：製品で採用している一般的なアーキテクチャやアクセシビリティは、あなたの専門性が認められない限り採用されません。
+      - 過去の登壇を基にする場合は、全体または一部を**新規の内容**にしてください。
+      """
+  )
+}

--- a/SharedModels/Sources/SharedModels/CfP/ProposalDTO.swift
+++ b/SharedModels/Sources/SharedModels/CfP/ProposalDTO.swift
@@ -1,171 +1,166 @@
 import Foundation
 
-// CfP types are iOS-only (not used in Android app)
-#if !SKIP
+/// Talk duration options
+public enum TalkDuration: String, Codable, Sendable, Equatable, CaseIterable {
+  case regular = "20min"
+  case lightning = "LT"
+  case invited = "invited"
 
-  /// Talk duration options
-  public enum TalkDuration: String, Codable, Sendable, Equatable, CaseIterable {
-    case regular = "20min"
-    case lightning = "LT"
-    case invited = "invited"
-
-    public var displayName: String {
-      switch self {
-      case .regular:
-        return "20 minutes"
-      case .lightning:
-        return "Lightning Talk (5 min)"
-      case .invited:
-        return "Invited Talk (20 min)"
-      }
-    }
-
-    /// Whether this duration is only available for invited speakers
-    public var isInvitedOnly: Bool {
-      self == .invited
+  public var displayName: String {
+    switch self {
+    case .regular:
+      return "20 minutes"
+    case .lightning:
+      return "Lightning Talk (5 min)"
+    case .invited:
+      return "Invited Talk (20 min)"
     }
   }
 
-  /// Data Transfer Object for CfP (Call for Proposals)
-  /// Shared between Server and iOS Client
-  public struct ProposalDTO: Codable, Sendable, Equatable, Identifiable {
-    public let id: UUID
-    /// Conference ID (hash/UUID)
-    public let conferenceId: UUID
-    /// Conference path for display (e.g., "tryswift-tokyo-2026")
-    public let conferencePath: String
-    /// Conference display name (e.g., "try! Swift Tokyo 2026")
-    public let conferenceDisplayName: String
-    public let title: String
-    public let abstract: String
-    public let talkDetail: String
-    public let talkDuration: TalkDuration
-    /// Speaker name at time of submission
-    public let speakerName: String
-    /// Speaker email at time of submission
-    public let speakerEmail: String
-    public let bio: String
-    public let iconURL: String?
-    public let notes: String?
-    public let speakerID: UUID
-    public let speakerUsername: String
-    public let status: ProposalStatus
-    public let createdAt: Date?
-    public let updatedAt: Date?
-
-    public init(
-      id: UUID,
-      conferenceId: UUID,
-      conferencePath: String,
-      conferenceDisplayName: String,
-      title: String,
-      abstract: String,
-      talkDetail: String,
-      talkDuration: TalkDuration,
-      speakerName: String,
-      speakerEmail: String,
-      bio: String,
-      iconURL: String? = nil,
-      notes: String? = nil,
-      speakerID: UUID,
-      speakerUsername: String,
-      status: ProposalStatus = .submitted,
-      createdAt: Date? = nil,
-      updatedAt: Date? = nil
-    ) {
-      self.id = id
-      self.conferenceId = conferenceId
-      self.conferencePath = conferencePath
-      self.conferenceDisplayName = conferenceDisplayName
-      self.title = title
-      self.abstract = abstract
-      self.talkDetail = talkDetail
-      self.talkDuration = talkDuration
-      self.speakerName = speakerName
-      self.speakerEmail = speakerEmail
-      self.bio = bio
-      self.iconURL = iconURL
-      self.notes = notes
-      self.speakerID = speakerID
-      self.speakerUsername = speakerUsername
-      self.status = status
-      self.createdAt = createdAt
-      self.updatedAt = updatedAt
-    }
+  /// Whether this duration is only available for invited speakers
+  public var isInvitedOnly: Bool {
+    self == .invited
   }
+}
 
-  /// Request object for creating a new proposal
-  public struct CreateProposalRequest: Codable, Sendable {
-    /// Conference path/alias (e.g., "tryswift-tokyo-2026")
-    public let conferencePath: String
-    public let title: String
-    public let abstract: String
-    public let talkDetail: String
-    public let talkDuration: TalkDuration
-    public let speakerName: String
-    public let speakerEmail: String
-    public let bio: String
-    public let iconURL: String?
-    public let notes: String?
+/// Data Transfer Object for CfP (Call for Proposals)
+/// Shared between Server and iOS Client
+public struct ProposalDTO: Codable, Sendable, Equatable, Identifiable {
+  public let id: UUID
+  /// Conference ID (hash/UUID)
+  public let conferenceId: UUID
+  /// Conference path for display (e.g., "tryswift-tokyo-2026")
+  public let conferencePath: String
+  /// Conference display name (e.g., "try! Swift Tokyo 2026")
+  public let conferenceDisplayName: String
+  public let title: String
+  public let abstract: String
+  public let talkDetail: String
+  public let talkDuration: TalkDuration
+  /// Speaker name at time of submission
+  public let speakerName: String
+  /// Speaker email at time of submission
+  public let speakerEmail: String
+  public let bio: String
+  public let iconURL: String?
+  public let notes: String?
+  public let speakerID: UUID
+  public let speakerUsername: String
+  public let status: ProposalStatus
+  public let createdAt: Date?
+  public let updatedAt: Date?
 
-    public init(
-      conferencePath: String,
-      title: String,
-      abstract: String,
-      talkDetail: String,
-      talkDuration: TalkDuration,
-      speakerName: String,
-      speakerEmail: String,
-      bio: String,
-      iconURL: String? = nil,
-      notes: String? = nil
-    ) {
-      self.conferencePath = conferencePath
-      self.title = title
-      self.abstract = abstract
-      self.talkDetail = talkDetail
-      self.talkDuration = talkDuration
-      self.speakerName = speakerName
-      self.speakerEmail = speakerEmail
-      self.bio = bio
-      self.iconURL = iconURL
-      self.notes = notes
-    }
+  public init(
+    id: UUID,
+    conferenceId: UUID,
+    conferencePath: String,
+    conferenceDisplayName: String,
+    title: String,
+    abstract: String,
+    talkDetail: String,
+    talkDuration: TalkDuration,
+    speakerName: String,
+    speakerEmail: String,
+    bio: String,
+    iconURL: String? = nil,
+    notes: String? = nil,
+    speakerID: UUID,
+    speakerUsername: String,
+    status: ProposalStatus = .submitted,
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil
+  ) {
+    self.id = id
+    self.conferenceId = conferenceId
+    self.conferencePath = conferencePath
+    self.conferenceDisplayName = conferenceDisplayName
+    self.title = title
+    self.abstract = abstract
+    self.talkDetail = talkDetail
+    self.talkDuration = talkDuration
+    self.speakerName = speakerName
+    self.speakerEmail = speakerEmail
+    self.bio = bio
+    self.iconURL = iconURL
+    self.notes = notes
+    self.speakerID = speakerID
+    self.speakerUsername = speakerUsername
+    self.status = status
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
   }
+}
 
-  /// Request object for updating an existing proposal
-  public struct UpdateProposalRequest: Codable, Sendable {
-    public let title: String?
-    public let abstract: String?
-    public let talkDetail: String?
-    public let talkDuration: TalkDuration?
-    public let speakerName: String?
-    public let speakerEmail: String?
-    public let bio: String?
-    public let iconURL: String?
-    public let notes: String?
+/// Request object for creating a new proposal
+public struct CreateProposalRequest: Codable, Sendable {
+  /// Conference path/alias (e.g., "tryswift-tokyo-2026")
+  public let conferencePath: String
+  public let title: String
+  public let abstract: String
+  public let talkDetail: String
+  public let talkDuration: TalkDuration
+  public let speakerName: String
+  public let speakerEmail: String
+  public let bio: String
+  public let iconURL: String?
+  public let notes: String?
 
-    public init(
-      title: String? = nil,
-      abstract: String? = nil,
-      talkDetail: String? = nil,
-      talkDuration: TalkDuration? = nil,
-      speakerName: String? = nil,
-      speakerEmail: String? = nil,
-      bio: String? = nil,
-      iconURL: String? = nil,
-      notes: String? = nil
-    ) {
-      self.title = title
-      self.abstract = abstract
-      self.talkDetail = talkDetail
-      self.talkDuration = talkDuration
-      self.speakerName = speakerName
-      self.speakerEmail = speakerEmail
-      self.bio = bio
-      self.iconURL = iconURL
-      self.notes = notes
-    }
+  public init(
+    conferencePath: String,
+    title: String,
+    abstract: String,
+    talkDetail: String,
+    talkDuration: TalkDuration,
+    speakerName: String,
+    speakerEmail: String,
+    bio: String,
+    iconURL: String? = nil,
+    notes: String? = nil
+  ) {
+    self.conferencePath = conferencePath
+    self.title = title
+    self.abstract = abstract
+    self.talkDetail = talkDetail
+    self.talkDuration = talkDuration
+    self.speakerName = speakerName
+    self.speakerEmail = speakerEmail
+    self.bio = bio
+    self.iconURL = iconURL
+    self.notes = notes
   }
+}
 
-#endif
+/// Request object for updating an existing proposal
+public struct UpdateProposalRequest: Codable, Sendable {
+  public let title: String?
+  public let abstract: String?
+  public let talkDetail: String?
+  public let talkDuration: TalkDuration?
+  public let speakerName: String?
+  public let speakerEmail: String?
+  public let bio: String?
+  public let iconURL: String?
+  public let notes: String?
+
+  public init(
+    title: String? = nil,
+    abstract: String? = nil,
+    talkDetail: String? = nil,
+    talkDuration: TalkDuration? = nil,
+    speakerName: String? = nil,
+    speakerEmail: String? = nil,
+    bio: String? = nil,
+    iconURL: String? = nil,
+    notes: String? = nil
+  ) {
+    self.title = title
+    self.abstract = abstract
+    self.talkDetail = talkDetail
+    self.talkDuration = talkDuration
+    self.speakerName = speakerName
+    self.speakerEmail = speakerEmail
+    self.bio = bio
+    self.iconURL = iconURL
+    self.notes = notes
+  }
+}

--- a/SharedModels/Sources/SharedModels/CfP/UserDTO.swift
+++ b/SharedModels/Sources/SharedModels/CfP/UserDTO.swift
@@ -1,94 +1,89 @@
 import Foundation
 
-// CfP types are iOS-only (not used in Android app)
-#if !SKIP
+/// Data Transfer Object for User profile
+public struct UserDTO: Codable, Sendable, Equatable, Identifiable {
+  public let id: UUID
+  public let githubID: Int
+  public let username: String
+  public let role: UserRole
+  /// User's display name
+  public let displayName: String?
+  /// User's email address
+  public let email: String?
+  /// User's bio/self-introduction
+  public let bio: String?
+  /// User's personal/portfolio URL
+  public let url: String?
+  /// User's organization/company
+  public let organization: String?
+  /// User's avatar/icon URL (from GitHub or custom)
+  public let avatarURL: String?
 
-  /// Data Transfer Object for User profile
-  public struct UserDTO: Codable, Sendable, Equatable, Identifiable {
-    public let id: UUID
-    public let githubID: Int
-    public let username: String
-    public let role: UserRole
-    /// User's display name
-    public let displayName: String?
-    /// User's email address
-    public let email: String?
-    /// User's bio/self-introduction
-    public let bio: String?
-    /// User's personal/portfolio URL
-    public let url: String?
-    /// User's organization/company
-    public let organization: String?
-    /// User's avatar/icon URL (from GitHub or custom)
-    public let avatarURL: String?
+  public let createdAt: Date?
+  public let updatedAt: Date?
 
-    public let createdAt: Date?
-    public let updatedAt: Date?
-
-    public init(
-      id: UUID,
-      githubID: Int,
-      username: String,
-      role: UserRole,
-      displayName: String? = nil,
-      email: String? = nil,
-      bio: String? = nil,
-      url: String? = nil,
-      organization: String? = nil,
-      avatarURL: String? = nil,
-      createdAt: Date? = nil,
-      updatedAt: Date? = nil
-    ) {
-      self.id = id
-      self.githubID = githubID
-      self.username = username
-      self.role = role
-      self.displayName = displayName
-      self.email = email
-      self.bio = bio
-      self.url = url
-      self.organization = organization
-      self.avatarURL = avatarURL
-      self.createdAt = createdAt
-      self.updatedAt = updatedAt
-    }
+  public init(
+    id: UUID,
+    githubID: Int,
+    username: String,
+    role: UserRole,
+    displayName: String? = nil,
+    email: String? = nil,
+    bio: String? = nil,
+    url: String? = nil,
+    organization: String? = nil,
+    avatarURL: String? = nil,
+    createdAt: Date? = nil,
+    updatedAt: Date? = nil
+  ) {
+    self.id = id
+    self.githubID = githubID
+    self.username = username
+    self.role = role
+    self.displayName = displayName
+    self.email = email
+    self.bio = bio
+    self.url = url
+    self.organization = organization
+    self.avatarURL = avatarURL
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
   }
+}
 
-  /// Request object for updating user profile
-  public struct UpdateUserProfileRequest: Codable, Sendable {
-    public let displayName: String?
-    public let email: String?
-    public let bio: String?
-    public let url: String?
-    public let organization: String?
-    public let avatarURL: String?
+/// Request object for updating user profile
+public struct UpdateUserProfileRequest: Codable, Sendable {
+  public let displayName: String?
+  public let email: String?
+  public let bio: String?
+  public let url: String?
+  public let organization: String?
+  public let avatarURL: String?
 
-    public init(
-      displayName: String? = nil,
-      email: String? = nil,
-      bio: String? = nil,
-      url: String? = nil,
-      organization: String? = nil,
-      avatarURL: String? = nil
-    ) {
-      self.displayName = displayName
-      self.email = email
-      self.bio = bio
-      self.url = url
-      self.organization = organization
-      self.avatarURL = avatarURL
-    }
+  public init(
+    displayName: String? = nil,
+    email: String? = nil,
+    bio: String? = nil,
+    url: String? = nil,
+    organization: String? = nil,
+    avatarURL: String? = nil
+  ) {
+    self.displayName = displayName
+    self.email = email
+    self.bio = bio
+    self.url = url
+    self.organization = organization
+    self.avatarURL = avatarURL
   }
+}
 
-  /// Auth response containing JWT token and user info
-  public struct AuthResponse: Codable, Sendable {
-    public let token: String
-    public let user: UserDTO
+/// Auth response containing JWT token and user info
+public struct AuthResponse: Codable, Sendable {
+  public let token: String
+  public let user: UserDTO
 
-    public init(token: String, user: UserDTO) {
-      self.token = token
-      self.user = user
-    }
+  public init(token: String, user: UserDTO) {
+    self.token = token
+    self.user = user
   }
-
-#endif
+}

--- a/SharedModels/Sources/SharedModels/CfP/UserRole.swift
+++ b/SharedModels/Sources/SharedModels/CfP/UserRole.swift
@@ -1,35 +1,30 @@
 import Foundation
 
-// CfP types are iOS-only (not used in Android app)
-#if !SKIP
+/// User role for the CfP system
+/// - admin: Organizer with full access (members of try-swift GitHub org)
+/// - invitedSpeaker: Invited speaker who can submit invited talks
+/// - speaker: Regular user who can submit proposals
+public enum UserRole: String, Codable, Sendable, Equatable, CaseIterable {
+  case admin
+  case invitedSpeaker
+  case speaker
 
-  /// User role for the CfP system
-  /// - admin: Organizer with full access (members of try-swift GitHub org)
-  /// - invitedSpeaker: Invited speaker who can submit invited talks
-  /// - speaker: Regular user who can submit proposals
-  public enum UserRole: String, Codable, Sendable, Equatable, CaseIterable {
-    case admin
-    case invitedSpeaker
-    case speaker
-
-    public var isAdmin: Bool {
-      self == .admin
-    }
-
-    public var isInvitedSpeaker: Bool {
-      self == .invitedSpeaker
-    }
-
-    public var displayName: String {
-      switch self {
-      case .admin:
-        return "Organizer"
-      case .invitedSpeaker:
-        return "Invited Speaker"
-      case .speaker:
-        return "Speaker"
-      }
-    }
+  public var isAdmin: Bool {
+    self == .admin
   }
 
-#endif
+  public var isInvitedSpeaker: Bool {
+    self == .invitedSpeaker
+  }
+
+  public var displayName: String {
+    switch self {
+    case .admin:
+      return "Organizer"
+    case .invitedSpeaker:
+      return "Invited Speaker"
+    case .speaker:
+      return "Speaker"
+    }
+  }
+}

--- a/SharedModels/Sources/SharedModels/CfPExports.swift
+++ b/SharedModels/Sources/SharedModels/CfPExports.swift
@@ -1,10 +1,2 @@
-// Re-export all CfP types from the SharedModels module
-// This file ensures all types in the CfP subfolder are accessible
-
-#if !SKIP
-  @_exported import struct Foundation.Date
-  @_exported import struct Foundation.UUID
-#endif
-
-// CfP types are automatically included as they are in the same module
-// This file exists to ensure the CfP folder is properly compiled as part of SharedModels
+@_exported import struct Foundation.Date
+@_exported import struct Foundation.UUID

--- a/SharedModels/Sources/SharedModels/Skip/skip.yml
+++ b/SharedModels/Sources/SharedModels/Skip/skip.yml
@@ -1,1 +1,0 @@
-# Skip configuration for SharedModels module


### PR DESCRIPTION
## Summary
- SharedModelsからSkip固有の依存関係(`skip`, `skip-foundation`)、`skipstone`プラグイン、`skip.yml`を除去
- CfPファイル4つから`#if !SKIP`ガードを除去し、`CfPExports.swift`を簡素化
- SharedModelsをプラットフォーム非依存な純粋Swiftパッケージに整理（Android側は自身のPackage.swiftでSkip依存を保持）

## Test plan
- [x] `swift build` でSharedModels単体ビルド成功
- [x] `swift test` で全27テスト合格

🤖 Generated with [Claude Code](https://claude.com/claude-code)