### PR TITLE
Add workshop fields to organizer proposal create/edit pages

### DIFF
--- a/Server/Sources/Server/CfP/CfPRoutes.swift
+++ b/Server/Sources/Server/CfP/CfPRoutes.swift
@@ -1859,9 +1859,8 @@ struct CfPRoutes: RouteCollection {
         throw Abort(.badRequest, reason: "Uniqueness is required")
       }
 
-      let numberOfTutors = Int(tutorsStr) ?? 0
-      guard numberOfTutors > 0 else {
-        throw Abort(.badRequest, reason: "Number of tutors must be at least 1")
+      guard let numberOfTutors = Int(tutorsStr), numberOfTutors > 0 else {
+        throw Abort(.badRequest, reason: "Number of tutors must be a valid number of at least 1")
       }
 
       let facilities =
@@ -2143,10 +2142,9 @@ struct CfPRoutes: RouteCollection {
           req: req, user: user, error: "Uniqueness is required")
       }
 
-      let numberOfTutors = Int(tutorsStr) ?? 0
-      guard numberOfTutors > 0 else {
+      guard let numberOfTutors = Int(tutorsStr), numberOfTutors > 0 else {
         return try await renderNewProposalPageWithError(
-          req: req, user: user, error: "Number of tutors must be at least 1")
+          req: req, user: user, error: "Number of tutors must be a valid number of at least 1")
       }
 
       let facilities =

--- a/Server/Sources/Server/CfP/Pages/OrganizerEditProposalPage.swift
+++ b/Server/Sources/Server/CfP/Pages/OrganizerEditProposalPage.swift
@@ -816,7 +816,7 @@ struct OrganizerEditProposalPageView: HTML, Sendable {
       <script>
         function updateIconPreview(url) {
           var preview = document.getElementById('iconPreview');
-          if (url && url.trim() !== '') { preview.src = url; }
+          if (preview && url && url.trim() !== '') { preview.src = url; }
         }
         document.addEventListener('DOMContentLoaded', function() {
           var typeSelect = document.getElementById('talkDuration');

--- a/Server/Sources/Server/CfP/Pages/OrganizerNewProposalPage.swift
+++ b/Server/Sources/Server/CfP/Pages/OrganizerNewProposalPage.swift
@@ -665,7 +665,7 @@ struct OrganizerNewProposalPageView: HTML, Sendable {
       <script>
         function updateIconPreview(url) {
           var preview = document.getElementById('iconPreview');
-          if (url && url.trim() !== '') { preview.src = url; }
+          if (preview && url && url.trim() !== '') { preview.src = url; }
         }
         document.addEventListener('DOMContentLoaded', function() {
           var typeSelect = document.getElementById('talkDuration');


### PR DESCRIPTION
## Summary
- Organizer の Add Proposal / Edit Proposal フォームに Workshop 固有フィールド（言語、チューター数、キーテイクアウェイ、アジェンダ、設備要件など13項目）と Co-Instructor フィールド（最大2名追加）を追加
- ハンドラー側で Workshop 選択時のバリデーション・データ構築・保存処理を追加
- タイプ変更時に Workshop データを適切にクリアする処理も追加

## Test plan
- [ ] Organizer から Add Proposal で Workshop タイプを選択し、Workshop フィールドが表示されることを確認
- [ ] Workshop の必須フィールドを埋めて保存し、`workshopDetails` と `coInstructors` が DB に保存されることを確認
- [ ] Edit Proposal で既存 Workshop データがプリフィルされることを確認
- [ ] タイプを Workshop 以外に変更して保存した際、Workshop データがクリアされることを確認
- [ ] Co-Instructor の Lookup ボタンが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)