### PR TITLE
Use Luma add-guests API with Standard ticket type for workshop tickets

### DIFF
--- a/Server/Sources/Server/Services/LumaClient.swift
+++ b/Server/Sources/Server/Services/LumaClient.swift
@@ -115,7 +115,10 @@ enum LumaClient {
 
     guard response.status == .ok else {
       let body = response.body.map { String(buffer: $0) } ?? "no body"
-      logger.error("Luma ticket-types/list failed: \(response.status.code) - \(body)")
+      let truncatedBody = String(body.prefix(1000))
+      logger.error(
+        "Luma ticket-types/list failed for eventID=\(eventID): \(response.status.code) - \(truncatedBody)"
+      )
       throw Abort(.badGateway, reason: "Failed to list Luma ticket types")
     }
 

--- a/Server/Sources/Server/Workshop/WorkshopRoutes.swift
+++ b/Server/Sources/Server/Workshop/WorkshopRoutes.swift
@@ -1123,36 +1123,40 @@ struct WorkshopRoutes: RouteCollection {
     var sent = 0
     var errors = 0
 
-    // Cache Standard ticket type ID per event
-    var ticketTypeCache: [String: String] = [:]
+    // Cache Standard ticket type ID per event (nil value = lookup failed)
+    var ticketTypeCache: [String: String?] = [:]
 
     for winner in winners {
       guard let workshop = winner.assignedWorkshop,
         let lumaEventID = workshop.lumaEventID
       else { continue }
 
-      // Fetch and cache the Standard ticket type for this event
-      if ticketTypeCache[lumaEventID] == nil {
+      // Fetch and cache the Standard ticket type for this event (once per event)
+      if !ticketTypeCache.keys.contains(lumaEventID) {
         do {
           let ticketTypes = try await LumaClient.getTicketTypes(
             eventID: lumaEventID,
             client: req.client,
             logger: req.logger
           )
-          guard let standard = ticketTypes.first(where: { $0.name == "Standard" }) else {
+          if let standard = ticketTypes.first(where: { $0.name == "Standard" }) {
+            ticketTypeCache[lumaEventID] = standard.id
+          } else {
             req.logger.error(
               "No 'Standard' ticket type found for event \(lumaEventID)")
-            continue
+            ticketTypeCache[lumaEventID] = nil as String?
           }
-          ticketTypeCache[lumaEventID] = standard.id
         } catch {
           req.logger.error(
             "Failed to fetch ticket types for event \(lumaEventID): \(error)")
-          continue
+          ticketTypeCache[lumaEventID] = nil as String?
         }
       }
 
-      guard let ticketTypeID = ticketTypeCache[lumaEventID] else { continue }
+      guard let ticketTypeID = ticketTypeCache[lumaEventID] ?? nil else {
+        errors += 1
+        continue
+      }
 
       do {
         let response = try await LumaClient.addGuestToEvent(


### PR DESCRIPTION
## Summary

- Switch workshop ticket sending from old `POST /event/add-guest` to new `POST /v1/event/add-guests` endpoint
- Fetch ticket types via `GET /v1/event/ticket-types/list` and use the "Standard" ticket type ID when adding guests
- Cache ticket type lookups per event to avoid redundant API calls

## Test plan

- [x] `swift build` passes
- [x] `swift test` passes (85 tests)
- [ ] Verify ticket type fetch returns expected "Standard" type with real Luma API key
- [ ] Verify add-guests endpoint successfully adds guest with Standard ticket

🤖 Generated with [Claude Code](https://claude.com/claude-code)