### PR TITLE
Update existing skills and add Skip/Playwright skills

### DIFF
--- a/.claude/skills/concurrency/SKILL.md
+++ b/.claude/skills/concurrency/SKILL.md
@@ -23,8 +23,15 @@ description: Definitive guide for Swift 6+ Concurrency, strictly enforcing Senda
 - Mark immutable structs/enums as `Sendable` (often implicit, but be explicit if public).
 - For classes, use `final` and `@unchecked Sendable` *only* if you are manually managing thread safety (locks/queues). Ideally, use `actor`.
 - **Closures:** Ensure closures passed between contexts are `@Sendable`.
+- TCA types: State and Reducer structs should conform to `Sendable`.
 
-## 4. Migration from Combine/Closures
+## 4. Observable Pattern
+
+- **Prefer `@Observable`** (Observation framework) over `ObservableObject` + `@Published`.
+- Pattern: `@Observable public final class ViewModel`.
+- Combine `@Observable` with `@MainActor` when accessing UI state from async contexts.
+
+## 5. Migration from Combine/Closures
 
 - Replace `DispatchQueue.main.async` with `await MainActor.run { ... }` or isolate the function itself.
 - Replace `Future`/`Promise` with direct `async throws` functions.
@@ -33,19 +40,23 @@ description: Definitive guide for Swift 6+ Concurrency, strictly enforcing Senda
 ## Example: Safe ViewModel
 
 ```swift
+@Observable
 @MainActor
-final class UserViewModel: ObservableObject {
-    @Published var users: [User] = []
+final class UserViewModel {
+    var users: [User] = []
 
-    // Dependencies should be Sendable
     private let client: APIClient
+
+    init(client: APIClient) {
+        self.client = client
+    }
 
     func load() async {
         do {
-            // 'await' suspends, allowing other work on MainActor if needed
             self.users = try await client.fetchUsers()
         } catch {
             print(error)
         }
     }
 }
+```

--- a/.claude/skills/ignite/SKILL.md
+++ b/.claude/skills/ignite/SKILL.md
@@ -7,36 +7,82 @@ description: Guidelines for building static sites using the Ignite Swift framewo
 
 You are an expert in using Ignite, the Swift static site generator.
 
-## 1. DSL Usage
+## 1. Pages
 
-- Use the result builder syntax for HTML generation (`Body`, `Head`, `Div`, `Section`).
-- Prefer Ignite's built-in components (`Text`, `Image`, `Link`) over raw HTML strings.
-- Use `.style(...)` modifiers for CSS styling rather than inline strings where possible.
+- Pages implement the `StaticPage` protocol.
+- Properties: `var title: String`, optional `var path: String`, `var description: String`.
+- Body: `var body: some HTML`.
+- Use `@Dependency(DataClient.self) var dataClient` for data loading.
+
+```swift
+struct Home: StaticPage {
+    var title = "try! Swift Tokyo"
+    @Dependency(DataClient.self) var dataClient
+
+    var body: some HTML {
+        Section {
+            Text("Welcome")
+                .font(.title1)
+        }
+    }
+}
+```
 
 ## 2. Components
 
