### PR TITLE
:apple: Add macOS support

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -31,6 +31,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Setup Swift
+        uses: swift-actions/setup-swift@364295d9c23900ce04d4e5cc708387921b4e50f9 # v3
+        with:
+          swift-version: "6.3"
+          skip-verify-signature: true
+
       - name: Build for macOS
         run: |
           cd App

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -31,11 +31,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Setup Swift
-        uses: swift-actions/setup-swift@364295d9c23900ce04d4e5cc708387921b4e50f9 # v3
-        with:
-          swift-version: "6.3"
-          skip-verify-signature: true
+      - name: Select latest Xcode
+        run: |
+          LATEST_XCODE=$(ls -d /Applications/Xcode*.app | sort -V | tail -1)
+          echo "Selecting $LATEST_XCODE"
+          sudo xcode-select -s "$LATEST_XCODE"
+          xcodebuild -version
+          swift --version
 
       - name: Build for macOS
         run: |

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -1,0 +1,43 @@
+name: Build macOS
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "App/**"
+      - "iOS/**"
+      - "SharedModels/**"
+      - "DataClient/**"
+      - "Shared/**"
+      - ".github/workflows/build-macos.yml"
+  push:
+    paths:
+      - "App/**"
+      - "iOS/**"
+      - "SharedModels/**"
+      - "DataClient/**"
+      - "Shared/**"
+      - ".github/workflows/build-macos.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build macOS
+    runs-on: macos-26
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Build for macOS
+        run: |
+          cd App
+          xcodebuild build \
+            -project App.xcodeproj \
+            -scheme App \
+            -destination 'platform=macOS' \
+            -skipMacroValidation \
+            -skipPackagePluginValidation \
+            CODE_SIGNING_ALLOWED=NO

--- a/App/App/App.swift
+++ b/App/App/App.swift
@@ -14,6 +14,12 @@ struct ConferenceApp: App {
     WindowGroup {
       AppView(store: store)
     }
+    #if os(macOS)
+      .defaultSize(width: 1100, height: 700)
+      .commands {
+        SidebarCommands()
+      }
+    #endif
     #if os(macOS) || os(visionOS)
       Window("Transcript", id: "transcript") {
         TranscriptWindowView(


### PR DESCRIPTION
## Summary
- macOS ビルドが既に通ることを検証済み（コード変更なしでコンパイル成功）
- メインウィンドウのデフォルトサイズ（1100x700）と `SidebarCommands` を追加
- macOS ビルド用の CI ワークフロー（`build-macos.yml`）を追加

## Changes
- `App/App/App.swift`: macOS 向けに `.defaultSize(width: 1100, height: 700)` と `.commands { SidebarCommands() }` を追加
- `.github/workflows/build-macos.yml`: `App/`, `iOS/`, `SharedModels/`, `DataClient/`, `Shared/` の変更時に macOS ビルドを実行する CI

## Test plan
- [x] ローカルで `xcodebuild build -scheme App -destination 'platform=macOS'` が成功することを確認
- [ ] CI の macOS ビルドが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)