### PR TITLE
Fix videoDetail ifLet error by checking cancellation after async player call

### DIFF
--- a/iOS/Sources/VideoFeature/VideoPlayerView.swift
+++ b/iOS/Sources/VideoFeature/VideoPlayerView.swift
@@ -66,6 +66,7 @@ struct VideoPlayerView: View {
         try? await Task.sleep(for: .milliseconds(500))
         guard !Task.isCancelled else { break }
         if let time = try? await player.getCurrentTime() {
+          guard !Task.isCancelled else { break }
           onTimeUpdate(time.converted(to: .seconds).value)
         }
       }


### PR DESCRIPTION
## Summary

- Add `guard !Task.isCancelled` after `await player.getCurrentTime()` in `VideoPlayerView` to prevent sending `playerTimeUpdated` actions after the video detail sheet is dismissed and `state.videoDetail` is `nil`
- Fixes the TCA runtime warning: `An "ifLet" at "AppFeature/AppView.swift:266" received a presentation action when destination state was absent`

## Test plan

- [ ] Open a video detail sheet (iOS) or detail column (macOS)
- [ ] Let the video play for a few seconds so the polling loop is active
- [ ] Dismiss the sheet quickly
- [ ] Verify no `ifLet` runtime warning appears in the console

🤖 Generated with [Claude Code](https://claude.com/claude-code)