-- Break complex UI into reusable `Component` structs.
-- Components must implement `var body: some HTML`.
-
-## 3. Themes & Layouts
-
-- Define a `MainTheme` implementing `Theme`.
-- Use `Page` protocol for content pages.
-
-## Example
+- Reusable components conform to `HTML` protocol.
+- Use `InlineElement` for inline content.
+- Body: `var body: some HTML`.
 
 ```swift
-struct MyPage: Page {
-    var title = "Home"
+struct SpeakerCard: HTML {
+    let speaker: Speaker
 
-    func body(context: PublishingContext) -> [any HTML] {
-        Text("Welcome to my site")
-            .font(.title1)
-            .margin(.top, 20)
-
-        Section {
-            Text("Content goes here")
-        }
-        .class("container")
+    var body: some HTML {
+        Text(speaker.name)
+            .font(.title3)
+            .fontWeight(.bold)
     }
 }
+```
+
+## 3. Layouts
+
+- Layouts implement the `Layout` protocol.
+- Body returns `some Document` (not `some HTML`).
+- Access page context via `@Environment(\.page)`.
+
+```swift
+struct MainLayout: Layout {
+    @Environment(\.page) private var currentPage
+
+    var body: some Document {
+        Head(for: currentPage)
+        Body {
+            content
+        }
+    }
+}
+```
+
+## 4. Site Configuration
+
+- `Site` protocol defines the overall site structure.
+- Properties: `titleSuffix`, `name`, `url`, `homePage`, `layout`, `darkTheme`, `favicon`.
+- `var staticPages: [any StaticPage]` lists all pages.
+
+## 5. Styling
+
+- Margin/padding: `.margin(.top, .px(20))`, `.padding(.all, .large)`.
+- Frame: `.frame(maxWidth: 230)`, `.frame(width: .percent(50))`.
+- Color: `.foregroundStyle(.bootstrapPurple)`, `.init(hex: "#FF0000")`.
+- Typography: `.font(.title1)`, `.fontWeight(.bold)`.
+- Full-width: `.ignorePageGutters()`.
+
+## 6. Interactive Components
+
+- `Modal(id:)` for modal dialogs, triggered by `ShowModal(id:)` / `DismissModal(id:)`.
+- `Grid` with `.columns(N)` for grid layouts.
+- `ZStack(alignment:)` for overlapping content.
+- `.onClick { ShowModal(id: "myModal") }` for click handlers.
+- `ForEach` / `InlineForEach` for iterating collections.

--- a/.claude/skills/playwright/SKILL.md
+++ b/.claude/skills/playwright/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: playwright
+description: Patterns for Playwright E2E testing with custom fixtures, role-based selectors, and assertion patterns.
+---
+
+# Playwright E2E Testing Guidelines
+
+## 1. Project Setup
+
+- Config: `e2e/playwright.config.ts`
+- Tests: `e2e/tests/`
+- Run: `cd e2e && npx playwright test`
+- Single project: chromium only
+- Timeouts: 60s test, 15s expect
+
+## 2. Custom Fixtures
+
+Extend `base` test with typed fixtures for multi-browser scenarios:
+
+```typescript
+import { test as base, expect, type Page } from "@playwright/test";
+
+export const test = base.extend<{ roomPage: Page; hostPage: Page }>({
+    roomPage: async ({ page }, use) => {
+        await page.goto("/");
+        await use(page);
+    },
+    hostPage: async ({ browser }, use) => {
+        const context = await browser.newContext();
+        const page = await context.newPage();
+        await page.goto("/host");
+        await use(page);
+        await page.context().close();
+    },
+});
+export { expect };
+```
+
+## 3. Selectors (prefer accessibility-based)
+
+- Role: `page.getByRole("button", { name: /english/i })`
+- Text: `page.getByText("Enter chat room code")`
+- Chaining: `page.getByText("Label").locator("..").getByRole("button")`
+- Filter: `page.getByRole("listitem").filter({ hasText: "Japanese" })`
+- Nth: `page.locator("input").nth(i)`
+- First: `.first()` to disambiguate multiple matches
+
+## 4. Assertions
+
+- Visibility: `await expect(element).toBeVisible({ timeout: 10_000 })`
+- Negated: `await expect(element).not.toBeVisible({ timeout: 10_000 })`
+- URL: `await expect(page).not.toHaveURL(/\/login/)`
+- Count: `expect(count).toBeGreaterThan(0)`
+- Text: `expect(text?.trim()).toBeTruthy()`
+
+## 5. Wait Patterns
+
+- Network idle: `await page.waitForLoadState("networkidle")`
+- Timeout: `await page.waitForTimeout(3_000)` (WebSocket propagation, animations)
+- Element: `await element.waitFor({ state: "visible", timeout: 15_000 })`
+- Graceful: `.isVisible().catch(() => false)` for optional elements
+
+## 6. Screenshots
+
+```typescript
+await page.screenshot({ path: "test-results/state.png" });
+await page.screenshot({ path: "test-results/full.png", fullPage: true });
+```
+
+## 7. Test Organization
+
+- Group: `test.describe("Feature - Aspect", () => { ... })`
+- Use fixture names: `async ({ roomPage: page }) => { ... }`
+- Import: `import { test, expect } from "./fixtures.js"` (note `.js` extension)

