### PR TITLE
Fix organizer proposals page showing "papercall-import" instead of speaker name

### DIFF
--- a/Server/Sources/Server/CfP/Pages/OrganizerProposalsPage.swift
+++ b/Server/Sources/Server/CfP/Pages/OrganizerProposalsPage.swift
@@ -539,12 +539,12 @@ struct OrganizerProposalRow: HTML, Sendable {
           if let iconURL = proposal.iconURL {
             img(
               .src(iconURL),
-              .alt(proposal.speakerUsername),
+              .alt(proposal.speakerName),
               .class("rounded-circle me-2"),
               .style("width: 24px; height: 24px;")
             )
           }
-          HTMLText(proposal.speakerUsername)
+          HTMLText(proposal.speakerName)
         }
       }
       td(.class("align-middle")) {


### PR DESCRIPTION
## Summary
- Organizer proposals ページのテーブルで、PaperCall からインポートされたプロポーザルの Speaker 列に `papercall-import`（システムユーザー名）が表示される問題を修正
- `proposal.speakerUsername`（User の username）の代わりに `proposal.speakerName`（プロポーザルに保存されたスピーカー名）を表示するように変更

## Test plan
- [ ] `/organizer/proposals` ページを開き、PaperCall からインポートされたプロポーザルに正しいスピーカー名が表示されることを確認
- [ ] 通常のプロポーザル（GitHub ユーザーが紐づいているもの）も正しくスピーカー名が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)