### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -16,6 +16,9 @@ on:
       - "DataClient/**"
       - ".github/workflows/build-android.yml"
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Android


### PR DESCRIPTION
Potential fix for [https://github.com/tryswift/try-swift-tokyo/security/code-scanning/15](https://github.com/tryswift/try-swift-tokyo/security/code-scanning/15)

In general, to fix this issue, add a `permissions` section to the workflow (either at the root or under the specific job) that grants only the minimal scopes needed. For a typical build job that just checks out code, caches dependencies, and runs a build, `contents: read` is sufficient; if the job needs to interact with packages, `packages: read` can be added as well.

The best minimal fix here, without changing existing behavior, is to add a top‑level `permissions` block just below the `name:` and `on:` sections (but before `jobs:`), setting `contents: read`. This will apply to all jobs in the workflow (currently just `build`) and constrain the `GITHUB_TOKEN` used by `actions/checkout` and `actions/cache` while preserving all existing steps. No additional methods or imports are required since this is purely a YAML configuration change.

Concretely, edit `.github/workflows/build-android.yml` to insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