--- a/.claude/skills/skip/SKILL.md
+++ b/.claude/skills/skip/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: skip
+description: Guidelines for Android development using the Skip framework (Swift to Kotlin transpilation).
+---
+
+# Skip Framework Guidelines
+
+You are an expert in Skip, the Swift-to-Kotlin transpilation framework for Android.
+
+## 1. Architecture
+
+- Android uses `@Observable` ViewModels, NOT TCA reducers.
+- Pattern: `@Observable public final class FeatureViewModel`.
+- Direct mutable state properties (no actions/reducers).
+- Views use `@State private var viewModel = FeatureViewModel()`.
+
+```swift
+@Observable
+public final class AboutViewModel {
+    public var items: [AboutItem] = []
+
+    public func load() {
+        // Load data directly
+    }
+}
+```
+
+## 2. Conditional Compilation
+
+- Use `#if SKIP ... #else ... #endif` for platform-specific code.
+- Android-specific imports inside `#if SKIP` blocks.
+- Wrap previews in `#if !SKIP`.
+
+```swift
+#if SKIP
+import SkipUI
+#else
+import SwiftUI
+#endif
+```
+
+## 3. SwiftUI Compatibility
+
+Skip requires explicit type qualification. Always use full enum paths:
+- `HorizontalAlignment.leading` not `.leading`
+- `TextAlignment.leading` not `.leading`
+- `Edge.Set.horizontal` not `.horizontal`
+- `ToolbarItemPlacement.topBarTrailing` not `.topBarTrailing`
+- `NavigationBarItem.TitleDisplayMode.inline` not `.inline`
+- `CGFloat.infinity`, `Alignment.leading`, etc.
+
+## 4. Async Patterns
+
+- Use `Task { [weak self] in ... }` for async work in ViewModels.
+- Timer: `Task { while !Task.isCancelled { try? await Task.sleep(nanoseconds:) } }`.
+- Store `Task` references and call `.cancel()` for cleanup.
+
+## 5. Resource Loading
+
+- Use `Bundle.module.url(forResource:withExtension:)` for JSON data files.
+- Decoder: `JSONDecoder()` with `.iso8601` date strategy and `.convertFromSnakeCase` key strategy.
+
+## 6. Networking
+
+- Use `URLSession.shared.data(for:)` directly (not dependency-injected clients).
+- Manual JSON encoding/decoding for API requests.
+
+## Example
+
+```swift
+struct ScheduleScreen: View {
+    @State private var viewModel = ScheduleViewModel()
+
+    var body: some View {
+        NavigationStack {
+            List {
+                ForEach(viewModel.sessions, id: \.id) { session in
+                    Text(session.title)
+                }
+            }
+            .navigationTitle("Schedule")
+            #if SKIP
+            .navigationBarTitleDisplayMode(NavigationBarItem.TitleDisplayMode.inline)
+            #else
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+        }
+        .task {
+            viewModel.load()
+        }
+    }
+}
+```

--- a/.claude/skills/tca/SKILL.md
+++ b/.claude/skills/tca/SKILL.md
@@ -11,25 +11,52 @@ You are an expert in Point-Free's Composable Architecture. When writing or refac
 
 - ALWAYS use the `@Reducer` macro.
 - State and Action must be nested types within the Reducer struct.
-- Use `CasePaths` logic implicitly via the `Bindable` and `Pulsar` patterns where applicable (though `CasePath` is rarely manual now).
-- Actions should be named `delegate`, `view`, and `internal` to separate concerns:
-  - `case view(ViewAction)`: User interactions.
-  - `case delegate(DelegateAction)`: Communication with parent reducers.
+- State uses `@ObservableState` macro: `@ObservableState public struct State: Equatable`.
+- Actions should be separated into:
+  - `case view(View)`: User interactions (`@CasePathable public enum View`).
+  - `case delegate(Delegate)`: Communication with parent reducers.
   - `case internal(InternalAction)`: Side-effect results.
 
