### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-cfp-server.yml
+++ b/.github/workflows/test-cfp-server.yml
@@ -11,6 +11,8 @@ jobs:
   test:
     name: Test Server
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/tryswift/try-swift-tokyo/security/code-scanning/5](https://github.com/tryswift/try-swift-tokyo/security/code-scanning/5)

In general, the fix is to explicitly declare a `permissions` block that limits the `GITHUB_TOKEN` to the minimal access needed. For this workflow, the steps only require read access to the repository contents (for `actions/checkout`) and possibly cache access, which does not need additional scopes. Therefore, the best fix is to add `permissions: contents: read` at the workflow or job level.

To avoid changing existing functionality and to keep the scope local to this job, add a `permissions` block under the `test` job in `.github/workflows/test-cfp-server.yml`. Specifically, after `runs-on: ubuntu-latest` (line 13), insert:

```yaml
    permissions:
      contents: read
```

No additional imports or definitions are required; this is standard GitHub Actions YAML configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
