### PR TITLE
Fix CSRF token mismatch on form submissions

### DIFF
--- a/Server/Sources/Server/Middleware/CSRFMiddleware.swift
+++ b/Server/Sources/Server/Middleware/CSRFMiddleware.swift
@@ -19,6 +19,11 @@ struct CSRFMiddleware: AsyncMiddleware {
       let submittedToken = formToken ?? headerToken
 
       guard let submittedToken, submittedToken == cookieToken else {
+        let formPrefix = formToken.map { String($0.prefix(8)) } ?? "nil"
+        let headerPrefix = headerToken.map { String($0.prefix(8)) } ?? "nil"
+        request.logger.warning(
+          "CSRF mismatch: cookie=\(String(cookieToken.prefix(8)))… form=\(formPrefix) header=\(headerPrefix)"
+        )
         throw Abort(.forbidden, reason: "CSRF token mismatch")
       }
 


### PR DESCRIPTION
## Summary
- Changed CSRF token encoding from base64 to hex (`%02x`) to avoid `+`, `/`, `=` characters that get corrupted in URL-encoded form data
- Added auto-regeneration of legacy base64 CSRF cookies on GET requests so existing users get a safe token immediately
- Added debug logging on CSRF mismatch (logs token prefixes) to help diagnose any remaining 403 errors in production
- GitHub ID field moved inline into the edit form (removes separate card)

## Test plan
- [x] All 14 CSRFMiddleware tests pass (including new hex-safety, legacy migration, multi-field, and GET→POST flow tests)
- [ ] Verify in production: organizer edit proposal → change duration to "Invited" → click Update → no CSRF error

🤖 Generated with [Claude Code](https://claude.com/claude-code)