### PR TITLE
Fix android-run Makefile target with correct Skip plugin output path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ android-emulator:
 	fi
 
 android-run: android-build android-emulator
-	cd Android/.build/plugins/outputs/skipstone/AndroidApp/skipstone && ./gradlew installDebug
+	cd Android/.build/plugins/outputs/try-swift-tokyo-android/AndroidApp/skipstone && ./gradlew installDebug
 	adb shell am start -n tokyo.tryswift.android/.MainActivity


### PR DESCRIPTION
## Summary
- Fix `make android-run` failing with "No such file or directory" after successful `swift build`
- The Skip framework's skipstone plugin outputs to `.build/plugins/outputs/{package-name}/{ModuleName}/skipstone/`, not `.build/plugins/outputs/skipstone/{ModuleName}/skipstone/`
- Updated the path to use the actual package name `try-swift-tokyo-android` from `Android/Package.swift`

## Test plan
- [ ] Run `make android-run` with an Android emulator running
- [ ] Verify the Gradle build starts at the correct path
- [ ] Verify the app installs and launches on the emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)