### PR TITLE
Disable multiple windows on iPad to prevent TCA state desync

### DIFF
--- a/App/App/Info.plist
+++ b/App/App/Info.plist
@@ -14,5 +14,10 @@
 		<string>remote-notification</string>
 		<string>audio</string>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+	</dict>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
- Disable multiple window support on iPad by setting `UIApplicationSupportsMultipleScenes = false` in Info.plist
- When Split View opens two app windows, each gets an independent TCA Store, causing state divergence
- Sharing a single Store would also sync navigation state across windows, which is undesirable

Closes #49

## Test plan
- [ ] Build the app targeting iPad simulator
- [ ] Verify that Split View no longer allows opening a second app window
- [ ] Confirm the app still works correctly in full-screen mode on iPad

🤖 Generated with [Claude Code](https://claude.com/claude-code)