### PR TITLE
Fix cross-subdomain auth and add Organizer nav link

### DIFF
--- a/CfPWeb/Public/scripts/app.js
+++ b/CfPWeb/Public/scripts/app.js
@@ -106,6 +106,10 @@
     }
   }
 
+  function isJapanese() {
+    return window.location.pathname.indexOf("/ja") === 0;
+  }
+
   function updateAuthState(user) {
     var authStatus = document.getElementById("auth-status");
     var loginButton = document.getElementById("login-button");
@@ -115,6 +119,22 @@
     var signedInCards = document.querySelectorAll("[data-auth-signed-in-card]");
 
     updatePageCopy(user);
+
+    // Dynamically show/hide Organizer nav link based on admin role
+    var nav = document.querySelector(".topbar-panel .nav");
+    var existingOrgLink = document.getElementById("organizer-nav-link");
+    if (user && user.role === "admin") {
+      if (!existingOrgLink && nav) {
+        var link = document.createElement("a");
+        link.id = "organizer-nav-link";
+        link.href = isJapanese() ? "/ja/organizer/proposals" : "/organizer";
+        link.className = "nav-link";
+        link.textContent = isJapanese() ? "運営向け" : "Organizer";
+        nav.appendChild(link);
+      }
+    } else {
+      if (existingOrgLink) existingOrgLink.remove();
+    }
 
     if (user) {
       if (authStatus) {

--- a/Server/DEPLOYMENT.md
+++ b/Server/DEPLOYMENT.md
@@ -52,8 +52,14 @@
    fly secrets set GITHUB_ORG="tryswift" --app tryswift-api-prod
    fly secrets set GITHUB_TEAM="tokyo" --app tryswift-api-prod
 
-   # Callback URL (update after deployment)
-   fly secrets set GITHUB_CALLBACK_URL="https://tryswift-api-prod.fly.dev/api/v1/auth/github/callback" --app tryswift-api-prod
+   # Frontend URL (for cookie domain and redirect)
+   fly secrets set FRONTEND_URL="https://cfp.tryswift.jp" --app tryswift-api-prod
+
+   # Production environment (enables Secure cookies)
+   fly secrets set APP_ENV="production" --app tryswift-api-prod
+
+   # Callback URL
+   fly secrets set GITHUB_CALLBACK_URL="https://api.tryswift.jp/api/v1/auth/github/callback" --app tryswift-api-prod
    ```
 
 ### Deploy
@@ -93,7 +99,7 @@ fly ssh console --app tryswift-api-prod
 2. Create a new OAuth App:
    - **Application name**: trySwift API
    - **Homepage URL**: <https://tryswift.jp>
-   - **Authorization callback URL**: <https://tryswift-api-prod.fly.dev/api/v1/auth/github/callback>
+   - **Authorization callback URL**: <https://api.tryswift.jp/api/v1/auth/github/callback>
 3. Copy the Client ID and Client Secret to Fly.io secrets
 
 ## Environment Variables
@@ -105,6 +111,9 @@ fly ssh console --app tryswift-api-prod
 | `GITHUB_CLIENT_ID` | GitHub OAuth App Client ID | Yes |
 | `GITHUB_CLIENT_SECRET` | GitHub OAuth App Client Secret | Yes |
 | `GITHUB_CALLBACK_URL` | OAuth callback URL | Yes |
+| `FRONTEND_URL` | Frontend URL for cookie domain (e.g., `https://cfp.tryswift.jp`) | Yes |
+| `APP_ENV` | Set to `production` for secure cookies | Yes |
+| `API_BASE_URL` | API server URL (e.g., `https://api.tryswift.jp`) | No |
 | `GITHUB_ORG` | GitHub organization name (default: tryswift) | No |
 | `GITHUB_TEAM` | Team slug for admin access (default: tokyo) | No |
 | `GITHUB_ORG_NAME` | Legacy alias for `GITHUB_ORG` | No |

--- a/Server/Sources/Server/Controllers/AuthController.swift
+++ b/Server/Sources/Server/Controllers/AuthController.swift
@@ -442,6 +442,8 @@ struct AuthController: RouteCollection {
     response.headers.replaceOrAdd(name: .location, value: returnTo)
 
     // Set HTTP-only cookie for authentication
+    // Use parent domain (.tryswift.jp) so the cookie is shared across subdomains
+    // (api.tryswift.jp and cfp.tryswift.jp are same-site, so SameSite=Lax works)
     let cookieDomain = Self.getCookieDomain()
     let isSecure = Environment.get("APP_ENV") == "production"
     response.cookies["auth_token"] = HTTPCookies.Value(
@@ -452,19 +454,18 @@ struct AuthController: RouteCollection {
       path: "/",
       isSecure: isSecure,
       isHTTPOnly: true,
-      sameSite: HTTPCookies.SameSitePolicy.none
+      sameSite: .lax
     )
 
-    // Also set username cookie (not HTTP-only, for display purposes)
+    // Username cookie kept host-scoped (no domain) for minimal exposure
     response.cookies["auth_username"] = HTTPCookies.Value(
       string: user.username,
       expires: Date().addingTimeInterval(86400 * 7),
       maxAge: 86400 * 7,
-      domain: cookieDomain,
       path: "/",
       isSecure: isSecure,
       isHTTPOnly: false,
-      sameSite: HTTPCookies.SameSitePolicy.none
+      sameSite: .lax
     )
 
     return response
@@ -481,7 +482,7 @@ struct AuthController: RouteCollection {
     }
 
     // For tryswift.jp domains, use .tryswift.jp to allow subdomains
-    if host.hasSuffix("tryswift.jp") {
+    if host == "tryswift.jp" || host.hasSuffix(".tryswift.jp") {
       return ".tryswift.jp"
     }
 
@@ -594,17 +595,16 @@ struct AuthController: RouteCollection {
       path: "/",
       isSecure: isSecure,
       isHTTPOnly: true,
-      sameSite: HTTPCookies.SameSitePolicy.none
+      sameSite: .lax
     )
     response.cookies["auth_username"] = HTTPCookies.Value(
       string: "",
       expires: Date(timeIntervalSince1970: 0),
       maxAge: 0,
-      domain: cookieDomain,
       path: "/",
       isSecure: isSecure,
       isHTTPOnly: false,
-      sameSite: HTTPCookies.SameSitePolicy.none
+      sameSite: .lax
     )
     return response
   }

--- a/Server/Sources/Server/Controllers/AuthController.swift
+++ b/Server/Sources/Server/Controllers/AuthController.swift
@@ -427,7 +427,7 @@ struct AuthController: RouteCollection {
 
     // 10. Set secure HTTP-only cookie and redirect to frontend
     // Use returnTo from state if provided, otherwise default to login page
-    let returnTo = statePayload.returnTo ?? "/login"
+    let returnTo = statePayload.returnTo ?? Self.frontendURL
 
     req.logger.info(
       "OAuth flow completed, redirecting",

--- a/Server/Sources/Server/Controllers/AuthController.swift
+++ b/Server/Sources/Server/Controllers/AuthController.swift
@@ -442,14 +442,17 @@ struct AuthController: RouteCollection {
     response.headers.replaceOrAdd(name: .location, value: returnTo)
 
     // Set HTTP-only cookie for authentication
+    let cookieDomain = Self.getCookieDomain()
+    let isSecure = Environment.get("APP_ENV") == "production"
     response.cookies["auth_token"] = HTTPCookies.Value(
       string: token,
       expires: Date().addingTimeInterval(86400 * 7),  // 7 days
       maxAge: 86400 * 7,
+      domain: cookieDomain,
       path: "/",
-      isSecure: Environment.get("APP_ENV") == "production",
+      isSecure: isSecure,
       isHTTPOnly: true,
-      sameSite: .lax
+      sameSite: HTTPCookies.SameSitePolicy.none
     )
 
     // Also set username cookie (not HTTP-only, for display purposes)
@@ -457,10 +460,11 @@ struct AuthController: RouteCollection {
       string: user.username,
       expires: Date().addingTimeInterval(86400 * 7),
       maxAge: 86400 * 7,
+      domain: cookieDomain,
       path: "/",
-      isSecure: Environment.get("APP_ENV") == "production",
+      isSecure: isSecure,
       isHTTPOnly: false,
-      sameSite: .lax
+      sameSite: HTTPCookies.SameSitePolicy.none
     )
 
     return response
@@ -580,23 +584,27 @@ struct AuthController: RouteCollection {
   @Sendable
   func logout(req: Request) async throws -> Response {
     let response = Response(status: .ok)
+    let cookieDomain = Self.getCookieDomain()
+    let isSecure = Environment.get("APP_ENV") == "production"
     response.cookies["auth_token"] = HTTPCookies.Value(
       string: "",
       expires: Date(timeIntervalSince1970: 0),
       maxAge: 0,
+      domain: cookieDomain,
       path: "/",
-      isSecure: Environment.get("APP_ENV") == "production",
+      isSecure: isSecure,
       isHTTPOnly: true,
-      sameSite: .lax
+      sameSite: HTTPCookies.SameSitePolicy.none
     )
     response.cookies["auth_username"] = HTTPCookies.Value(
       string: "",
       expires: Date(timeIntervalSince1970: 0),
       maxAge: 0,
+      domain: cookieDomain,
       path: "/",
-      isSecure: Environment.get("APP_ENV") == "production",
+      isSecure: isSecure,
       isHTTPOnly: false,
-      sameSite: .lax
+      sameSite: HTTPCookies.SameSitePolicy.none
     )
     return response
   }


### PR DESCRIPTION
## Summary
- **Organizer nav link**: Dynamically show "Organizer" / "運営向け" navigation link for admin users after login via JavaScript
- **Auth returnTo fix**: Change OAuth callback fallback redirect from relative `/login` (→ `api.tryswift.jp/login`, broken) to `FRONTEND_URL` (→ `cfp.tryswift.jp`)
- **Cookie domain fix**: Set `auth_token` cookie domain to `.tryswift.jp` for cross-subdomain sharing between `api.tryswift.jp` and `cfp.tryswift.jp`
- **Deployment docs**: Add `FRONTEND_URL`, `APP_ENV`, `API_BASE_URL` to required env vars; update callback URLs from `fly.dev` to `api.tryswift.jp`
- **CI/CD**: Add CfPWeb deploy workflow (Cloudflare Pages), rename API server workflows, clean up legacy fly.toml files

## Post-merge manual steps
```bash
fly secrets set FRONTEND_URL="https://cfp.tryswift.jp" --app tryswift-api-prod
fly secrets set APP_ENV="production" --app tryswift-api-prod
fly secrets set GITHUB_CALLBACK_URL="https://api.tryswift.jp/api/v1/auth/github/callback" --app tryswift-api-prod
```
Also update the GitHub OAuth App callback URL to `https://api.tryswift.jp/api/v1/auth/github/callback`.

## Test plan
- [ ] `cd Server && swift test` passes (94 tests)
- [ ] After deploy, login on `cfp.tryswift.jp` with GitHub → Organizer nav link appears for admin users
- [ ] Navigate to `/organizer` → proposals list loads correctly
- [ ] Non-admin users do not see the Organizer link
- [ ] Logout clears auth state and removes the Organizer link

🤖 Generated with [Claude Code](https://claude.com/claude-code)