### PR TITLE
Bump source.skip.tools/skip-model from 1.7.1 to 1.7.2 in /Android

### DIFF
--- a/Android/Package.resolved
+++ b/Android/Package.resolved
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://source.skip.tools/skip-model.git",
       "state" : {
-        "revision" : "9636e2a3a1dac662cbe04600e5d6a9e0914c4723",
-        "version" : "1.7.1"
+        "revision" : "400a13cf64387a0ae81403084c61eb15ca151096",
+        "version" : "1.7.2"
       }
     },
     {


### PR DESCRIPTION
## Summary
- Bumps `skip-model` from 1.7.1 to 1.7.2 in `/Android`
- Supersedes #328 which had a merge conflict (opencombine was removed from main in #332)

## Test plan
- [x] `swift package update skip-model` resolved cleanly
- [x] Package.resolved has skip-model 1.7.2, no stale opencombine entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)