### PR TITLE
Make Skip dependencies conditional in SharedModels

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Cache SwiftPM dependencies
         uses: actions/cache@v5
         with:
-          key: spm-android-${{ runner.os }}-${{ hashFiles('Android/Package.resolved', 'Android/Package.swift') }}
+          key: spm-android-${{ runner.os }}-${{ hashFiles('Android/Package.resolved', 'Android/Package.swift', 'SharedModels/Package.swift') }}
           restore-keys: spm-android-${{ runner.os }}-
           path: Android/.build
 

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ android-emulator:
 		echo "Starting emulator: $$AVD"; \
 		emulator -avd $$AVD & \
 		adb wait-for-device; \
+		adb shell 'while [ "$$(getprop sys.boot_completed)" != "1" ]; do sleep 1; done'; \
 	fi
 
 android-run: android-build android-emulator

--- a/SharedModels/Package.swift
+++ b/SharedModels/Package.swift
@@ -5,7 +5,8 @@ import PackageDescription
 
 // Skip dependencies are only needed for Android transpilation (skipstone plugin).
 // Set INCLUDE_SKIP=1 environment variable to enable (e.g., `INCLUDE_SKIP=1 swift build`).
-let includeSkip = ProcessInfo.processInfo.environment["INCLUDE_SKIP"] != nil
+let includeSkipEnv = ProcessInfo.processInfo.environment["INCLUDE_SKIP"]?.lowercased()
+let includeSkip = includeSkipEnv == "1" || includeSkipEnv == "true"
 
 var packageDependencies: [Package.Dependency] = []
 var targetDependencies: [Target.Dependency] = []


### PR DESCRIPTION
## Summary
- Gate Skip framework dependencies in SharedModels behind `INCLUDE_SKIP` env var so iOS/Server/Website builds no longer pull in Skip packages
- Add `android-build`, `android-emulator`, and `android-run` Makefile targets for streamlined Android development
- Update `build-android.yml` CI workflow to set `INCLUDE_SKIP=1`

## Test plan
- [ ] `cd SharedModels && swift test` passes without Skip dependencies
- [ ] `cd Server && swift test` builds without Skip
- [ ] `cd Android && INCLUDE_SKIP=1 swift build` builds with Skip enabled
- [ ] `make android-build` works correctly
- [ ] `make android-run` builds, starts emulator, and installs app

🤖 Generated with [Claude Code](https://claude.com/claude-code)