### PR TITLE
Fix timetable slot 400 error due to fractional seconds in ISO 8601

### DIFF
--- a/Server/Sources/Server/CfP/CfPRoutes.swift
+++ b/Server/Sources/Server/CfP/CfPRoutes.swift
@@ -1908,7 +1908,7 @@ struct CfPRoutes: RouteCollection {
     }
 
     let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime]
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
     guard let startTime = formatter.date(from: body.startTime) else {
       throw Abort(.badRequest, reason: "Invalid start time format")
     }
@@ -1998,7 +1998,7 @@ struct CfPRoutes: RouteCollection {
 
     let body = try req.content.decode(UpdateSlotRequest.self)
     let formatter = ISO8601DateFormatter()
-    formatter.formatOptions = [.withInternetDateTime]
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
 
     if let slotTypeStr = body.slotType {
       guard let slotType = SlotType(rawValue: slotTypeStr) else {


### PR DESCRIPTION
## Summary
- JavaScript's `Date.toISOString()` returns timestamps with milliseconds (e.g. `2026-04-08T01:00:00.000Z`), but Swift's `ISO8601DateFormatter` with `.withInternetDateTime` only parses timestamps **without** fractional seconds (e.g. `2026-04-08T01:00:00Z`)
- Added `.withFractionalSeconds` to the formatter options in both `createSlot` and `updateSlot` endpoints so the backend accepts the frontend's timestamp format

## Test plan
- [ ] Create a new timetable slot via the Timetable Editor UI — should succeed without 400 error
- [ ] Update an existing timetable slot — should succeed without 400 error

🤖 Generated with [Claude Code](https://claude.com/claude-code)