### PR TITLE
Set CFBundleName to "try! Tokyo" for macOS menu bar

### DIFF
--- a/App/App.xcodeproj/project.pbxproj
+++ b/App/App.xcodeproj/project.pbxproj
@@ -437,6 +437,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "try! Tokyo";
+				INFOPLIST_KEY_CFBundleName = "try! Tokyo";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 try! Swift Tokyo. All rights reserved.";
@@ -492,6 +493,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = App/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "try! Tokyo";
+				INFOPLIST_KEY_CFBundleName = "try! Tokyo";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.education";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2026 try! Swift Tokyo. All rights reserved.";


### PR DESCRIPTION
## Summary
- macOSのメニューバーにアプリ名が「App」と表示されていた問題を修正
- `INFOPLIST_KEY_CFBundleName = "try! Tokyo"` をDebug/Release両設定に追加
- `CFBundleName` が未設定だったため `PRODUCT_NAME` ("App") にフォールバックしていた

## Test plan
- [ ] macOS targetをビルドし、メニューバーのアプリ名が "try! Tokyo" と表示されることを確認
- [ ] iOS targetのビルドが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)