### PR TITLE
Show organizer profile in detail column instead of modal on macOS

### DIFF
--- a/iOS/Sources/AppFeature/AppView.swift
+++ b/iOS/Sources/AppFeature/AppView.swift
@@ -33,6 +33,7 @@ public struct AppReducer {
   public enum DetailColumn {
     case scheduleDetail(ScheduleDetail)
     case videoDetail(VideoDetail)
+    case profileDetail(Profile)
   }
 
   @ObservableState
@@ -163,7 +164,11 @@ public struct AppReducer {
         }
 
       case .sidebarOrganizers(.delegate(.organizerTapped(let organizer))):
-        state.sidebarProfile = .init(organizer: organizer)
+        #if os(macOS)
+          state.detailColumn = .profileDetail(.init(organizer: organizer))
+        #else
+          state.sidebarProfile = .init(organizer: organizer)
+        #endif
         return .none
 
       case .schedule(.view(.yearSelected(let year))):
@@ -313,6 +318,10 @@ public struct AppView: View {
         state: \.detailColumn?.videoDetail, action: \.detailColumn.videoDetail)
       {
         VideoDetailView(store: videoStore, speakerImageBundle: scheduleFeatureBundle)
+      } else if let profileStore = store.scope(
+        state: \.detailColumn?.profileDetail, action: \.detailColumn.profileDetail)
+      {
+        ProfileView(store: profileStore)
       } else {
         ContentUnavailableView {
           Label(

--- a/iOS/Sources/trySwiftFeature/Organizers.swift
+++ b/iOS/Sources/trySwiftFeature/Organizers.swift
@@ -11,20 +11,16 @@ public struct Organizers {
   @ObservableState
   public struct State: Equatable {
     var organizers = IdentifiedArrayOf<Organizer>()
-    @Presents var destination: Destination.State?
 
     public init(
-      organizers: IdentifiedArrayOf<Organizer> = [],
-      destination: Destination.State? = nil
+      organizers: IdentifiedArrayOf<Organizer> = []
     ) {
       self.organizers = organizers
-      self.destination = destination
     }
   }
 
   public enum Action: ViewAction {
     case view(View)
-    case destination(PresentationAction<Destination.Action>)
     case delegate(Delegate)
 
     public enum View {
@@ -38,11 +34,6 @@ public struct Organizers {
     }
   }
 
-  @Reducer
-  public enum Destination {
-    case profile(Profile)
-  }
-
   @Dependency(DataClient.self) var dataClient
 
   public var body: some ReducerOf<Organizers> {
@@ -54,23 +45,13 @@ public struct Organizers {
         }
         return .none
       case .view(._organizerTapped(let organizer)):
-        #if os(macOS)
-          state.destination = .profile(.init(organizer: organizer))
-          return .none
-        #else
-          return .send(.delegate(.organizerTapped(organizer)))
-        #endif
+        return .send(.delegate(.organizerTapped(organizer)))
       case .delegate:
-        return .none
-      case .destination:
         return .none
       }
     }
-    .ifLet(\.$destination, action: \.destination)
   }
 }
-
-extension Organizers.Destination.State: Equatable {}
 
 @ViewAction(for: Organizers.self)
 public struct OrganizersView: View {
@@ -110,23 +91,6 @@ public struct OrganizersView: View {
       send(.onAppear)
     }
     .navigationTitle(Text("Meet Organizers", bundle: .module))
-    #if os(macOS)
-      .sheet(
-        item: $store.scope(state: \.destination?.profile, action: \.destination.profile)
-      ) { profileStore in
-        NavigationStack {
-          ProfileView(store: profileStore)
-          .toolbar {
-            ToolbarItem(placement: .cancellationAction) {
-              Button(String(localized: "Close", bundle: .module)) {
-                store.send(.destination(.dismiss))
-              }
-            }
-          }
-        }
-        .frame(minWidth: 500, minHeight: 400)
-      }
-    #endif
   }
 }
 


### PR DESCRIPTION
## Summary
- On macOS, tapping an organizer now displays the profile in the 3rd column of `NavigationSplitView` instead of presenting a `.sheet()` modal
- Added `profileDetail(Profile)` case to `DetailColumn` reducer, consistent with `scheduleDetail` and `videoDetail`
- Removed `Organizers.Destination` and macOS-only `.sheet()` modifier, simplifying the reducer by always delegating to the parent

## Test plan
- [ ] macOS: Select "Organizers" in sidebar → tap an organizer → profile appears in 3rd column (not a modal)
- [ ] macOS: Switch sidebar item (e.g. Day 1) → detail column resets
- [ ] iOS: Organizer tap still navigates via `navigationDestination` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)