### PR TITLE
Skip already-invited Luma guests and batch ticket sends per event

### DIFF
--- a/Server/Sources/Server/Services/LumaClient.swift
+++ b/Server/Sources/Server/Services/LumaClient.swift
@@ -168,6 +168,52 @@ enum LumaClient {
     return allGuests
   }
 
+  /// Add multiple guests to a Luma event in a single request
+  static func addGuestsToEvent(
+    eventID: String,
+    guests: [LumaGuestInput],
+    ticketTypeID: String,
+    client: Client,
+    logger: Logger
+  ) async throws {
+    guard !guests.isEmpty else { return }
+    guard let apiKey = Environment.get("LUMA_API_KEY") else {
+      throw Abort(.internalServerError, reason: "Luma API not configured")
+    }
+
+    let payload = LumaAddGuestsRequest(
+      event_api_id: eventID,
+      guests: guests,
+      ticket: LumaTicketSpec(event_ticket_type_id: ticketTypeID)
+    )
+
+    var response = try await client.post(URI(string: "\(baseURL)/event/add-guests")) { req in
+      req.headers.add(name: "x-luma-api-key", value: apiKey)
+      req.headers.contentType = .json
+      try req.content.encode(payload)
+    }
+
+    // Retry once on rate limit (429) — Luma blocks for 1 minute after exceeding limits
+    if response.status == .tooManyRequests {
+      logger.warning(
+        "Luma rate limit hit for add-guests (\(guests.count) guests), waiting 65s before retry...")
+      try await Task.sleep(nanoseconds: 65_000_000_000)
+      response = try await client.post(URI(string: "\(baseURL)/event/add-guests")) { req in
+        req.headers.add(name: "x-luma-api-key", value: apiKey)
+        req.headers.contentType = .json
+        try req.content.encode(payload)
+      }
+    }
+
+    guard response.status == .ok || response.status == .created else {
+      let body = response.body.map { String(buffer: $0) } ?? "no body"
+      logger.error("Luma add-guests failed: \(response.status.code) - \(body)")
+      throw Abort(.badGateway, reason: "Failed to add guests to Luma event")
+    }
+
+    logger.info("Successfully added \(guests.count) guests to Luma event \(eventID)")
+  }
+
   /// Add a guest to a Luma event with a specific ticket type
   static func addGuestToEvent(
     eventID: String,

--- a/Server/Sources/Server/Workshop/WorkshopRoutes.swift
+++ b/Server/Sources/Server/Workshop/WorkshopRoutes.swift
@@ -1124,90 +1124,115 @@ struct WorkshopRoutes: RouteCollection {
     var errors = 0
     var skipped = 0
 
-    // Cache Standard ticket type ID per event (nil value = lookup failed)
-    var ticketTypeCache: [String: String?] = [:]
-    // Cache existing guest emails per event to avoid duplicate sends
-    var existingGuestsCache: [String: [String: String]] = [:]  // eventID -> [email: guestID]
-
+    // Group winners by Luma event ID for batch processing
+    var winnersByEvent: [String: [WorkshopApplication]] = [:]
     for winner in winners {
       guard let workshop = winner.assignedWorkshop,
         let lumaEventID = workshop.lumaEventID
       else { continue }
+      winnersByEvent[lumaEventID, default: []].append(winner)
+    }
 
-      // Fetch and cache existing guests for this event (once per event)
-      if !existingGuestsCache.keys.contains(lumaEventID) {
-        do {
-          let guests = try await LumaClient.getGuests(
-            eventID: lumaEventID,
-            client: req.client,
-            logger: req.logger
-          )
-          var emailToID: [String: String] = [:]
-          for guest in guests {
-            if let email = guest.user_email?.lowercased(), let id = guest.id {
-              emailToID[email] = id
-            }
-          }
-          existingGuestsCache[lumaEventID] = emailToID
-        } catch {
-          req.logger.error(
-            "Failed to fetch existing guests for event \(lumaEventID): \(error)")
-          existingGuestsCache[lumaEventID] = [:]
-        }
-      }
-
-      // Skip if guest already exists on Luma
-      if let guestID = existingGuestsCache[lumaEventID]?[winner.email.lowercased()] {
-        winner.lumaGuestID = guestID
-        try await winner.save(on: req.db)
-        skipped += 1
-        continue
-      }
-
-      // Fetch and cache the Standard ticket type for this event (once per event)
-      if !ticketTypeCache.keys.contains(lumaEventID) {
-        do {
-          let ticketTypes = try await LumaClient.getTicketTypes(
-            eventID: lumaEventID,
-            client: req.client,
-            logger: req.logger
-          )
-          if let standard = ticketTypes.first(where: { $0.name == "Standard" }) {
-            ticketTypeCache[lumaEventID] = standard.id
-          } else {
-            req.logger.error(
-              "No 'Standard' ticket type found for event \(lumaEventID)")
-            ticketTypeCache[lumaEventID] = nil as String?
-          }
-        } catch {
-          req.logger.error(
-            "Failed to fetch ticket types for event \(lumaEventID): \(error)")
-          ticketTypeCache[lumaEventID] = nil as String?
-        }
-      }
-
-      guard let ticketTypeID = ticketTypeCache[lumaEventID] ?? nil else {
-        errors += 1
-        continue
-      }
-
+    for (lumaEventID, eventWinners) in winnersByEvent {
+      // 1. Fetch existing guests to skip duplicates and sync DB
+      var existingEmails: [String: String] = [:]  // email -> guestID
       do {
-        let response = try await LumaClient.addGuestToEvent(
+        let guests = try await LumaClient.getGuests(
           eventID: lumaEventID,
-          email: winner.email,
-          name: winner.applicantName,
+          client: req.client,
+          logger: req.logger
+        )
+        for guest in guests {
+          if let email = guest.user_email?.lowercased(), let id = guest.id {
+            existingEmails[email] = id
+          }
+        }
+      } catch {
+        req.logger.error(
+          "Failed to fetch existing guests for event \(lumaEventID): \(error)")
+      }
+
+      // 2. Separate already-invited from new guests
+      var newWinners: [WorkshopApplication] = []
+      for winner in eventWinners {
+        if let guestID = existingEmails[winner.email.lowercased()] {
+          winner.lumaGuestID = guestID
+          try await winner.save(on: req.db)
+          skipped += 1
+        } else {
+          newWinners.append(winner)
+        }
+      }
+
+      guard !newWinners.isEmpty else { continue }
+
+      // 3. Fetch Standard ticket type for this event
+      let ticketTypeID: String
+      do {
+        let ticketTypes = try await LumaClient.getTicketTypes(
+          eventID: lumaEventID,
+          client: req.client,
+          logger: req.logger
+        )
+        guard let standard = ticketTypes.first(where: { $0.name == "Standard" }) else {
+          req.logger.error("No 'Standard' ticket type found for event \(lumaEventID)")
+          errors += newWinners.count
+          continue
+        }
+        ticketTypeID = standard.id
+      } catch {
+        req.logger.error(
+          "Failed to fetch ticket types for event \(lumaEventID): \(error)")
+        errors += newWinners.count
+        continue
+      }
+
+      // 4. Batch add all new guests in a single API call
+      let guestInputs = newWinners.map { LumaGuestInput(email: $0.email, name: $0.applicantName) }
+      do {
+        try await LumaClient.addGuestsToEvent(
+          eventID: lumaEventID,
+          guests: guestInputs,
           ticketTypeID: ticketTypeID,
           client: req.client,
           logger: req.logger
         )
-        winner.lumaGuestID = response.id
-        try await winner.save(on: req.db)
-        sent += 1
-        // Throttle to stay under Luma POST rate limit (100 req / 5 min)
-        try await Task.sleep(nanoseconds: 3_000_000_000)
       } catch {
-        req.logger.error("Failed to send ticket to \(winner.email): \(error)")
-        errors += 1
+        req.logger.error(
+          "Failed to batch-add \(guestInputs.count) guests to event \(lumaEventID): \(error)")
+        errors += newWinners.count
+        continue
+      }
+
+      // 5. Re-fetch guest list to resolve guest IDs for DB
+      do {
+        let updatedGuests = try await LumaClient.getGuests(
+          eventID: lumaEventID,
+          client: req.client,
+          logger: req.logger
+        )
+        var emailToID: [String: String] = [:]
+        for guest in updatedGuests {
+          if let email = guest.user_email?.lowercased(), let id = guest.id {
+            emailToID[email] = id
+          }
+        }
+        for winner in newWinners {
+          if let guestID = emailToID[winner.email.lowercased()] {
+            winner.lumaGuestID = guestID
+            try await winner.save(on: req.db)
+            sent += 1
+          } else {
+            req.logger.warning(
+              "Guest \(winner.email) not found in Luma after batch add for event \(lumaEventID)")
+            errors += 1
+          }
+        }
+      } catch {
+        req.logger.error(
+          "Failed to re-fetch guests after batch add for event \(lumaEventID): \(error)")
+        // Guests were added to Luma but we couldn't resolve IDs — count as sent
+        sent += newWinners.count
       }
     }
 


### PR DESCRIPTION
## Summary
- Lumaのゲスト一覧を事前取得し、既に招待済みのゲストをスキップして重複送信を防止
- `add-guests` APIの `guests` 配列を活用し、イベント単位で1リクエストにバッチ化してRate Limit（POST 100 req/5min）を回避
- 429レスポンス検出時は65秒待機して自動リトライ
- バッチ追加後にゲスト一覧を再取得し、`lumaGuestID` をDBに同期

## Test plan
- [ ] `cd Server && swift build` が成功すること
- [ ] `cd Server && swift test` が全テストパスすること
- [ ] Send Ticketsボタンで既存ゲストがスキップされること
- [ ] 新規ゲストがバッチで追加されること
- [ ] リダイレクトメッセージに sent/skipped/errors が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)