### PR TITLE
✨ Position-aware slot insertion with 5min buffer

### DIFF
--- a/Server/Sources/Server/CfP/Pages/TimetableEditorPage.swift
+++ b/Server/Sources/Server/CfP/Pages/TimetableEditorPage.swift
@@ -755,9 +755,16 @@ struct TimetableEditorPageView: HTML, Sendable {
                     var timeEl = prevCard.querySelector('.slot-time');
                     if (timeEl) {
                       var prevEnd = timeEl.getAttribute('data-end');
-                      if (!prevEnd) { prevEnd = timeEl.getAttribute('data-start'); }
+                      var prevStart = timeEl.getAttribute('data-start');
+                      var prevSlotBtn = prevCard.querySelector('.edit-slot-btn');
+                      var prevSlotType = prevSlotBtn ? prevSlotBtn.getAttribute('data-slot-type') : '';
+                      var isPrevTalk = (prevSlotType === 'talk' || prevSlotType === 'lightning_talk');
                       if (prevEnd) {
-                        startTime = new Date(new Date(prevEnd).getTime() + BUFFER_MS).toISOString();
+                        startTime = isPrevTalk
+                          ? new Date(new Date(prevEnd).getTime() + BUFFER_MS).toISOString()
+                          : prevEnd;
+                      } else if (prevStart) {
+                        startTime = prevStart;
                       }
                     }
                   }


### PR DESCRIPTION
## Summary
- Use drop position (`evt.newIndex`) to calculate new slot's start time from the preceding slot's end time, instead of always using the last slot
- Add 5-minute buffer between consecutive talks when inserting via drag-and-drop
- Regular talks default to 20min, lightning talks to 5min (existing behavior, unchanged)

## Test plan
- [ ] Drop proposal onto empty timeline → starts at 10:00, ends at 10:20
- [ ] Drop at position 0 of populated timeline → starts at 10:00
- [ ] Drop after last slot (ends at 11:00) → starts at 11:05
- [ ] Drop between two existing slots → starts at preceding slot's end + 5min
- [ ] Drop a lightning talk → duration is 5min

🤖 Generated with [Claude Code](https://claude.com/claude-code)