### PR TITLE
Fix missing workshops and hackathons for past years in iOS app

### DIFF
--- a/iOS/Sources/ScheduleFeature/Schedule.swift
+++ b/iOS/Sources/ScheduleFeature/Schedule.swift
@@ -133,7 +133,12 @@ public struct Schedule {
               Result {
                 let day1 = try dataClient.fetchDay1(year)
                 let day2 = try dataClient.fetchDay2(year)
-                let day3 = try? dataClient.fetchDay3(year) ?? dataClient.fetchWorkshop(year)
+                let day3: Conference?
+                do {
+                  day3 = try dataClient.fetchDay3(year)
+                } catch is DataClientError {
+                  day3 = try? dataClient.fetchWorkshop(year)
+                }
                 let videos = (try? dataClient.fetchVideos(year)) ?? []
                 return .init(day1: day1, day2: day2, day3: day3, videos: videos)
               })),


### PR DESCRIPTION
## Summary
- Fall back to `fetchWorkshop` when `fetchDay3` is unavailable for years that store workshop/hackathon data in separate JSON files (2017, 2018, 2019, 2024)
- Include workshop data in the all-sessions search index so past workshops are discoverable via search
- Aligns iOS app behavior with the existing website implementation

## Test plan
- [ ] Select years 2017, 2018, 2019, 2024 in the iOS app year picker — Day 3 tab should now appear with workshop/hackathon content
- [ ] Verify 2025/2026 Day 3 still loads correctly (no regression)
- [ ] Verify search finds sessions from past workshop/hackathon days
- [ ] Run `cd DataClient && swift test` — all 26 PastEventDecodingTests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)