### PR TITLE
🐛  handle format workflow for fork PRs

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -11,12 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     container: swift:6.2
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout (non-fork PR)
+        uses: actions/checkout@v6
         if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           ref: ${{ github.head_ref }}
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@v6
+      - name: Checkout (fork PR)
+        uses: actions/checkout@v6
         if: ${{ github.event.pull_request.head.repo.fork }}
         with:
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -26,10 +28,10 @@ jobs:
       - name: Format
         run: swift format --ignore-unparsable-files --in-place --recursive ./App/ ./Server/ ./SharedModels/ ./iOS/ ./Website/
       - name: Check diff (fork PR)
-        if: github.event.pull_request.head.repo.fork == true
+        if: ${{ github.event.pull_request.head.repo.fork }}
         run: git diff --exit-code
       - uses: stefanzweifel/git-auto-commit-action@v7
-        if: github.event.pull_request.head.repo.fork == false
+        if: ${{ !github.event.pull_request.head.repo.fork }}
         with:
           commit_message: "[ci skip] Run swift-format"
         env:


### PR DESCRIPTION
## Summary

Since this is an OSS project, most contributors submit PRs from forked repositories.
This change updates the Format workflow to behave correctly depending on whether the PR comes from a fork.

## Changes

### Checkout step
Split the checkout step into two, conditioned on `github.event.pull_request.head.repo.fork`:

- **Non-fork PR**: checkout by branch name (`github.head_ref`) with `GITHUB_TOKEN` so the auto-commit step can push back.
- **Fork PR**: checkout from the fork's repository using the exact SHA (`github.event.pull_request.head.sha`) to reliably fetch the correct commit, avoiding potential conflicts when a branch with the same name exists in the base repo.

### Format step
Using `github.event.pull_request.head.repo.fork` to branch the behavior:

| PR type | Behavior |
|---|---|
| Fork PR | Check only via `git diff --exit-code` (CI fails if diff exists) |
| Non-fork PR | Auto-commit the formatted result as before |

## Background

For fork PRs:
1. `GITHUB_TOKEN` does not have write permission, causing `stefanzweifel/git-auto-commit-action` to fail.
2. Using `github.head_ref` for checkout could resolve to a branch with the same name in the base repo instead of the fork's branch.

Contributors submitting PRs from a fork should run `swift format` locally before pushing:

```bash
swift format --ignore-unparsable-files --in-place --recursive ./App/ ./Server/ ./SharedModels/ ./iOS/ ./Website/