### PR TITLE
Fix LiveTranslation connection failure and surface error messages

### DIFF
--- a/iOS/Sources/LiveTranslationFeature/LiveTranslation.swift
+++ b/iOS/Sources/LiveTranslationFeature/LiveTranslation.swift
@@ -18,6 +18,8 @@ public struct LiveTranslation: Sendable {
     var supportLanguages: [LanguageItemEntity] = []
     /// Streaming is connected
     var isConnected: Bool = false
+    /// Last error message from the translation service
+    var lastErrorMessage: String? = nil
     /// Live Translation Room Title
     var roomTitle: String? = nil
     /// Current language code which user selected
@@ -79,6 +81,7 @@ public struct LiveTranslation: Sendable {
       switch action {
       case .view(.onAppear):
         state.roomNumber = buildConfig.liveTranslationRoomNumber()
+        guard !state.roomNumber.isEmpty else { return .none }
         return .run { [state] send in
           await liveTranslationServiceClient.connect(
             state.roomNumber, state.selectedLangCode)
@@ -88,6 +91,7 @@ public struct LiveTranslation: Sendable {
         }.cancellable(id: observationTaskId, cancelInFlight: true)
 
       case .view(.connectStream):
+        guard !state.roomNumber.isEmpty else { return .none }
         return .run { [state] send in
           await liveTranslationServiceClient.connect(
             state.roomNumber, state.selectedLangCode)
@@ -150,6 +154,7 @@ public struct LiveTranslation: Sendable {
         state.supportLanguages = storeState.supportLanguages
         state.isConnected = storeState.isConnected
         state.roomTitle = storeState.roomTitle
+        state.lastErrorMessage = storeState.isConnected ? nil : storeState.lastErrorMessage
         if storeState.supportLanguages != previousLanguages
           && !storeState.supportLanguages.isEmpty
         {
@@ -201,7 +206,18 @@ public struct LiveTranslationView: View {
               Spacer()
               flittoLogo
             } else if store.chatList.isEmpty {
-              ContentUnavailableView("Not started yet", systemImage: "text.page.slash.fill")
+              if let errorMessage = store.lastErrorMessage {
+                ContentUnavailableView {
+                  Label(
+                    String(localized: "Connection error", bundle: .module),
+                    systemImage: "exclamationmark.triangle.fill"
+                  )
+                } description: {
+                  Text(errorMessage)
+                }
+              } else {
+                ContentUnavailableView("Not started yet", systemImage: "text.page.slash.fill")
+              }
               Spacer()
               flittoLogo
             } else {

--- a/iOS/Sources/LiveTranslationFeature/LiveTranslationServiceClient.swift
+++ b/iOS/Sources/LiveTranslationFeature/LiveTranslationServiceClient.swift
@@ -67,6 +67,7 @@ extension LiveTranslationServiceClient: DependencyKey {
       disconnect: {
         await MainActor.run {
           ref.store?.disconnect()
+          ref.store = nil
         }
       },
       requestTranslationLanguage: { langCode in

--- a/iOS/Sources/LiveTranslationFeature/Localizable.xcstrings
+++ b/iOS/Sources/LiveTranslationFeature/Localizable.xcstrings
@@ -1,6 +1,16 @@
 {
   "sourceLanguage" : "en",
   "strings" : {
+    "Connection error" : {
+      "localizations" : {
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "接続エラー"
+          }
+        }
+      }
+    },
     "Fast" : {
       "localizations" : {
         "ja" : {

--- a/iOS/Tests/LiveTranslationFeatureTests/LiveTranslationTests.swift
+++ b/iOS/Tests/LiveTranslationFeatureTests/LiveTranslationTests.swift
@@ -264,6 +264,59 @@ struct LiveTranslationTests {
   // MARK: - Stream Connection
 
   @Test
+  func onAppear_emptyRoomNumber_doesNotConnect() async {
+    let connectCalled = LockIsolated(false)
+
+    let store = TestStore(initialState: LiveTranslation.State()) {
+      LiveTranslation()
+    } withDependencies: {
+      $0.buildConfig.liveTranslationRoomNumber = { "" }
+      $0.liveTranslationServiceClient.connect = { _, _ in
+        connectCalled.setValue(true)
+      }
+      $0.liveTranslationServiceClient.stateStream = { .never }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.view(.onAppear)) {
+      $0.roomNumber = ""
+    }
+
+    connectCalled.withValue { #expect($0 == false) }
+  }
+
+  @Test
+  func storeStateUpdated_populatesLastErrorMessage() async {
+    let store = TestStore(initialState: LiveTranslation.State()) {
+      LiveTranslation()
+    }
+    store.exhaustivity = .off
+
+    await store.send(
+      .storeStateUpdated(
+        StoreState(isConnected: false, lastErrorMessage: "Socket error"))
+    ) {
+      $0.lastErrorMessage = "Socket error"
+    }
+  }
+
+  @Test
+  func storeStateUpdated_clearsErrorOnConnected() async {
+    var state = LiveTranslation.State()
+    state.lastErrorMessage = "Previous error"
+
+    let store = TestStore(initialState: state) {
+      LiveTranslation()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.storeStateUpdated(StoreState(isConnected: true))) {
+      $0.isConnected = true
+      $0.lastErrorMessage = nil
+    }
+  }
+
+  @Test
   func disconnectStream_setsNotConnectedAndDisconnects() async {
     let disconnectCalled = LockIsolated(false)
     var state = LiveTranslation.State()


### PR DESCRIPTION
## Summary
- **Reset `ChatAudienceStore` on disconnect** — nil out the SDK store after `disconnect()` so reconnection creates a fresh instance instead of reusing a potentially broken one (root cause of repeated socket failures)
- **Surface SDK error messages in UI** — read `lastErrorMessage` from the Flitto SDK state stream and display it via `ContentUnavailableView` instead of silently showing "Not started yet"
- **Guard empty room number** — skip connection attempts when room number is empty, matching existing Android behavior

## Test plan
- [x] Added `onAppear_emptyRoomNumber_doesNotConnect` test
- [x] Added `storeStateUpdated_populatesLastErrorMessage` test
- [x] Added `storeStateUpdated_clearsErrorOnConnected` test
- [ ] Manual: verify error message appears when Flitto connection fails
- [ ] Manual: verify reconnect button creates fresh connection after failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)