-## 2. Dependencies
+## 2. View Integration
 
-- Use the `@Dependency(\.clientName)` pattern.
+- Use `@ViewAction(for: Feature.self)` macro on view structs.
+- Store reference: `@Bindable var store: StoreOf<Feature>`.
+- Actions from views: `send(.actionName)` shorthand (provided by `@ViewAction`).
+- Child stores: `store.scope(state: \.child, action: \.child)`.
+
+## 3. Bindings
+
+- Conform Action to `BindableAction`: `enum Action: BindableAction, ViewAction`.
+- Add `case binding(BindingAction<State>)` to Action.
+- Add `BindingReducer()` in the reducer body composition.
+- Two-way binding in views: `$store.searchText`, `$store.isPresented`.
+
+## 4. Navigation
+
+**Stack-based:**
+- State: `var path = StackState<Path.State>()`.
+- Action: `case path(StackActionOf<Path>)`.
+- Define: `@Reducer public enum Path { case detail(ScheduleDetail) }`.
+- Reducer body: `.forEach(\.path, action: \.path)`.
+- View: `NavigationStack(path: $store.scope(state: \.path, action: \.path))`.
+
+**Presentation (sheets/alerts):**
+- State: `@Presents var destination: Destination.State?`.
+- Reducer body: `.ifLet(\.$destination, action: \.destination)`.
+- View: `.sheet(item: $store.scope(state: \.destination?.detail, action: \.destination.detail))`.
+
+## 5. Dependencies
+
+- Use the `@Dependency(\.clientName)` or `@Dependency(ClientType.self)` pattern.
 - NEVER reach out to global singletons.
 - Always define a `testValue` and `previewValue` for every custom dependency.
 
-## 3. Effects & Concurrency
+## 6. Effects & Concurrency
 
 - Use `.run { send in ... }` for asynchronous side effects.
-- Avoid `Effect.task` unless strictly necessary for simple bridging.
 - Ensure all loops in effects handle cancellation properly via `.cancellable(id:)`.
 
-## 4. Testing
+## 7. Testing
 
 - Use `TestStore` for all logic verification.
 - Enforce exhaustivity: `store.exhaustivity = .on`.
