### PR TITLE
Fix CfP deploy by copying DataClient into Docker build image

### DIFF
--- a/.github/workflows/deploy-cfp-server-prod.yml
+++ b/.github/workflows/deploy-cfp-server-prod.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "Server/**"
       - "MyLibrary/Sources/SharedModels/**"
+      - "DataClient/**"
       - "fly.production.toml"
   workflow_dispatch:
 

--- a/.github/workflows/deploy-cfp-server.yml
+++ b/.github/workflows/deploy-cfp-server.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - "Server/**"
       - "MyLibrary/Sources/SharedModels/**"
+      - "DataClient/**"
       - "fly.toml"
   workflow_dispatch:
 

--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -12,6 +12,9 @@ WORKDIR /build
 # Copy SharedModels package (CfP types shared with iOS)
 COPY ./SharedModels ./SharedModels
 
+# Copy DataClient package (speaker data for timetable export)
+COPY ./DataClient ./DataClient
+
 # Copy Server package manifest
 COPY ./Server/Package.swift ./Server/Package.swift
 


### PR DESCRIPTION
## Summary
- Add `COPY ./DataClient ./DataClient` to `Server/Dockerfile` so the local package dependency is available during `swift package resolve`
- Add `DataClient/**` to path triggers in both deploy workflows so DataClient changes trigger redeploys

## Context
The production deploy started failing after #296 added DataClient as a Server dependency (for speaker data matching in timetable export). The Dockerfile copied SharedModels but not DataClient, causing `swift package resolve` to fail with:
```
error: the package at '/build/DataClient' cannot be accessed (The folder "DataClient" doesn't exist.)
```

## Test plan
- [ ] Verify the deploy workflow succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)