### PR TITLE
Enable Picture in Picture for video playback on iOS

### DIFF
--- a/App/App/Info.plist
+++ b/App/App/Info.plist
@@ -12,6 +12,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>
+		<string>audio</string>
 	</array>
 </dict>
 </plist>

--- a/iOS/Sources/VideoFeature/VideoPlayerView.swift
+++ b/iOS/Sources/VideoFeature/VideoPlayerView.swift
@@ -26,6 +26,9 @@ struct VideoPlayerView: View {
         parameters: .init(
           autoPlay: false,
           showControls: true
+        ),
+        configuration: .init(
+          allowsPictureInPictureMediaPlayback: true
         )
       ))
   }


### PR DESCRIPTION
## Summary
- Enable PiP so YouTube videos continue playing in a floating window when the app moves to the background
- Add `audio` background mode to `Info.plist` (covers Audio, AirPlay, and PiP capability)
- Set `allowsPictureInPictureMediaPlayback: true` in `YouTubePlayerKit` configuration

## Test plan
- [ ] Play a YouTube video in the Schedule detail view on iOS
- [ ] Swipe up to go home — verify a PiP window appears with the video still playing
- [ ] Verify play/pause and close controls work in the PiP window
- [ ] Verify macOS build is unaffected (PiP config is ignored on macOS internally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)