### PR TITLE
Fix workshop email alias matching and optional choice validation

### DIFF
--- a/Server/Sources/Server/Services/LumaClient.swift
+++ b/Server/Sources/Server/Services/LumaClient.swift
@@ -26,11 +26,16 @@ enum LumaClient {
       logger.error("LUMA_EVENT_ID not configured and no eventID provided")
       throw Abort(.internalServerError, reason: "Luma event ID not configured")
     }
-    var allowedCharacters = CharacterSet.urlQueryAllowed
-    allowedCharacters.remove("+")
-    let encodedEmail =
-      email.addingPercentEncoding(withAllowedCharacters: allowedCharacters) ?? email
-    let url = "\(baseURL)/event/get-guest?event_id=\(lumaEventID)&id=\(encodedEmail)"
+    var components = URLComponents(string: "\(baseURL)/event/get-guest")!
+    components.queryItems = [
+      URLQueryItem(name: "event_id", value: lumaEventID),
+      URLQueryItem(name: "id", value: email),
+    ]
+    // URLComponents leaves + unencoded (valid per RFC 3986), but many servers
+    // interpret + as space per x-www-form-urlencoded. Encode it explicitly.
+    components.percentEncodedQuery = components.percentEncodedQuery?
+      .replacingOccurrences(of: "+", with: "%2B")
+    let url = components.string!
 
     let response = try await client.get(URI(string: url)) { req in
       req.headers.add(name: "x-luma-api-key", value: apiKey)

--- a/Server/Sources/Server/Workshop/WorkshopRoutes.swift
+++ b/Server/Sources/Server/Workshop/WorkshopRoutes.swift
@@ -404,9 +404,28 @@ struct WorkshopRoutes: RouteCollection {
 
     let form = try req.content.decode(ApplyForm.self)
 
-    // Parse optional choice IDs (empty strings from the form become nil)
-    let secondChoiceID = form.second_choice_id.flatMap { UUID(uuidString: $0) }
-    let thirdChoiceID = form.third_choice_id.flatMap { UUID(uuidString: $0) }
+    // Parse optional choice IDs:
+    // - nil or empty strings from the form become nil
+    // - non-empty but invalid UUID strings cause a bad request
+    let secondChoiceID: UUID?
+    if let rawSecond = form.second_choice_id, !rawSecond.isEmpty {
+      guard let parsed = UUID(uuidString: rawSecond) else {
+        throw Abort(.badRequest, reason: "Invalid second_choice_id")
+      }
+      secondChoiceID = parsed
+    } else {
+      secondChoiceID = nil
+    }
+
+    let thirdChoiceID: UUID?
+    if let rawThird = form.third_choice_id, !rawThird.isEmpty {
+      guard let parsed = UUID(uuidString: rawThird) else {
+        throw Abort(.badRequest, reason: "Invalid third_choice_id")
+      }
+      thirdChoiceID = parsed
+    } else {
+      thirdChoiceID = nil
+    }
 
     // Verify the token
     let payload: WorkshopVerifyPayload


### PR DESCRIPTION
## Summary
- Fix email `+` alias (e.g. `user+tag@example.com`) not matching in Luma ticket verification by encoding `+` as `%2B` in the API query parameter
- Fix workshop application form requiring 2nd/3rd choices even though they're optional, by changing `ApplyForm` fields from `UUID?` to `String?` and manually parsing (empty string → `nil`)

## Test plan
- [ ] Verify email with `+` alias passes Luma ticket verification
- [ ] Submit workshop application with only 1st choice selected — should succeed
- [ ] Submit workshop application with all 3 choices — should still work as before
- [ ] Verify duplicate choice validation still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)