### PR TITLE
Fix .buttonStyle(.link) availability on iOS

### DIFF
--- a/iOS/Sources/AppFeature/AppView.swift
+++ b/iOS/Sources/AppFeature/AppView.swift
@@ -306,21 +306,33 @@ public struct AppView: View {
           externalLinkLabel(
             String(localized: "Code of Conduct", bundle: .module), systemImage: "doc.text")
         }
-        .buttonStyle(.link)
+        #if os(macOS)
+          .buttonStyle(.link)
+        #else
+          .buttonStyle(.plain)
+        #endif
         Button {
           store.send(.openExternalLink(.privacyPolicy))
         } label: {
           externalLinkLabel(
             String(localized: "Privacy Policy", bundle: .module), systemImage: "hand.raised")
         }
-        .buttonStyle(.link)
+        #if os(macOS)
+          .buttonStyle(.link)
+        #else
+          .buttonStyle(.plain)
+        #endif
 
         Button {
           store.send(.openExternalLink(.luma))
         } label: {
           externalLinkLabel(String(localized: "Luma", bundle: .module), systemImage: "ticket")
         }
-        .buttonStyle(.link)
+        #if os(macOS)
+          .buttonStyle(.link)
+        #else
+          .buttonStyle(.plain)
+        #endif
 
         Button {
           store.send(.openExternalLink(.website))
@@ -328,7 +340,11 @@ public struct AppView: View {
           externalLinkLabel(
             String(localized: "try! Swift Website", bundle: .module), systemImage: "safari")
         }
-        .buttonStyle(.link)
+        #if os(macOS)
+          .buttonStyle(.link)
+        #else
+          .buttonStyle(.plain)
+        #endif
 
       }
 


### PR DESCRIPTION
## Summary
- `.buttonStyle(.link)` is macOS-only but was used in `sidebarContent` which is also rendered on iPad
- Wrapped with `#if os(macOS)` and falls back to `.buttonStyle(.plain)` on other platforms
- Follows the existing platform-check pattern from `GlassEffect+.swift`

## Test plan
- [ ] Build iOS target successfully
- [ ] Verify sidebar buttons render correctly on macOS
- [ ] Verify sidebar buttons render correctly on iPad

🤖 Generated with [Claude Code](https://claude.com/claude-code)