### PR TITLE
Fix android-run Makefile target with correct Skip plugin output path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,5 @@ android-emulator:
 	fi
 
 android-run: android-build android-emulator
-	cd Android/.build/plugins/outputs/try-swift-tokyo-android/AndroidApp/skipstone && ./gradlew installDebug
+	cd Android/.build/plugins/outputs/android/AndroidApp/destination/skipstone && ./gradlew installDebug
 	adb shell am start -n tokyo.tryswift.android/.MainActivity


### PR DESCRIPTION
## Summary
- Fix the `android-run` Makefile target path to match the actual Skip plugin output directory
- Changed from `Android/.build/plugins/outputs/try-swift-tokyo-android/AndroidApp/skipstone` to `Android/.build/plugins/outputs/android/AndroidApp/destination/skipstone`

## Test plan
- [ ] Run `make android-build` and verify the output path exists
- [ ] Run `make android-run` and verify the app installs and launches on emulator

🤖 Generated with [Claude Code](https://claude.com/claude-code)