@@ -43,26 +70,45 @@ struct Feature {
     @ObservableState
     struct State: Equatable {
         var count = 0
+        var isLoading = false
     }
-    enum Action {
-        case view(ViewAction)
-        case internal(InternalAction)
 
-        enum ViewAction {
+    enum Action: BindableAction, ViewAction {
+        case binding(BindingAction<State>)
+        case view(View)
+        case delegate(Delegate)
+
+        @CasePathable
+        enum View {
             case incrementButtonTapped
         }
-        enum InternalAction {
-            case loadResponse(Int)
+        enum Delegate: Equatable {
+            case countChanged(Int)
         }
     }
 
     var body: some ReducerOf<Self> {
+        BindingReducer()
         Reduce { state, action in
             switch action {
             case .view(.incrementButtonTapped):
                 state.count += 1
+                return .send(.delegate(.countChanged(state.count)))
+            case .binding, .delegate:
                 return .none
             }
         }
     }
 }
+
+@ViewAction(for: Feature.self)
+struct FeatureView: View {
+    @Bindable var store: StoreOf<Feature>
+
+    var body: some View {
+        Button("Increment") {
+            send(.incrementButtonTapped)
+        }
+    }
+}
+```

--- a/.claude/skills/vapor/SKILL.md
+++ b/.claude/skills/vapor/SKILL.md
@@ -8,21 +8,49 @@ description: Expert guidance for Vapor 4+ development, focusing on async/await, 
 ## 1. Concurrency
 
 - ALWAYS use Swift Concurrency (`async`/`await`) over `EventLoopFuture`.
-- Use `req.application.asyncController` patterns if using custom executors, but standard `async` route handlers are preferred.
+- All route handlers MUST be annotated with `@Sendable`.
 
 ## 2. Controllers & Routing
 
 - Organize routes into `RouteCollection` conformances.
 - Do not put logic in `routes.swift`; delegate immediately to a Controller.
 - Group routes by feature (e.g., `UsersController`, `AuthController`).
+- Register controllers: `app.register(collection: MyController())`.
+- API versioning: `app.grouped("api", "v1")`.
 
-## 3. Fluent (Database)
+## 3. Middleware
+
+- Use `AsyncMiddleware` for custom middleware:
+
+```swift
+struct AuthMiddleware: AsyncMiddleware {
+    func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
+        let payload = try await request.jwt.verify(as: UserJWTPayload.self)
+        request.auth.login(payload)
+        return try await next.respond(to: request)
+    }
+}
+```
+
+- Apply to route groups: `routes.grouped(AuthMiddleware())`.
+
+## 4. Fluent (Database)
 
 - Use `@Parent` and `@Children` property wrappers correctly.
-- Always use `DTOs` (Data Transfer Objects) implementation `Content` for API requests/responses. NEVER return a Fluent Model directly to the client.
+- Always use DTOs (Data Transfer Objects) implementing `Content` for API requests/responses. NEVER return a Fluent Model directly to the client.
 - Run migrations via `app.migrations.add(...)`.
+- Filter with `$` syntax: `.filter(\.$deviceID == id)`.
 
-## 4. Environment
+**Direct SQL Access** (for complex queries not expressible via Fluent):
+
+```swift
+guard let sql = req.db as? any SQLDatabase else {
+    throw Abort(.internalServerError)
+}
+let rows = try await sql.raw("SELECT ... FROM \(raw: Model.schema)").all(decoding: SomeRow.self)
+```
+
+## 5. Environment
 
 - Use `Environment.get("KEY")` for configuration.
 - Support `Production` vs `Development` modes explicitly in `configure.swift`.
@@ -30,13 +58,16 @@ description: Expert guidance for Vapor 4+ development, focusing on async/await, 
 ## Example Route
 
 ```swift
-func boot(routes: RoutesBuilder) throws {
-    let users = routes.grouped("users")
-    users.get(use: index)
-}
+struct UsersController: RouteCollection {
+    func boot(routes: RoutesBuilder) throws {
+        let users = routes.grouped("users")
+        users.get(use: index)
+    }
 
-@Sendable
-func index(req: Request) async throws -> [UserDTO] {
-    let users = try await User.query(on: req.db).all()
-    return users.map { $0.toDTO() }
+    @Sendable
+    func index(req: Request) async throws -> [UserDTO] {
+        let users = try await User.query(on: req.db).all()
+        return users.map { $0.toDTO() }
+    }
 }
+```


### PR DESCRIPTION
## Summary
- **Updated 4 existing skills** (ignite, tca, vapor, concurrency) to match actual codebase patterns
- **Added 2 new skills**: `/skip` (Android/Skip framework) and `/playwright` (E2E testing)

### Updated Skills
- **Ignite**: `Page` → `StaticPage`, `[any HTML]` → `some HTML`, added Layout/Site protocols, styling/interactive components
- **TCA**: Added `@ViewAction`, `@Bindable`, stack navigation, presentation, bindings, `@CasePathable`
- **Vapor**: Added `AsyncMiddleware`, `@Sendable`, direct SQL access, controller registration
- **Concurrency**: Added `@Observable` pattern, updated example from `ObservableObject` to `@Observable`

### New Skills
- **Skip** (`/skip`): `@Observable` ViewModel pattern, `#if SKIP` conditional compilation, SwiftUI compatibility rules
- **Playwright** (`/playwright`): Custom fixtures, accessibility-based selectors, assertion/wait patterns

## Test plan
- [ ] Verify skills appear in Claude Code skill list
- [ ] Test each skill trigger (`/tca`, `/vapor`, `/ignite`, `/concurrency`, `/skip`, `/playwright`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)