### PR TITLE
Fix macOS video not switching when selecting different session

### DIFF
--- a/iOS/Sources/VideoFeature/VideoDetailView.swift
+++ b/iOS/Sources/VideoFeature/VideoDetailView.swift
@@ -24,6 +24,7 @@ public struct VideoDetailView: View {
             send(.playerTimeUpdated(time))
           }
         )
+        .id(store.videoMetadata.youtubeVideoId)
         .padding(.horizontal)
         .padding(.top)
 


### PR DESCRIPTION
## Summary
- macOSの3カラムNavigationSplitViewで別のセッションを選択しても、動画プレイヤーが前のセッションの動画を再生し続けるバグを修正
- `VideoPlayerView`の`@State`がSwiftUIのビュー再利用時に再初期化されないことが原因
- `VideoPlayerView`に`.id(youtubeVideoId)`を付与し、動画IDが変わった際にビューを再作成するよう修正

## Test plan
- [ ] macOSでアプリをビルド・起動
- [ ] 動画があるセッションをタップし、3カラム目で動画が表示されることを確認
- [ ] 別の動画セッションをタップし、動画が切り替わることを確認
- [ ] Past Yearsのセッションでも同様に確認
- [ ] iOSで既存の動画再生が問題なく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)