### PR TITLE
Fix macOS video player fullscreen rendering at small size

### DIFF
--- a/iOS/Sources/VideoFeature/VideoPlayerView.swift
+++ b/iOS/Sources/VideoFeature/VideoPlayerView.swift
@@ -71,5 +71,19 @@ struct VideoPlayerView: View {
         }
       }
     }
+    #if os(macOS)
+      .onReceive(player.fullscreenStatePublisher.receive(on: DispatchQueue.main)) { state in
+        if state.isFullscreen {
+          Task {
+            try? await player.evaluate(
+              javaScript: .youTubePlayer(
+                functionName: "setSize",
+                parameters: ["screen.width", "screen.height"]
+              )
+            )
+          }
+        }
+      }
+    #endif
   }
 }


### PR DESCRIPTION
## Summary
- When entering YouTube fullscreen on macOS, the player's internal size remained constrained by the SwiftUI `aspectRatio` modifier, resulting in a tiny video on a black fullscreen background
- Subscribe to `fullscreenStatePublisher` and resize the player to screen dimensions via JavaScript when fullscreen is detected

## Test plan
- [ ] Open a video on macOS and click the YouTube fullscreen button
- [ ] Verify the video fills the entire screen in fullscreen mode
- [ ] Exit fullscreen and verify the player returns to its normal constrained size

🤖 Generated with [Claude Code](https://claude.com/claude-code)