### PR TITLE
Skip Luma ticket verification when API is not configured

### DIFF
--- a/Server/Sources/Server/Services/LumaClient.swift
+++ b/Server/Sources/Server/Services/LumaClient.swift
@@ -34,8 +34,11 @@ enum LumaClient {
     }
 
     guard response.status == .ok else {
-      logger.info("Luma get-guest returned status \(response.status.code) for email: \(email)")
-      return nil
+      if response.status == .notFound {
+        return nil
+      }
+      logger.error("Luma get-guest returned status \(response.status.code) for email: \(email)")
+      throw Abort(.badGateway, reason: "Luma API returned \(response.status.code)")
     }
 
     return try response.content.decode(LumaGuest.self)

--- a/Server/Sources/Server/Workshop/WorkshopRoutes.swift
+++ b/Server/Sources/Server/Workshop/WorkshopRoutes.swift
@@ -288,7 +288,7 @@ struct WorkshopRoutes: RouteCollection {
 
     // Verify Luma ticket (skip if Luma API is not configured)
     let guestName: String
-    if Environment.get("LUMA_API_KEY") != nil {
+    if let lumaApiKey = Environment.get("LUMA_API_KEY"), !lumaApiKey.isEmpty {
       let guest: LumaGuest?
       do {
         guest = try await LumaClient.getGuest(
@@ -304,7 +304,17 @@ struct WorkshopRoutes: RouteCollection {
         return try await html.encodeResponse(for: req)
       }
 
-      guard let guest, guest.hasTicket else {
+      guard let guest else {
+        let html = try await renderWorkshopApplyPage(
+          req: req, language: language,
+          errorMessage: language == .ja
+            ? "このメールアドレスでtry! Swift Tokyo 2026のチケットが見つかりませんでした。"
+            : "No try! Swift Tokyo 2026 ticket found for this email address."
+        )
+        return try await html.encodeResponse(for: req)
+      }
+
+      guard guest.hasTicket else {
         let html = try await renderWorkshopApplyPage(
           req: req, language: language,
           errorMessage: language == .ja
@@ -315,7 +325,7 @@ struct WorkshopRoutes: RouteCollection {
       }
       guestName = guest.displayName
     } else {
-      req.logger.info("LUMA_API_KEY not configured, skipping ticket verification")
+      req.logger.debug("LUMA_API_KEY not configured, skipping ticket verification")
       guestName = ""
     }
 


### PR DESCRIPTION
## Summary
- `/workshops/apply` でメールアドレスをsubmit時、`LUMA_API_KEY` 未設定だと `{"error":true,"reason":"Luma API not configured"}` というJSON生エラーが返されていた
- `LUMA_API_KEY` 未設定時はLumaチケット確認をスキップし、誰でもワークショップに申し込めるようにした
- `LUMA_API_KEY` 設定済みの場合は従来通りチケット確認を行い、API障害時もフレンドリーなエラーページを表示する

## Test plan
- [ ] `LUMA_API_KEY` なしでサーバー起動 → `/workshops/apply` でメール入力 → ワークショップ選択画面が表示される
- [ ] `LUMA_API_KEY` 設定済みで正常にチケット確認が動作する
- [ ] `LUMA_API_KEY` 設定済みでAPI障害時にフレンドリーなエラーページが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)