### PR TITLE
Use production LiveTranslation SDK environment in all builds

### DIFF
--- a/iOS/Sources/LiveTranslationFeature/LiveTranslationServiceClient.swift
+++ b/iOS/Sources/LiveTranslationFeature/LiveTranslationServiceClient.swift
@@ -61,11 +61,7 @@ extension LiveTranslationServiceClient: DependencyKey {
           if ref.store == nil {
             ref.store = ChatAudienceStore()
           }
-          #if DEBUG
-            LiveTranslationSDKConfiguration.configure(environment: .development)
-          #else
-            LiveTranslationSDKConfiguration.configure(environment: .production)
-          #endif
+          LiveTranslationSDKConfiguration.configure(environment: .production)
           ref.store?.connect(interactionKey: interactionKey, dstLangCode: dstLangCode)
         }
       },


### PR DESCRIPTION
## Summary
- Remove `#if DEBUG` environment switching in `LiveTranslationServiceClient` and always use `.production`
- The Flitto account can only access the production server, so development builds were failing

## Test plan
- [ ] Verify LiveTranslation works in DEBUG builds with the Flitto production account

Closes #421

🤖 Generated with [Claude Code](https://claude.com/claude-code)