### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-website.yml
+++ b/.github/workflows/test-website.yml
@@ -1,4 +1,6 @@
 name: Test Website
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/tryswift/try-swift-tokyo/security/code-scanning/6](https://github.com/tryswift/try-swift-tokyo/security/code-scanning/6)

In general, the fix is to add an explicit `permissions` section that grants only the least privileges needed. For a build-and-test workflow that just checks out code, uses caches, and runs `swift build`, the minimal needed scope is read access to repository contents. This can be done at the workflow root (applies to all jobs) or per job.

The best, minimal-impact fix here is to add a workflow-level `permissions` block right after the `name:` line, setting `contents: read`. This documents that the workflow only needs read access and ensures that if repo defaults are more permissive, the `GITHUB_TOKEN` used in this workflow is constrained. No existing steps need to change, and no extra libraries or actions are required. Concretely, in `.github/workflows/test-website.yml`, between lines 1 and 3, insert:

```yaml
permissions:
  contents: read
```

No imports, methods, or other definitions are needed; this is purely a YAML configuration change inside the existing workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
