### PR TITLE
Replace curl with actions/github-script in format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -9,6 +9,9 @@ jobs:
   swift_format:
     name: swift-format
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: write
     container: swift:6.2
     steps:
       - name: Checkout (non-fork PR)


### PR DESCRIPTION
## Summary
- Addresses [review comment](https://github.com/tryswift/try-swift-tokyo/pull/321#discussion_r2971761626) on #321 — the `swift:6.2` container may not have `curl` available
- Replaces the `curl` shell call with `actions/github-script@v7` for posting check-run status after auto-formatting
- Uses `steps.auto-commit.outputs.commit_hash` instead of shelling out to `git rev-parse HEAD`
- Removes manual `GITHUB_TOKEN` env/header handling (github-script handles auth automatically)

## Test plan
- [ ] Verify workflow YAML syntax is valid
- [ ] Push a file with formatting issues to a non-fork branch and confirm the check-run is posted after auto-commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)