### PR TITLE
Fix trailing comma in 2026-sponsors.json breaking Luma sync workflow

### DIFF
--- a/DataClient/Sources/DataClient/Resources/2026-sponsors.json
+++ b/DataClient/Sources/DataClient/Resources/2026-sponsors.json
@@ -114,7 +114,7 @@
             "imageName": "Sponsor/2026/2026_Mirrative",
             "link": "https://www.mirrativ.co.jp/en",
             "japanese_link": "https://www.mirrativ.co.jp/"
-        },
+        }
     ],
     "diversity": [
         {


### PR DESCRIPTION
## Summary
- Remove illegal trailing comma in `bronze` array of `2026-sponsors.json` (line 117)
- This was causing `JSONDecodeError` in the "Sync Individual Sponsors from Luma" scheduled workflow
- Introduced in PR #293 when adding 株式会社ミラティブ as a bronze sponsor

## Test plan
- [x] Verified JSON is valid with `python3 -m json.tool`

🤖 Generated with [Claude Code](https://claude.com/claude-code)