### PR TITLE
🐛 Fix CSRF token missing in proposal list Accept/Reject forms

### DIFF
--- a/Server/Sources/Server/CfP/Pages/OrganizerProposalsPage.swift
+++ b/Server/Sources/Server/CfP/Pages/OrganizerProposalsPage.swift
@@ -231,7 +231,7 @@ struct OrganizerProposalsPageView: HTML, Sendable {
             }
             tbody {
               for (index, proposal) in proposals.enumerated() {
-                OrganizerProposalRow(proposal: proposal, index: index + 1)
+                OrganizerProposalRow(proposal: proposal, index: index + 1, csrfToken: csrfToken)
               }
             }
           }
@@ -518,6 +518,7 @@ struct OrganizerProposalsPageView: HTML, Sendable {
 struct OrganizerProposalRow: HTML, Sendable {
   let proposal: ProposalDTO
   let index: Int
+  let csrfToken: String
 
   var body: some HTML {
     tr(
@@ -588,6 +589,7 @@ struct OrganizerProposalRow: HTML, Sendable {
             HTMLRaw(
               """
               <form method="post" action="/organizer/proposals/\(proposal.id)/accept" style="display:inline">
+                <input type="hidden" name="_csrf" value="\(csrfToken)">
                 <button type="submit" class="btn btn-sm btn-success">Accept</button>
               </form>
               """)
@@ -596,6 +598,7 @@ struct OrganizerProposalRow: HTML, Sendable {
             HTMLRaw(
               """
               <form method="post" action="/organizer/proposals/\(proposal.id)/reject" style="display:inline">
+                <input type="hidden" name="_csrf" value="\(csrfToken)">
                 <button type="submit" class="btn btn-sm btn-outline-danger">Reject</button>
               </form>
               """)


### PR DESCRIPTION
## Summary
- Organizerのプロポーザル一覧ページにあるAccept/Rejectフォーム (`OrganizerProposalRow`) に `_csrf` hidden inputが欠落しており、POSTリクエスト時に常にCSRF 403エラーが発生していた
- `OrganizerProposalRow` に `csrfToken` プロパティを追加し、Accept/Reject両フォームにトークンを埋め込むように修正

## Test plan
- [ ] Organizerでプロポーザル一覧ページを開き、Accept/Rejectボタンが正常に動作することを確認
- [ ] 詳細ページのAccept/Reject/Revertボタンが引き続き正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)