### PR TITLE
Fix timetable speaker images not rendering in table cells

### DIFF
--- a/Website/Sources/Components/TimetableComponent.swift
+++ b/Website/Sources/Components/TimetableComponent.swift
@@ -7,6 +7,7 @@ struct TimetableComponent: HTML {
   let language: SupportedLanguage
   var accentColor: Color = .bootstrapPurple
   private let imageSize = 50
+  private let imageGap = 4
 
   var body: some HTML {
     Text(conference.title)
@@ -49,8 +50,8 @@ struct TimetableComponent: HTML {
                   .style(.display, "flex")
                   .style(.flexWrap, "wrap")
                   .style(.justifyContent, "center")
-                  .style(.gap, "4px")
-                  .style(.maxWidth, "\(size * 2 + 4)px")
+                  .style(.gap, "\(imageGap)px")
+                  .style(.maxWidth, "\(size * 2 + imageGap)px")
                 } else {
                   Image.defaultImage
                     .resizable()


### PR DESCRIPTION
## Summary
- Replace `CenterAlignedGrid` with CSS flexbox layout for speaker images in the timetable
- Ignite's `Grid` + `ForEach` fails to render content inside `Table` > `Row` > `Column`, producing empty `<div>` containers with no `<img>` tags
- Using a `Section` with a `for` loop and flexbox styling (`flex-wrap` + `justify-content: center`) correctly renders speaker images with the iOS app's 2-column centered layout pattern

## Test plan
- [ ] `cd Website && swift build` passes
- [ ] `cd Website && swift run Website` generates HTML with speaker images (`/images/from_app/`) in the timetable section
- [ ] Timetable displays speaker images at correct sizes (50px / 36px / 28px / 22px)
- [ ] Multi-speaker sessions show 2-column wrap layout (e.g., 3 speakers → 2 top + 1 centered below)
- [ ] Title column alignment is consistent across all rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)