### PR TITLE
Use Button(role: .close) for video detail sheet dismiss button

### DIFF
--- a/iOS/Sources/AppFeature/AppView.swift
+++ b/iOS/Sources/AppFeature/AppView.swift
@@ -249,13 +249,8 @@ public struct AppView: View {
         NavigationStack {
           VideoDetailView(store: videoDetailStore, speakerImageBundle: scheduleFeatureBundle)
           .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-              Button {
-                store.send(.videoDetail(.dismiss))
-              } label: {
-                Image(systemName: "xmark.circle.fill")
-                .symbolRenderingMode(.hierarchical)
-              }
+            Button(role: .close) {
+              store.send(.videoDetail(.dismiss))
             }
           }
         }


### PR DESCRIPTION
## Summary
- Replace the custom gray `xmark.circle.fill` icon with `Button(role: .close)` (iOS 26) for the video detail sheet dismiss button
- The system-standard close button provides proper glass effect styling and platform-consistent appearance

## Test plan
- [ ] Open a video session from the schedule to present the detail sheet
- [ ] Verify the close button uses the system-standard glass effect × mark instead of the gray icon
- [ ] Confirm the button still dismisses the sheet correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)