### PR TITLE
Allow manual input/edit of Luma event ID for workshops

### DIFF
--- a/Server/Sources/Server/Workshop/Pages/OrganizerWorkshopsPage.swift
+++ b/Server/Sources/Server/Workshop/Pages/OrganizerWorkshopsPage.swift
@@ -109,7 +109,7 @@ struct OrganizerWorkshopsPageView: HTML, Sendable {
         <td colspan="2">
           <form method="post" action="/organizer/workshops/\(ws.registrationID.uuidString)/luma-event" class="d-flex gap-1 align-items-center">
             <input type="hidden" name="_csrf" value="\(csrfToken)">
-            <input type="text" name="luma_event_id" value="\(escapeHTML(ws.lumaEventID ?? ""))" class="form-control form-control-sm" style="min-width: 160px;" placeholder="Luma Event ID">
+            <input type="text" name="luma_event_id" value="\(escapeHTML(ws.lumaEventID ?? ""))" class="form-control form-control-sm" style="min-width: 160px;" placeholder="Luma Event ID" aria-label="Luma Event ID">
             <button type="submit" class="btn btn-sm btn-outline-primary">Save</button>
         """
       if ws.lumaEventID == nil {

--- a/Server/Sources/Server/Workshop/WorkshopRoutes.swift
+++ b/Server/Sources/Server/Workshop/WorkshopRoutes.swift
@@ -672,6 +672,21 @@ struct WorkshopRoutes: RouteCollection {
     }
 
     let trimmed = form.luma_event_id.trimmingCharacters(in: .whitespacesAndNewlines)
+
+    if !trimmed.isEmpty {
+      let maxLength = 128
+      let allowedCharacters = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
+      guard trimmed.count <= maxLength,
+        trimmed.unicodeScalars.allSatisfy({ allowedCharacters.contains($0) })
+      else {
+        throw Abort(
+          .badRequest,
+          reason:
+            "Invalid Luma event ID. Use only letters, numbers, '-' and '_', maximum \(maxLength) characters."
+        )
+      }
+    }
+
     registration.lumaEventID = trimmed.isEmpty ? nil : trimmed
     try await registration.save(on: req.db)
 


### PR DESCRIPTION
## Summary
- Organizer管理画面でLuma Event IDを手動入力・編集できるフォームを追加
- 既存のLumaイベントIDがある場合も編集可能に
- 空にすることでクリアも可能
- Lumaイベント未設定時は従来通りAPI経由の「Create」ボタンも表示

## Test plan
- [ ] `/organizer/workshops` でLuma Event ID入力欄が表示される
- [ ] IDを入力してSave → 保存される
- [ ] 既存IDを変更してSave → 更新される
- [ ] IDを空にしてSave → クリアされる
- [ ] 未設定時に「Create」ボタンでAPI経由作成も引き続き動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)