### PR TITLE
Replace gray background with purple border on speaker cards

### DIFF
--- a/Website/Sources/Components/TimetableComponent.swift
+++ b/Website/Sources/Components/TimetableComponent.swift
@@ -109,7 +109,7 @@ struct SessionDetailModal: HTML {
         if let speakers = session.speakers {
           ForEach(speakers) { speaker in
             SpeakerDetailComponent(speaker: speaker, language: language)
-              .background(.lightGray)
+              .border(.bootstrapPurple, width: 1)
               .cornerRadius(8)
               .margin(.bottom, .px(8))
           }


### PR DESCRIPTION
## Summary
- タイムテーブルモーダル内のスピーカーカードのグレー背景（`.background(.lightGray)`）を紫ボーダー（`.border(.bootstrapPurple, width: 1)`）に変更
- サイト全体のアクセントカラーである `.bootstrapPurple` に統一

## Test plan
- [ ] `cd Website && swift build` でビルド成功を確認
- [ ] Webサイトのタイムテーブルでセッション詳細モーダルを開き、スピーカーカードに紫のボーダーが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)