### PR TITLE
Add email notification feature for accepted/rejected speakers

### DIFF
--- a/Server/Sources/Server/CfP/CfPRoutes.swift
+++ b/Server/Sources/Server/CfP/CfPRoutes.swift
@@ -1310,11 +1310,12 @@ struct CfPRoutes: RouteCollection {
       throw Abort(.badRequest, reason: "Invalid proposal ID")
     }
 
-    guard let dbProposal = try await Proposal.query(on: req.db)
-      .filter(\.$id == proposalID)
-      .with(\.$speaker)
-      .with(\.$conference)
-      .first()
+    guard
+      let dbProposal = try await Proposal.query(on: req.db)
+        .filter(\.$id == proposalID)
+        .with(\.$speaker)
+        .with(\.$conference)
+        .first()
     else {
       throw Abort(.notFound, reason: "Proposal not found")
     }

--- a/Server/Sources/Server/CfP/EmailTemplates.swift
+++ b/Server/Sources/Server/CfP/EmailTemplates.swift
@@ -7,6 +7,16 @@ enum EmailType: String, CaseIterable, Sendable {
 /// Bilingual email templates for speaker notifications
 enum EmailTemplates {
 
+  /// Escape HTML special characters to prevent XSS
+  private static func escapeHTML(_ string: String) -> String {
+    string
+      .replacingOccurrences(of: "&", with: "&amp;")
+      .replacingOccurrences(of: "<", with: "&lt;")
+      .replacingOccurrences(of: ">", with: "&gt;")
+      .replacingOccurrences(of: "\"", with: "&quot;")
+      .replacingOccurrences(of: "'", with: "&#39;")
+  }
+
   // MARK: - Acceptance Email
 
   enum Acceptance {
@@ -18,13 +28,15 @@ enum EmailTemplates {
     }
 
     static func body(_ lang: CfPLanguage, speakerName: String, proposalTitle: String) -> String {
+      let name = escapeHTML(speakerName)
+      let title = escapeHTML(proposalTitle)
       switch lang {
       case .en:
         return """
           <html><body style="font-family: sans-serif; line-height: 1.6; color: #333;">
-          <p>Dear \(speakerName),</p>
+          <p>Dear \(name),</p>
           <p>Congratulations! We are thrilled to inform you that your proposal \
-          &ldquo;<strong>\(proposalTitle)</strong>&rdquo; has been accepted \
+          &ldquo;<strong>\(title)</strong>&rdquo; has been accepted \
           for try! Swift Tokyo 2026!</p>
           <p>We will follow up with more details about the schedule, speaker benefits, \
           and logistics soon.</p>
@@ -35,8 +47,8 @@ enum EmailTemplates {
       case .ja:
         return """
           <html><body style="font-family: sans-serif; line-height: 1.6; color: #333;">
-          <p>\(speakerName) 様</p>
-          <p>おめでとうございます！「<strong>\(proposalTitle)</strong>」が \
+          <p>\(name) 様</p>
+          <p>おめでとうございます！「<strong>\(title)</strong>」が \
           try! Swift Tokyo 2026 に採択されましたことをお知らせいたします！</p>
           <p>スケジュール、スピーカー特典、ロジスティクスの詳細については、\
           後日改めてご連絡いたします。</p>
@@ -59,12 +71,14 @@ enum EmailTemplates {
     }
 
     static func body(_ lang: CfPLanguage, speakerName: String, proposalTitle: String) -> String {
+      let name = escapeHTML(speakerName)
+      let title = escapeHTML(proposalTitle)
       switch lang {
       case .en:
         return """
           <html><body style="font-family: sans-serif; line-height: 1.6; color: #333;">
-          <p>Dear \(speakerName),</p>
-          <p>Thank you for submitting your proposal &ldquo;<strong>\(proposalTitle)</strong>&rdquo; \
+          <p>Dear \(name),</p>
+          <p>Thank you for submitting your proposal &ldquo;<strong>\(title)</strong>&rdquo; \
           to try! Swift Tokyo 2026.</p>
           <p>After careful review by our selection committee, we regret to inform you \
           that your proposal was not selected for this year&rsquo;s conference.</p>
@@ -77,8 +91,8 @@ enum EmailTemplates {
       case .ja:
         return """
           <html><body style="font-family: sans-serif; line-height: 1.6; color: #333;">
-          <p>\(speakerName) 様</p>
-          <p>try! Swift Tokyo 2026 へのプロポーザル「<strong>\(proposalTitle)</strong>」の\
+          <p>\(name) 様</p>
+          <p>try! Swift Tokyo 2026 へのプロポーザル「<strong>\(title)</strong>」の\
           ご応募ありがとうございました。</p>
           <p>選考委員会による慎重な審査の結果、誠に残念ながら今回は採択に至らなかったことを\
           お知らせいたします。</p>

--- a/Server/Sources/Server/CfP/EmailTemplates.swift
+++ b/Server/Sources/Server/CfP/EmailTemplates.swift
@@ -1,0 +1,116 @@
+/// Email type for speaker notifications
+enum EmailType: String, CaseIterable, Sendable {
+  case acceptance
+  case rejection
+}
+
+/// Bilingual email templates for speaker notifications
+enum EmailTemplates {
+
+  // MARK: - Acceptance Email
+
+  enum Acceptance {
+    static func subject(_ lang: CfPLanguage) -> String {
+      switch lang {
+      case .en: return "[try! Swift Tokyo 2026] Your Proposal Has Been Accepted!"
+      case .ja: return "[try! Swift Tokyo 2026] プロポーザルが採択されました！"
+      }
+    }
+
+    static func body(_ lang: CfPLanguage, speakerName: String, proposalTitle: String) -> String {
+      switch lang {
+      case .en:
+        return """
+          <html><body style="font-family: sans-serif; line-height: 1.6; color: #333;">
+          <p>Dear \(speakerName),</p>
+          <p>Congratulations! We are thrilled to inform you that your proposal \
+          &ldquo;<strong>\(proposalTitle)</strong>&rdquo; has been accepted \
+          for try! Swift Tokyo 2026!</p>
+          <p>We will follow up with more details about the schedule, speaker benefits, \
+          and logistics soon.</p>
+          <p>Thank you for your contribution to the Swift community!</p>
+          <p>Best regards,<br>try! Swift Tokyo Organizing Team</p>
+          </body></html>
+          """
+      case .ja:
+        return """
+          <html><body style="font-family: sans-serif; line-height: 1.6; color: #333;">
+          <p>\(speakerName) 様</p>
+          <p>おめでとうございます！「<strong>\(proposalTitle)</strong>」が \
+          try! Swift Tokyo 2026 に採択されましたことをお知らせいたします！</p>
+          <p>スケジュール、スピーカー特典、ロジスティクスの詳細については、\
+          後日改めてご連絡いたします。</p>
+          <p>Swift コミュニティへのご貢献に感謝いたします！</p>
+          <p>try! Swift Tokyo 運営チーム</p>
+          </body></html>
+          """
+      }
+    }
+  }
+
+  // MARK: - Rejection Email
+
+  enum Rejection {
+    static func subject(_ lang: CfPLanguage) -> String {
+      switch lang {
+      case .en: return "[try! Swift Tokyo 2026] CfP Review Result"
+      case .ja: return "[try! Swift Tokyo 2026] CfP 選考結果のお知らせ"
+      }
+    }
+
+    static func body(_ lang: CfPLanguage, speakerName: String, proposalTitle: String) -> String {
+      switch lang {
+      case .en:
+        return """
+          <html><body style="font-family: sans-serif; line-height: 1.6; color: #333;">
+          <p>Dear \(speakerName),</p>
+          <p>Thank you for submitting your proposal &ldquo;<strong>\(proposalTitle)</strong>&rdquo; \
+          to try! Swift Tokyo 2026.</p>
+          <p>After careful review by our selection committee, we regret to inform you \
+          that your proposal was not selected for this year&rsquo;s conference.</p>
+          <p>We received many outstanding proposals and the selection was extremely competitive. \
+          We encourage you to apply again for future events.</p>
+          <p>We hope to see you at the conference!</p>
+          <p>Best regards,<br>try! Swift Tokyo Organizing Team</p>
+          </body></html>
+          """
+      case .ja:
+        return """
+          <html><body style="font-family: sans-serif; line-height: 1.6; color: #333;">
+          <p>\(speakerName) 様</p>
+          <p>try! Swift Tokyo 2026 へのプロポーザル「<strong>\(proposalTitle)</strong>」の\
+          ご応募ありがとうございました。</p>
+          <p>選考委員会による慎重な審査の結果、誠に残念ながら今回は採択に至らなかったことを\
+          お知らせいたします。</p>
+          <p>多数の素晴らしいプロポーザルをいただき、大変競争の激しい選考となりました。\
+          今後のイベントへのご応募をお待ちしております。</p>
+          <p>カンファレンスでお会いできることを楽しみにしております！</p>
+          <p>try! Swift Tokyo 運営チーム</p>
+          </body></html>
+          """
+      }
+    }
+  }
+
+  // MARK: - Preview Helper
+
+  static func preview(
+    type: EmailType,
+    language: CfPLanguage,
+    speakerName: String = "Speaker Name",
+    proposalTitle: String = "Proposal Title"
+  ) -> (subject: String, body: String) {
+    switch type {
+    case .acceptance:
+      return (
+        Acceptance.subject(language),
+        Acceptance.body(language, speakerName: speakerName, proposalTitle: proposalTitle)
+      )
+    case .rejection:
+      return (
+        Rejection.subject(language),
+        Rejection.body(language, speakerName: speakerName, proposalTitle: proposalTitle)
+      )
+    }
+  }
+}

--- a/Server/Sources/Server/CfP/Pages/OrganizerEmailPreviewPage.swift
+++ b/Server/Sources/Server/CfP/Pages/OrganizerEmailPreviewPage.swift
@@ -1,0 +1,207 @@
+import Elementary
+import Foundation
+import SharedModels
+
+struct OrganizerEmailPreviewPageView: HTML, Sendable {
+  let user: UserDTO?
+  let proposal: ProposalDTO?
+  let emailType: EmailType
+  let language: CfPLanguage
+  let previewSubject: String
+  let previewBody: String
+  let sendResult: EmailNotifier.SendResult?
+  let csrfToken: String
+
+  var body: some HTML {
+    div(.class("container py-5")) {
+      if let user, user.role == .admin {
+        if let proposal {
+          renderHeader(proposal)
+          renderLanguageSelector(proposal)
+
+          if let sendResult {
+            renderResult(sendResult)
+          }
+
+          renderPreview()
+          renderSendForm(proposal)
+        } else {
+          renderNotFound()
+        }
+      } else {
+        renderAccessDenied()
+      }
+    }
+  }
+
+  // MARK: - Header
+
+  @HTMLBuilder
+  private func renderHeader(_ proposal: ProposalDTO) -> some HTML {
+    div(.class("mb-4")) {
+      a(
+        .class("btn btn-outline-secondary"),
+        .href("/organizer/proposals/\(proposal.id.uuidString)")
+      ) {
+        "← Back to Proposal"
+      }
+    }
+
+    div(.class("mb-4")) {
+      h1(.class("fw-bold mb-2")) { "Send Email" }
+      p(.class("lead text-muted mb-0")) {
+        HTMLText("To: \(proposal.speakerName) (\(proposal.speakerEmail))")
+      }
+    }
+  }
+
+  // MARK: - Language Selector
+
+  @HTMLBuilder
+  private func renderLanguageSelector(_ proposal: ProposalDTO) -> some HTML {
+    div(.class("card mb-4")) {
+      div(.class("card-body")) {
+        form(.method(.get), .action("/organizer/proposals/\(proposal.id.uuidString)/email")) {
+          input(.type(.hidden), .name("type"), .value(emailType.rawValue))
+          div(.class("row g-3 align-items-end")) {
+            div(.class("col-md-5")) {
+              label(.class("form-label fw-semibold"), .for("emailLang")) { "Language" }
+              select(.class("form-select"), .name("lang"), .id("emailLang")) {
+                option(.value("en"), language == .en ? .selected : .class("")) { "English" }
+                option(.value("ja"), language == .ja ? .selected : .class("")) { "日本語" }
+              }
+            }
+            div(.class("col-md-5")) {
+              label(.class("form-label fw-semibold"), .for("emailType")) { "Email Type" }
+              select(.class("form-select"), .name("type"), .id("emailType")) {
+                option(
+                  .value("acceptance"),
+                  emailType == .acceptance ? .selected : .class("")
+                ) { "Acceptance" }
+                option(
+                  .value("rejection"),
+                  emailType == .rejection ? .selected : .class("")
+                ) { "Rejection" }
+              }
+            }
+            div(.class("col-md-2")) {
+              button(.type(.submit), .class("btn btn-primary w-100")) {
+                "Preview"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Preview
+
+  @HTMLBuilder
+  private func renderPreview() -> some HTML {
+    div(.class("card mb-4")) {
+      div(.class("card-header")) {
+        strong { "Email Preview" }
+      }
+      div(.class("card-body")) {
+        div(.class("mb-3")) {
+          label(.class("form-label fw-semibold")) { "Subject:" }
+          div(.class("form-control-plaintext border rounded px-3 py-2 bg-light")) {
+            HTMLText(previewSubject)
+          }
+        }
+        div {
+          label(.class("form-label fw-semibold")) { "Body:" }
+          div(
+            .class("border rounded p-3 bg-light"),
+            .style("max-height: 400px; overflow-y: auto;")
+          ) {
+            HTMLRaw(previewBody)
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Send Form
+
+  @HTMLBuilder
+  private func renderSendForm(_ proposal: ProposalDTO) -> some HTML {
+    div(.class("d-flex gap-2")) {
+      HTMLRaw(
+        """
+        <form method="post" \
+        action="/organizer/proposals/\(proposal.id.uuidString)/email/send" \
+        onsubmit="return confirm('Send this email to \(proposal.speakerEmail)?');">
+          <input type="hidden" name="_csrf" value="\(csrfToken)">
+          <input type="hidden" name="emailType" value="\(emailType.rawValue)">
+          <input type="hidden" name="lang" value="\(language.rawValue)">
+          <button type="submit" class="btn btn-success btn-lg">Send Email</button>
+        </form>
+        """)
+      a(
+        .class("btn btn-outline-secondary btn-lg"),
+        .href("/organizer/proposals/\(proposal.id.uuidString)")
+      ) {
+        "Cancel"
+      }
+    }
+  }
+
+  // MARK: - Result
+
+  @HTMLBuilder
+  private func renderResult(_ result: EmailNotifier.SendResult) -> some HTML {
+    if result.success {
+      div(.class("alert alert-success alert-dismissible fade show mb-4")) {
+        strong { "Email sent successfully " }
+        HTMLText("to \(result.recipientEmail)")
+        HTMLRaw(
+          """
+          <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+          """)
+      }
+    } else {
+      div(.class("alert alert-danger alert-dismissible fade show mb-4")) {
+        strong { "Failed to send email: " }
+        HTMLText(result.error ?? "Unknown error")
+        HTMLRaw(
+          """
+          <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+          """)
+      }
+    }
+  }
+
+  // MARK: - Not Found
+
+  @HTMLBuilder
+  private func renderNotFound() -> some HTML {
+    div(.class("card")) {
+      div(.class("card-body text-center p-5")) {
+        h3(.class("fw-bold mb-2")) { "Proposal Not Found" }
+        p(.class("text-muted mb-4")) {
+          "The proposal you are looking for does not exist."
+        }
+        a(.class("btn btn-primary"), .href("/organizer/proposals")) {
+          "Back to All Proposals"
+        }
+      }
+    }
+  }
+
+  // MARK: - Access Denied
+
+  @HTMLBuilder
+  private func renderAccessDenied() -> some HTML {
+    div(.class("card")) {
+      div(.class("card-body text-center p-5")) {
+        h3(.class("fw-bold mb-2")) { "Access Denied" }
+        p(.class("text-muted mb-4")) {
+          "You need organizer permissions to view this page."
+        }
+        a(.class("btn btn-primary"), .href("/")) { "Return to Home" }
+      }
+    }
+  }
+}

--- a/Server/Sources/Server/CfP/Pages/OrganizerEmailPreviewPage.swift
+++ b/Server/Sources/Server/CfP/Pages/OrganizerEmailPreviewPage.swift
@@ -62,26 +62,35 @@ struct OrganizerEmailPreviewPageView: HTML, Sendable {
     div(.class("card mb-4")) {
       div(.class("card-body")) {
         form(.method(.get), .action("/organizer/proposals/\(proposal.id.uuidString)/email")) {
-          input(.type(.hidden), .name("type"), .value(emailType.rawValue))
           div(.class("row g-3 align-items-end")) {
             div(.class("col-md-5")) {
               label(.class("form-label fw-semibold"), .for("emailLang")) { "Language" }
               select(.class("form-select"), .name("lang"), .id("emailLang")) {
-                option(.value("en"), language == .en ? .selected : .class("")) { "English" }
-                option(.value("ja"), language == .ja ? .selected : .class("")) { "日本語" }
+                if language == .en {
+                  option(.value("en"), .selected) { "English" }
+                } else {
+                  option(.value("en")) { "English" }
+                }
+                if language == .ja {
+                  option(.value("ja"), .selected) { "日本語" }
+                } else {
+                  option(.value("ja")) { "日本語" }
+                }
               }
             }
             div(.class("col-md-5")) {
               label(.class("form-label fw-semibold"), .for("emailType")) { "Email Type" }
               select(.class("form-select"), .name("type"), .id("emailType")) {
-                option(
-                  .value("acceptance"),
-                  emailType == .acceptance ? .selected : .class("")
-                ) { "Acceptance" }
-                option(
-                  .value("rejection"),
-                  emailType == .rejection ? .selected : .class("")
-                ) { "Rejection" }
+                if emailType == .acceptance {
+                  option(.value("acceptance"), .selected) { "Acceptance" }
+                } else {
+                  option(.value("acceptance")) { "Acceptance" }
+                }
+                if emailType == .rejection {
+                  option(.value("rejection"), .selected) { "Rejection" }
+                } else {
+                  option(.value("rejection")) { "Rejection" }
+                }
               }
             }
             div(.class("col-md-2")) {
@@ -134,7 +143,6 @@ struct OrganizerEmailPreviewPageView: HTML, Sendable {
         action="/organizer/proposals/\(proposal.id.uuidString)/email/send" \
         onsubmit="return confirm('Send this email to \(proposal.speakerEmail)?');">
           <input type="hidden" name="_csrf" value="\(csrfToken)">
-          <input type="hidden" name="emailType" value="\(emailType.rawValue)">
           <input type="hidden" name="lang" value="\(language.rawValue)">
           <button type="submit" class="btn btn-success btn-lg">Send Email</button>
         </form>

--- a/Server/Sources/Server/CfP/Pages/OrganizerEmailsPage.swift
+++ b/Server/Sources/Server/CfP/Pages/OrganizerEmailsPage.swift
@@ -1,0 +1,269 @@
+import Elementary
+import Foundation
+import SharedModels
+
+struct OrganizerEmailsPageView: HTML, Sendable {
+  let user: UserDTO?
+  let proposals: [ProposalDTO]
+  let statusFilter: String
+  let language: CfPLanguage
+  let emailType: EmailType
+  let previewSubject: String
+  let previewBody: String
+  let sendResults: [EmailNotifier.SendResult]?
+  let csrfToken: String
+
+  var body: some HTML {
+    div(.class("container py-5")) {
+      if let user, user.role == .admin {
+        renderHeader()
+        renderFilterForm()
+        renderPreview()
+        renderRecipientList()
+
+        if let sendResults {
+          renderResults(sendResults)
+        }
+      } else {
+        renderAccessDenied()
+      }
+    }
+  }
+
+  // MARK: - Header
+
+  @HTMLBuilder
+  private func renderHeader() -> some HTML {
+    div(.class("mb-4")) {
+      a(.class("btn btn-outline-secondary"), .href("/organizer/proposals")) {
+        "← Back to All Proposals"
+      }
+    }
+
+    div(.class("mb-4")) {
+      h1(.class("fw-bold mb-2")) { "Email Notifications" }
+      p(.class("lead text-muted mb-0")) {
+        "Send acceptance or rejection emails to speakers."
+      }
+    }
+  }
+
+  // MARK: - Filter Form
+
+  @HTMLBuilder
+  private func renderFilterForm() -> some HTML {
+    div(.class("card mb-4")) {
+      div(.class("card-header")) {
+        strong { "Filter & Template" }
+      }
+      div(.class("card-body")) {
+        form(.method(.get), .action("/organizer/emails")) {
+          div(.class("row g-3 align-items-end")) {
+            div(.class("col-md-4")) {
+              label(.class("form-label fw-semibold"), .for("statusFilter")) { "Status" }
+              select(.class("form-select"), .name("status"), .id("statusFilter")) {
+                option(
+                  .value("accepted"),
+                  statusFilter == "accepted" ? .selected : .class("")
+                ) { "Accepted" }
+                option(
+                  .value("rejected"),
+                  statusFilter == "rejected" ? .selected : .class("")
+                ) { "Rejected" }
+              }
+            }
+            div(.class("col-md-4")) {
+              label(.class("form-label fw-semibold"), .for("langFilter")) { "Language" }
+              select(.class("form-select"), .name("lang"), .id("langFilter")) {
+                option(
+                  .value("en"),
+                  language == .en ? .selected : .class("")
+                ) { "English" }
+                option(
+                  .value("ja"),
+                  language == .ja ? .selected : .class("")
+                ) { "日本語" }
+              }
+            }
+            div(.class("col-md-4")) {
+              button(.type(.submit), .class("btn btn-primary w-100")) {
+                "Update Preview"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Preview
+
+  @HTMLBuilder
+  private func renderPreview() -> some HTML {
+    div(.class("card mb-4")) {
+      div(.class("card-header")) {
+        strong { "Email Preview" }
+      }
+      div(.class("card-body")) {
+        div(.class("mb-3")) {
+          label(.class("form-label fw-semibold")) { "Subject:" }
+          div(.class("form-control-plaintext border rounded px-3 py-2 bg-light")) {
+            HTMLText(previewSubject)
+          }
+        }
+        div {
+          label(.class("form-label fw-semibold")) { "Body:" }
+          div(
+            .class("border rounded p-3 bg-light"),
+            .style("max-height: 400px; overflow-y: auto;")
+          ) {
+            HTMLRaw(previewBody)
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Recipient List
+
+  @HTMLBuilder
+  private func renderRecipientList() -> some HTML {
+    div(.class("card mb-4")) {
+      div(.class("card-header d-flex justify-content-between align-items-center")) {
+        strong {
+          "Recipients (\(proposals.count))"
+        }
+        if !proposals.isEmpty {
+          HTMLRaw(
+            """
+            <form method="post" action="/organizer/emails/send" \
+            onsubmit="return confirm('Are you sure you want to send \(proposals.count) email(s)?');">
+              <input type="hidden" name="_csrf" value="\(csrfToken)">
+              <input type="hidden" name="status" value="\(statusFilter)">
+              <input type="hidden" name="lang" value="\(language.rawValue)">
+              <input type="hidden" name="emailType" value="\(emailType.rawValue)">
+              <button type="submit" class="btn btn-success">
+                Send to All \(proposals.count) Recipients
+              </button>
+            </form>
+            """)
+        }
+      }
+
+      if proposals.isEmpty {
+        div(.class("card-body text-center p-4")) {
+          p(.class("text-muted mb-0")) {
+            "No proposals with this status."
+          }
+        }
+      } else {
+        div(.class("table-responsive")) {
+          table(.class("table table-hover mb-0")) {
+            thead(.class("table-light")) {
+              tr {
+                th(.style("width: 5%")) { "#" }
+                th(.style("width: 25%")) { "Speaker Name" }
+                th(.style("width: 30%")) { "Email" }
+                th(.style("width: 40%")) { "Proposal Title" }
+              }
+            }
+            tbody {
+              for (index, proposal) in proposals.enumerated() {
+                tr {
+                  td(.class("align-middle")) { HTMLText("\(index + 1)") }
+                  td(.class("align-middle")) { HTMLText(proposal.speakerName) }
+                  td(.class("align-middle")) {
+                    HTMLText(proposal.speakerEmail)
+                  }
+                  td(.class("align-middle")) { HTMLText(proposal.title) }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Results
+
+  @HTMLBuilder
+  private func renderResults(_ results: [EmailNotifier.SendResult]) -> some HTML {
+    let successCount = results.filter(\.success).count
+    let failedCount = results.count - successCount
+
+    div(.class("card mb-4")) {
+      div(.class("card-header")) {
+        strong { "Send Results" }
+      }
+      div(.class("card-body")) {
+        div(.class("row mb-3")) {
+          div(.class("col-md-4")) {
+            div(.class("card bg-success text-white")) {
+              div(.class("card-body")) {
+                h4(.class("mb-0")) { HTMLText("\(successCount)") }
+                p(.class("mb-0")) { "Sent" }
+              }
+            }
+          }
+          div(.class("col-md-4")) {
+            div(.class("card bg-danger text-white")) {
+              div(.class("card-body")) {
+                h4(.class("mb-0")) { HTMLText("\(failedCount)") }
+                p(.class("mb-0")) { "Failed" }
+              }
+            }
+          }
+          div(.class("col-md-4")) {
+            div(.class("card bg-primary text-white")) {
+              div(.class("card-body")) {
+                h4(.class("mb-0")) { HTMLText("\(results.count)") }
+                p(.class("mb-0")) { "Total" }
+              }
+            }
+          }
+        }
+
+        if failedCount > 0 {
+          div(.class("table-responsive")) {
+            table(.class("table table-sm")) {
+              thead(.class("table-light")) {
+                tr {
+                  th { "Email" }
+                  th { "Status" }
+                  th { "Error" }
+                }
+              }
+              tbody {
+                for result in results where !result.success {
+                  tr {
+                    td { HTMLText(result.recipientEmail) }
+                    td {
+                      span(.class("badge bg-danger")) { "Failed" }
+                    }
+                    td { HTMLText(result.error ?? "Unknown error") }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // MARK: - Access Denied
+
+  @HTMLBuilder
+  private func renderAccessDenied() -> some HTML {
+    div(.class("card")) {
+      div(.class("card-body text-center p-5")) {
+        h3(.class("fw-bold mb-2")) { "Access Denied" }
+        p(.class("text-muted mb-4")) {
+          "You need organizer permissions to view this page."
+        }
+        a(.class("btn btn-primary"), .href("/")) { "Return to Home" }
+      }
+    }
+  }
+}

--- a/Server/Sources/Server/CfP/Pages/OrganizerEmailsPage.swift
+++ b/Server/Sources/Server/CfP/Pages/OrganizerEmailsPage.swift
@@ -7,7 +7,6 @@ struct OrganizerEmailsPageView: HTML, Sendable {
   let proposals: [ProposalDTO]
   let statusFilter: String
   let language: CfPLanguage
-  let emailType: EmailType
   let previewSubject: String
   let previewBody: String
   let sendResults: [EmailNotifier.SendResult]?
@@ -62,27 +61,31 @@ struct OrganizerEmailsPageView: HTML, Sendable {
             div(.class("col-md-4")) {
               label(.class("form-label fw-semibold"), .for("statusFilter")) { "Status" }
               select(.class("form-select"), .name("status"), .id("statusFilter")) {
-                option(
-                  .value("accepted"),
-                  statusFilter == "accepted" ? .selected : .class("")
-                ) { "Accepted" }
-                option(
-                  .value("rejected"),
-                  statusFilter == "rejected" ? .selected : .class("")
-                ) { "Rejected" }
+                if statusFilter == "accepted" {
+                  option(.value("accepted"), .selected) { "Accepted" }
+                } else {
+                  option(.value("accepted")) { "Accepted" }
+                }
+                if statusFilter == "rejected" {
+                  option(.value("rejected"), .selected) { "Rejected" }
+                } else {
+                  option(.value("rejected")) { "Rejected" }
+                }
               }
             }
             div(.class("col-md-4")) {
               label(.class("form-label fw-semibold"), .for("langFilter")) { "Language" }
               select(.class("form-select"), .name("lang"), .id("langFilter")) {
-                option(
-                  .value("en"),
-                  language == .en ? .selected : .class("")
-                ) { "English" }
-                option(
-                  .value("ja"),
-                  language == .ja ? .selected : .class("")
-                ) { "日本語" }
+                if language == .en {
+                  option(.value("en"), .selected) { "English" }
+                } else {
+                  option(.value("en")) { "English" }
+                }
+                if language == .ja {
+                  option(.value("ja"), .selected) { "日本語" }
+                } else {
+                  option(.value("ja")) { "日本語" }
+                }
               }
             }
             div(.class("col-md-4")) {
@@ -141,7 +144,6 @@ struct OrganizerEmailsPageView: HTML, Sendable {
               <input type="hidden" name="_csrf" value="\(csrfToken)">
               <input type="hidden" name="status" value="\(statusFilter)">
               <input type="hidden" name="lang" value="\(language.rawValue)">
-              <input type="hidden" name="emailType" value="\(emailType.rawValue)">
               <button type="submit" class="btn btn-success">
                 Send to All \(proposals.count) Recipients
               </button>

--- a/Server/Sources/Server/CfP/Pages/OrganizerProposalDetailPage.swift
+++ b/Server/Sources/Server/CfP/Pages/OrganizerProposalDetailPage.swift
@@ -70,6 +70,17 @@ struct OrganizerProposalDetailPageView: HTML, Sendable {
                   </form>
                   """)
               }
+              // Send Email button
+              if proposal.status == .accepted || proposal.status == .rejected {
+                a(
+                  .class("btn btn-outline-info"),
+                  .href(
+                    "/organizer/proposals/\(proposal.id.uuidString)/email?type=\(proposal.status == .accepted ? "acceptance" : "rejection")"
+                  )
+                ) {
+                  "Send Email"
+                }
+              }
               // Edit button
               a(
                 .class("btn btn-outline-primary"),

--- a/Server/Sources/Server/CfP/Pages/OrganizerProposalsPage.swift
+++ b/Server/Sources/Server/CfP/Pages/OrganizerProposalsPage.swift
@@ -58,6 +58,13 @@ struct OrganizerProposalsPageView: HTML, Sendable {
             + Add Proposal
           </button>
           """)
+        // Send Emails button
+        a(
+          .class("btn btn-outline-info"),
+          .href("/organizer/emails")
+        ) {
+          "Send Emails"
+        }
         // Import button
         a(
           .class("btn btn-outline-primary"),

--- a/Server/Sources/Server/Services/EmailNotifier.swift
+++ b/Server/Sources/Server/Services/EmailNotifier.swift
@@ -91,7 +91,8 @@ enum EmailNotifier {
   ) async -> SendResult {
     guard let apiKey = Environment.get("EMAIL_API_KEY") else {
       logger.debug("EMAIL_API_KEY not configured, skipping email")
-      return SendResult(success: false, recipientEmail: email, error: "EMAIL_API_KEY not configured")
+      return SendResult(
+        success: false, recipientEmail: email, error: "EMAIL_API_KEY not configured")
     }
     guard let fromAddress = Environment.get("EMAIL_FROM_ADDRESS") else {
       logger.debug("EMAIL_FROM_ADDRESS not configured, skipping email")

--- a/Server/Sources/Server/Services/EmailNotifier.swift
+++ b/Server/Sources/Server/Services/EmailNotifier.swift
@@ -1,0 +1,145 @@
+import Vapor
+
+/// Service for sending emails via an HTTP email API (e.g. Resend)
+enum EmailNotifier {
+
+  /// Result of an email send attempt
+  struct SendResult: Sendable {
+    let success: Bool
+    let recipientEmail: String
+    let error: String?
+  }
+
+  /// Send an acceptance email to a speaker
+  static func sendAcceptanceEmail(
+    speakerName: String,
+    speakerEmail: String,
+    proposalTitle: String,
+    language: CfPLanguage,
+    client: Client,
+    logger: Logger
+  ) async -> SendResult {
+    let subject = EmailTemplates.Acceptance.subject(language)
+    let html = EmailTemplates.Acceptance.body(
+      language, speakerName: speakerName, proposalTitle: proposalTitle)
+    return await sendEmail(
+      to: speakerEmail, subject: subject, html: html, client: client, logger: logger)
+  }
+
+  /// Send a rejection email to a speaker
+  static func sendRejectionEmail(
+    speakerName: String,
+    speakerEmail: String,
+    proposalTitle: String,
+    language: CfPLanguage,
+    client: Client,
+    logger: Logger
+  ) async -> SendResult {
+    let subject = EmailTemplates.Rejection.subject(language)
+    let html = EmailTemplates.Rejection.body(
+      language, speakerName: speakerName, proposalTitle: proposalTitle)
+    return await sendEmail(
+      to: speakerEmail, subject: subject, html: html, client: client, logger: logger)
+  }
+
+  /// Send bulk emails to proposals matching a given type
+  static func sendBulkEmails(
+    proposals: [(speakerName: String, speakerEmail: String, proposalTitle: String)],
+    emailType: EmailType,
+    language: CfPLanguage,
+    client: Client,
+    logger: Logger
+  ) async -> [SendResult] {
+    var results: [SendResult] = []
+    for proposal in proposals {
+      let result: SendResult
+      switch emailType {
+      case .acceptance:
+        result = await sendAcceptanceEmail(
+          speakerName: proposal.speakerName,
+          speakerEmail: proposal.speakerEmail,
+          proposalTitle: proposal.proposalTitle,
+          language: language,
+          client: client,
+          logger: logger
+        )
+      case .rejection:
+        result = await sendRejectionEmail(
+          speakerName: proposal.speakerName,
+          speakerEmail: proposal.speakerEmail,
+          proposalTitle: proposal.proposalTitle,
+          language: language,
+          client: client,
+          logger: logger
+        )
+      }
+      results.append(result)
+      // Small delay between sends to avoid rate limiting
+      try? await Task.sleep(for: .milliseconds(100))
+    }
+    return results
+  }
+
+  // MARK: - Private
+
+  private static func sendEmail(
+    to email: String,
+    subject: String,
+    html: String,
+    client: Client,
+    logger: Logger
+  ) async -> SendResult {
+    guard let apiKey = Environment.get("EMAIL_API_KEY") else {
+      logger.debug("EMAIL_API_KEY not configured, skipping email")
+      return SendResult(success: false, recipientEmail: email, error: "EMAIL_API_KEY not configured")
+    }
+    guard let fromAddress = Environment.get("EMAIL_FROM_ADDRESS") else {
+      logger.debug("EMAIL_FROM_ADDRESS not configured, skipping email")
+      return SendResult(
+        success: false, recipientEmail: email, error: "EMAIL_FROM_ADDRESS not configured")
+    }
+
+    let apiURL = Environment.get("EMAIL_API_URL") ?? "https://api.resend.com/emails"
+
+    let payload = EmailRequest(
+      from: "try! Swift Tokyo <\(fromAddress)>",
+      to: [email],
+      subject: subject,
+      html: html
+    )
+
+    do {
+      let jsonData = try JSONEncoder().encode(payload)
+
+      let response = try await client.post(URI(string: apiURL)) { req in
+        req.headers.contentType = .json
+        req.headers.bearerAuthorization = BearerAuthorization(token: apiKey)
+        req.body = ByteBuffer(data: jsonData)
+      }
+
+      if response.status == .ok || response.status == .created {
+        logger.info("Email sent to \(email): \(subject)")
+        return SendResult(success: true, recipientEmail: email, error: nil)
+      } else {
+        let bodyStr = response.body.map { String(buffer: $0) } ?? "no body"
+        logger.warning("Email API responded \(response.status.code) for \(email): \(bodyStr)")
+        return SendResult(
+          success: false, recipientEmail: email,
+          error: "API returned \(response.status.code)")
+      }
+    } catch {
+      logger.warning("Failed to send email to \(email): \(error)")
+      return SendResult(
+        success: false, recipientEmail: email, error: error.localizedDescription)
+    }
+  }
+}
+
+// MARK: - API Request Model
+
+private struct EmailRequest: Encodable {
+  let from: String
+  let to: [String]
+  let subject: String
+  let html: String
+}


### PR DESCRIPTION
## Summary

- Organizer が採択・非採択スピーカーにメール通知を送信できる機能を追加
- 日本語・英語のメールテンプレートを用意し、スピーカー名・プロポーザルタイトルを自動埋め込み
- 個別送信（プロポーザル詳細画面 → Send Email）と一括送信（`/organizer/emails`）の両方に対応
- Resend API ベースの HTTP メール送信（Vapor の `Client` を使用、追加依存なし）

## Changes

- **`EmailTemplates.swift`** (新規): 採択/非採択の件名・本文テンプレート（EN/JA）
- **`EmailNotifier.swift`** (新規): メール送信サービス（`SlackNotifier` と同パターン）
- **`OrganizerEmailsPage.swift`** (新規): 一括メール送信ページ（ステータス/言語フィルタ、プレビュー、送信結果表示）
- **`OrganizerEmailPreviewPage.swift`** (新規): 個別メールプレビュー・送信ページ
- **`CfPRoutes.swift`** (修正): 4ルート + 4ハンドラ追加
- **`OrganizerProposalDetailPage.swift`** (修正): 「Send Email」ボタン追加
- **`OrganizerProposalsPage.swift`** (修正): 「Send Emails」ボタン追加

## 必要な環境変数

| 変数 | 説明 | 例 |
|---|---|---|
| `EMAIL_API_KEY` | メールサービス API キー | `re_xxxxxxxxxxxx` |
| `EMAIL_FROM_ADDRESS` | 送信元アドレス | `cfp@tryswift.jp` |
| `EMAIL_API_URL` | (任意) API エンドポイント | デフォルト: Resend API |

## Test plan

- [ ] `EMAIL_API_KEY` 未設定時にエラーメッセージが正しく表示されること
- [ ] `/organizer/emails` で Accepted/Rejected フィルタと EN/JA 言語切り替えが動作すること
- [ ] テンプレートプレビューにスピーカー名・タイトルが正しく埋め込まれること
- [ ] プロポーザル詳細画面の「Send Email」ボタンが accepted/rejected 時のみ表示されること
- [ ] 個別メール送信が成功/失敗時に適切なフィードバックが表示されること
- [ ] 一括送信が成功/失敗件数を正しく表示すること
- [ ] `swift build` が通ること ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)