### PR TITLE
Restore Organizer content in CfPWeb

### DIFF
--- a/CfPWeb/Public/scripts/app.js
+++ b/CfPWeb/Public/scripts/app.js
@@ -1708,7 +1708,11 @@
       populateSelect("organizer-editor-conference-id", state.conferences, null, "id", "displayName");
       updateExportLinks();
     } catch (error) {
-      showStatus("organizer-status", error.message, "error");
+      if (document.getElementById("organizer-status")) {
+        showStatus("organizer-status", error.message, "error");
+      } else {
+        console.error("[organizer] shell bootstrap failed:", error);
+      }
     }
   }
 

--- a/CfPWeb/Public/scripts/app.js
+++ b/CfPWeb/Public/scripts/app.js
@@ -1697,34 +1697,7 @@
     }
   }
 
-  async function bootstrapOrganizerPage() {
-    var createForm = document.getElementById("organizer-create-form");
-    var refreshButton = document.getElementById("organizer-refresh");
-    var filter = document.getElementById("organizer-conference-filter");
-    var list = document.getElementById("organizer-proposals");
-    var lookupButton = document.getElementById("organizer-lookup-button");
-    var importForm = document.getElementById("organizer-import-form");
-    var slotForm = document.getElementById("organizer-slot-form");
-    var slotList = document.getElementById("organizer-slot-list");
-    var slotFilter = document.getElementById("organizer-slot-conference-filter");
-    var slotEditorForm = document.getElementById("organizer-slot-editor-form");
-    var slotEditorResetButton = document.getElementById("organizer-slot-editor-reset");
-    var slotReorderButton = document.getElementById("organizer-slot-reorder-button");
-    var editorForm = document.getElementById("organizer-editor-form");
-    var editorResetButton = document.getElementById("organizer-editor-reset");
-    var deleteProposalButton = document.getElementById("organizer-delete-proposal-button");
-    var workshopRefreshButton = document.getElementById("organizer-workshops-refresh");
-    var workshopList = document.getElementById("organizer-workshops-list");
-    var workshopFilter = document.getElementById("organizer-workshop-filter");
-    var workshopApplicationsRefreshButton = document.getElementById("organizer-workshop-applications-refresh");
-    var workshopApplicationsList = document.getElementById("organizer-workshop-applications-list");
-    var workshopLotteryButton = document.getElementById("organizer-workshop-lottery-button");
-    var workshopSendTicketsButton = document.getElementById("organizer-workshop-send-tickets-button");
-    var workshopResultsRefreshButton = document.getElementById("organizer-workshop-results-refresh");
-    if (!createForm || !refreshButton || !filter || !list || !lookupButton || !importForm || !slotForm || !slotList || !slotFilter || !slotEditorForm || !slotEditorResetButton || !slotReorderButton || !editorForm || !editorResetButton || !deleteProposalButton || !workshopRefreshButton || !workshopList || !workshopFilter || !workshopApplicationsRefreshButton || !workshopApplicationsList || !workshopLotteryButton || !workshopSendTicketsButton || !workshopResultsRefreshButton) return;
-    wireWorkshopToggle(createForm, "talkDuration", "organizer-create-workshop-section");
-    wireWorkshopToggle(editorForm, "talkDuration", "organizer-edit-workshop-section");
-
+  async function bootstrapOrganizerShell() {
     try {
       await loadAllConferences();
       populateSelect("organizer-conference-id", state.conferences, null, "id", "displayName");
@@ -1737,19 +1710,29 @@
     } catch (error) {
       showStatus("organizer-status", error.message, "error");
     }
+  }
+
+  async function bootstrapOrganizerProposalsSection() {
+    var createForm = document.getElementById("organizer-create-form");
+    var refreshButton = document.getElementById("organizer-refresh");
+    var filter = document.getElementById("organizer-conference-filter");
+    var list = document.getElementById("organizer-proposals");
+    var lookupButton = document.getElementById("organizer-lookup-button");
+    var importForm = document.getElementById("organizer-import-form");
+    var editorForm = document.getElementById("organizer-editor-form");
+    var editorResetButton = document.getElementById("organizer-editor-reset");
+    var deleteProposalButton = document.getElementById("organizer-delete-proposal-button");
+    if (!createForm || !refreshButton || !filter || !list || !lookupButton || !importForm || !editorForm || !editorResetButton || !deleteProposalButton) return;
+
+    wireWorkshopToggle(createForm, "talkDuration", "organizer-create-workshop-section");
+    wireWorkshopToggle(editorForm, "talkDuration", "organizer-edit-workshop-section");
 
     refreshButton.addEventListener("click", refreshOrganizerProposals);
     filter.addEventListener("change", function () {
       refreshOrganizerProposals();
       updateExportLinks();
     });
-    slotFilter.addEventListener("change", refreshOrganizerSlots);
-    workshopRefreshButton.addEventListener("click", refreshOrganizerWorkshops);
-    workshopApplicationsRefreshButton.addEventListener("click", refreshOrganizerWorkshopApplications);
-    workshopResultsRefreshButton.addEventListener("click", refreshOrganizerWorkshopResults);
-    workshopFilter.addEventListener("change", refreshOrganizerWorkshopApplications);
     editorResetButton.addEventListener("click", resetOrganizerEditor);
-    slotEditorResetButton.addEventListener("click", resetSlotEditor);
 
     lookupButton.addEventListener("click", async function () {
       var username = (createForm.elements.githubUsername.value || "").trim();
@@ -1757,7 +1740,6 @@
         showStatus("organizer-create-status", "Enter a GitHub username first.", "error");
         return;
       }
-
       try {
         var lookup = await apiRequest("/api/v1/admin/users/lookup/" + encodeURIComponent(username));
         if (lookup.name) createForm.elements.speakerName.value = lookup.name;
@@ -1773,17 +1755,8 @@
     createForm.addEventListener("submit", async function (event) {
       event.preventDefault();
       var payload = readFormJSON(createForm, [
-        "conferenceId",
-        "title",
-        "abstract",
-        "talkDetail",
-        "talkDuration",
-        "speakerName",
-        "speakerEmail",
-        "bio",
-        "githubUsername",
-        "iconURL",
-        "notes"
+        "conferenceId", "title", "abstract", "talkDetail", "talkDuration",
+        "speakerName", "speakerEmail", "bio", "githubUsername", "iconURL", "notes"
       ]);
       if (payload.talkDuration === "workshop") {
         Object.assign(payload, readWorkshopPayload(createForm, {
@@ -1791,12 +1764,8 @@
           includeJapaneseFields: false
         }));
       }
-
       try {
-        await apiRequest("/api/v1/admin/proposals", {
-          method: "POST",
-          body: JSON.stringify(payload)
-        });
+        await apiRequest("/api/v1/admin/proposals", { method: "POST", body: JSON.stringify(payload) });
         showStatus("organizer-create-status", "Proposal created.", "success");
         createForm.reset();
         populateSelect("organizer-conference-id", state.conferences, null, "id", "displayName");
@@ -1810,13 +1779,11 @@
 
     importForm.addEventListener("submit", async function (event) {
       event.preventDefault();
-
       var fileInput = importForm.elements.csvFile;
       if (!fileInput || !fileInput.files || !fileInput.files[0]) {
         showStatus("organizer-import-status", "Choose a CSV or JSON file to import.", "error");
         return;
       }
-
       var formData = new FormData();
       formData.append("csvFile", fileInput.files[0]);
       formData.append("conferenceId", importForm.elements.conferenceId.value);
@@ -1824,12 +1791,8 @@
         formData.append("githubUsername", importForm.elements.githubUsername.value.trim());
       }
       formData.append("skipDuplicates", importForm.elements.skipDuplicates.checked ? "true" : "false");
-
       try {
-        await apiRequest("/api/v1/admin/proposals/import", {
-          method: "POST",
-          body: formData
-        });
+        await apiRequest("/api/v1/admin/proposals/import", { method: "POST", body: formData });
         showStatus("organizer-import-status", "Import completed.", "success");
         importForm.reset();
         populateSelect("organizer-import-conference-id", state.conferences, null, "id", "displayName");
@@ -1839,65 +1802,20 @@
       }
     });
 
-    slotForm.addEventListener("submit", async function (event) {
-      event.preventDefault();
-
-      var payload = {
-        conferenceId: slotForm.elements.conferenceId.value,
-        day: Number(slotForm.elements.day.value),
-        startTime: toISODateTime(slotForm.elements.startTime.value),
-        slotType: slotForm.elements.slotType.value
-      };
-
-      var proposalId = slotForm.elements.proposalId.value.trim();
-      var endTime = toISODateTime(slotForm.elements.endTime.value);
-      var customTitle = slotForm.elements.customTitle.value.trim();
-      var place = slotForm.elements.place.value.trim();
-      if (proposalId) payload.proposalId = proposalId;
-      if (endTime) payload.endTime = endTime;
-      if (customTitle) payload.customTitle = customTitle;
-      if (place) payload.place = place;
-
-      if (!payload.startTime) {
-        showStatus("organizer-timetable-status", "Start time is required.", "error");
-        return;
-      }
-
-      try {
-        await apiRequest("/api/v1/admin/timetable/slots", {
-          method: "POST",
-          body: JSON.stringify(payload)
-        });
-        showStatus("organizer-timetable-status", "Timetable slot created.", "success");
-        slotForm.reset();
-        slotForm.elements.day.value = "1";
-        populateSelect("organizer-slot-conference-id", state.conferences, null, "id", "displayName");
-        populateProposalSelectForSlots();
-        populateSlotEditorProposalSelect();
-        await refreshOrganizerSlots();
-      } catch (error) {
-        showStatus("organizer-timetable-status", error.message, "error");
-      }
-    });
-
     list.addEventListener("click", async function (event) {
       var editButton = event.target.closest("[data-edit-admin-proposal]");
       if (editButton) {
         loadOrganizerProposalIntoEditor(editButton.getAttribute("data-edit-admin-proposal"));
         return;
       }
-
       var saveButton = event.target.closest("[data-save-status]");
       if (!saveButton) return;
-
       var proposalID = saveButton.getAttribute("data-save-status");
       var select = list.querySelector('[data-status-select="' + proposalID + '"]');
       if (!proposalID || !select) return;
-
       try {
         await apiRequest("/api/v1/admin/proposals/" + encodeURIComponent(proposalID) + "/status", {
-          method: "POST",
-          body: JSON.stringify({ status: select.value })
+          method: "POST", body: JSON.stringify({ status: select.value })
         });
         showStatus("organizer-status", "Updated proposal status.", "success");
         await refreshOrganizerProposals();
@@ -1913,7 +1831,6 @@
         showStatus("organizer-editor-status", "Choose a proposal first.", "error");
         return;
       }
-
       var payload = {
         conferenceId: editorForm.elements.conferenceId.value.trim(),
         title: editorForm.elements.title.value.trim(),
@@ -1938,11 +1855,9 @@
           includeJapaneseFields: true
         }));
       }
-
       try {
         await apiRequest("/api/v1/admin/proposals/" + encodeURIComponent(proposalID), {
-          method: "PUT",
-          body: JSON.stringify(payload)
+          method: "PUT", body: JSON.stringify(payload)
         });
         showStatus("organizer-editor-status", "Proposal updated.", "success");
         await refreshOrganizerProposals();
@@ -1958,11 +1873,8 @@
         showStatus("organizer-editor-status", "Choose a proposal first.", "error");
         return;
       }
-
       try {
-        await apiRequest("/api/v1/admin/proposals/" + encodeURIComponent(proposalID), {
-          method: "DELETE"
-        });
+        await apiRequest("/api/v1/admin/proposals/" + encodeURIComponent(proposalID), { method: "DELETE" });
         showStatus("organizer-editor-status", "Proposal deleted.", "success");
         await refreshOrganizerProposals();
         resetOrganizerEditor();
@@ -1971,35 +1883,73 @@
       }
     });
 
+    await refreshOrganizerProposals();
+    resetOrganizerEditor();
+    var initialProposalID = extractOrganizerProposalRouteID();
+    if (initialProposalID) {
+      loadOrganizerProposalIntoEditor(initialProposalID);
+    }
+  }
+
+  async function bootstrapOrganizerTimetableSection() {
+    var slotForm = document.getElementById("organizer-slot-form");
+    var slotList = document.getElementById("organizer-slot-list");
+    var slotFilter = document.getElementById("organizer-slot-conference-filter");
+    var slotEditorForm = document.getElementById("organizer-slot-editor-form");
+    var slotEditorResetButton = document.getElementById("organizer-slot-editor-reset");
+    var slotReorderButton = document.getElementById("organizer-slot-reorder-button");
+    if (!slotForm || !slotList || !slotFilter || !slotEditorForm || !slotEditorResetButton || !slotReorderButton) return;
+
+    slotFilter.addEventListener("change", refreshOrganizerSlots);
+    slotEditorResetButton.addEventListener("click", resetSlotEditor);
+
+    slotForm.addEventListener("submit", async function (event) {
+      event.preventDefault();
+      var payload = {
+        conferenceId: slotForm.elements.conferenceId.value,
+        day: Number(slotForm.elements.day.value),
+        startTime: toISODateTime(slotForm.elements.startTime.value),
+        slotType: slotForm.elements.slotType.value
+      };
+      var proposalId = slotForm.elements.proposalId.value.trim();
+      var endTime = toISODateTime(slotForm.elements.endTime.value);
+      var customTitle = slotForm.elements.customTitle.value.trim();
+      var place = slotForm.elements.place.value.trim();
+      if (proposalId) payload.proposalId = proposalId;
+      if (endTime) payload.endTime = endTime;
+      if (customTitle) payload.customTitle = customTitle;
+      if (place) payload.place = place;
+      if (!payload.startTime) {
+        showStatus("organizer-timetable-status", "Start time is required.", "error");
+        return;
+      }
+      try {
+        await apiRequest("/api/v1/admin/timetable/slots", { method: "POST", body: JSON.stringify(payload) });
+        showStatus("organizer-timetable-status", "Timetable slot created.", "success");
+        slotForm.reset();
+        slotForm.elements.day.value = "1";
+        populateSelect("organizer-slot-conference-id", state.conferences, null, "id", "displayName");
+        populateProposalSelectForSlots();
+        populateSlotEditorProposalSelect();
+        await refreshOrganizerSlots();
+      } catch (error) {
+        showStatus("organizer-timetable-status", error.message, "error");
+      }
+    });
+
     slotList.addEventListener("click", async function (event) {
       var editButton = event.target.closest("[data-edit-slot]");
-      if (editButton) {
-        loadSlotIntoEditor(editButton.getAttribute("data-edit-slot"));
-        return;
-      }
-
+      if (editButton) { loadSlotIntoEditor(editButton.getAttribute("data-edit-slot")); return; }
       var moveUpButton = event.target.closest("[data-move-slot-up]");
-      if (moveUpButton) {
-        moveSlot(moveUpButton.getAttribute("data-move-slot-up"), "up");
-        return;
-      }
-
+      if (moveUpButton) { moveSlot(moveUpButton.getAttribute("data-move-slot-up"), "up"); return; }
       var moveDownButton = event.target.closest("[data-move-slot-down]");
-      if (moveDownButton) {
-        moveSlot(moveDownButton.getAttribute("data-move-slot-down"), "down");
-        return;
-      }
-
+      if (moveDownButton) { moveSlot(moveDownButton.getAttribute("data-move-slot-down"), "down"); return; }
       var deleteButton = event.target.closest("[data-delete-slot]");
       if (!deleteButton) return;
-
       var slotID = deleteButton.getAttribute("data-delete-slot");
       if (!slotID) return;
-
       try {
-        await apiRequest("/api/v1/admin/timetable/slots/" + encodeURIComponent(slotID), {
-          method: "DELETE"
-        });
+        await apiRequest("/api/v1/admin/timetable/slots/" + encodeURIComponent(slotID), { method: "DELETE" });
         showStatus("organizer-timetable-status", "Timetable slot deleted.", "success");
         await refreshOrganizerSlots();
       } catch (error) {
@@ -2014,11 +1964,7 @@
         showStatus("organizer-slot-editor-status", "Choose a slot first.", "error");
         return;
       }
-
-      var payload = {
-        day: Number(slotEditorForm.elements.day.value),
-        slotType: slotEditorForm.elements.slotType.value
-      };
+      var payload = { day: Number(slotEditorForm.elements.day.value), slotType: slotEditorForm.elements.slotType.value };
       var proposalId = slotEditorForm.elements.proposalId.value.trim();
       var place = slotEditorForm.elements.place.value.trim();
       var startTime = toISODateTime(slotEditorForm.elements.startTime.value);
@@ -2029,11 +1975,9 @@
       payload.startTime = startTime || null;
       payload.endTime = endTime || null;
       payload.customTitle = customTitle ? customTitle : null;
-
       try {
         await apiRequest("/api/v1/admin/timetable/slots/" + encodeURIComponent(slotID), {
-          method: "PUT",
-          body: JSON.stringify(payload)
+          method: "PUT", body: JSON.stringify(payload)
         });
         showStatus("organizer-slot-editor-status", "Slot updated.", "success");
         await refreshOrganizerSlots();
@@ -2049,20 +1993,13 @@
         showStatus("organizer-slot-editor-status", "Choose a slot first.", "error");
         return;
       }
-
       var day = Number(slotEditorForm.elements.day.value);
       var sameDay = state.organizerSlots
         .filter(function (item) { return item.day === day; })
         .sort(function (lhs, rhs) { return lhs.sortOrder - rhs.sortOrder; })
-        .map(function (item, index) {
-          return { id: item.id, sortOrder: index };
-        });
-
+        .map(function (item, index) { return { id: item.id, sortOrder: index }; });
       try {
-        await apiRequest("/api/v1/admin/timetable/reorder", {
-          method: "POST",
-          body: JSON.stringify(sameDay)
-        });
+        await apiRequest("/api/v1/admin/timetable/reorder", { method: "POST", body: JSON.stringify(sameDay) });
         showStatus("organizer-slot-editor-status", "Day order saved.", "success");
         await refreshOrganizerSlots();
       } catch (error) {
@@ -2070,17 +2007,33 @@
       }
     });
 
-    workshopList.addEventListener("click", async function (event) {
+    // Timetable needs proposals loaded to populate the proposalId selects.
+    await refreshOrganizerProposals();
+    populateProposalSelectForSlots();
+    populateSlotEditorProposalSelect();
+    await refreshOrganizerSlots();
+    resetSlotEditor();
+  }
+
+  async function bootstrapOrganizerWorkshopsSection() {
+    var refreshButton = document.getElementById("organizer-workshops-refresh");
+    var list = document.getElementById("organizer-workshops-list");
+    var filter = document.getElementById("organizer-workshop-filter");
+    var lotteryButton = document.getElementById("organizer-workshop-lottery-button");
+    var sendTicketsButton = document.getElementById("organizer-workshop-send-tickets-button");
+    if (!refreshButton || !list || !filter || !lotteryButton || !sendTicketsButton) return;
+
+    refreshButton.addEventListener("click", refreshOrganizerWorkshops);
+
+    list.addEventListener("click", async function (event) {
       var capacityButton = event.target.closest("[data-save-workshop-capacity]");
       if (capacityButton) {
         var registrationID = capacityButton.getAttribute("data-save-workshop-capacity");
-        var capacityInput = workshopList.querySelector('[data-workshop-capacity="' + registrationID + '"]');
+        var capacityInput = list.querySelector('[data-workshop-capacity="' + registrationID + '"]');
         if (!registrationID || !capacityInput) return;
-
         try {
           await apiRequest("/api/v1/admin/workshops/" + encodeURIComponent(registrationID) + "/capacity", {
-            method: "PUT",
-            body: JSON.stringify({ capacity: Number(capacityInput.value) })
+            method: "PUT", body: JSON.stringify({ capacity: Number(capacityInput.value) })
           });
           showStatus("organizer-workshops-status", "Capacity updated.", "success");
           await refreshOrganizerWorkshops();
@@ -2093,13 +2046,11 @@
       var lumaButton = event.target.closest("[data-save-workshop-luma]");
       if (lumaButton) {
         var lumaRegistrationID = lumaButton.getAttribute("data-save-workshop-luma");
-        var lumaInput = workshopList.querySelector('[data-workshop-luma-event="' + lumaRegistrationID + '"]');
+        var lumaInput = list.querySelector('[data-workshop-luma-event="' + lumaRegistrationID + '"]');
         if (!lumaRegistrationID || !lumaInput) return;
-
         try {
           await apiRequest("/api/v1/admin/workshops/" + encodeURIComponent(lumaRegistrationID) + "/luma-event", {
-            method: "PUT",
-            body: JSON.stringify({ lumaEventID: lumaInput.value.trim() || null })
+            method: "PUT", body: JSON.stringify({ lumaEventID: lumaInput.value.trim() || null })
           });
           showStatus("organizer-workshops-status", "Luma event ID updated.", "success");
           await refreshOrganizerWorkshops();
@@ -2111,14 +2062,10 @@
 
       var createLumaButton = event.target.closest("[data-create-workshop-luma]");
       if (!createLumaButton) return;
-
       var createRegistrationID = createLumaButton.getAttribute("data-create-workshop-luma");
       if (!createRegistrationID) return;
-
       try {
-        var createResponse = await apiRequest("/api/v1/admin/workshops/" + encodeURIComponent(createRegistrationID) + "/create-luma-event", {
-          method: "POST"
-        });
+        var createResponse = await apiRequest("/api/v1/admin/workshops/" + encodeURIComponent(createRegistrationID) + "/create-luma-event", { method: "POST" });
         showStatus("organizer-workshops-status", createResponse.message || "Luma event created.", "success");
         await refreshOrganizerWorkshops();
       } catch (error) {
@@ -2126,16 +2073,45 @@
       }
     });
 
-    workshopApplicationsList.addEventListener("click", async function (event) {
+    lotteryButton.addEventListener("click", async function () {
+      try {
+        var lottery = await apiRequest("/api/v1/admin/workshops/lottery", { method: "POST" });
+        showStatus("organizer-workshops-status", "Lottery complete: " + lottery.assigned + " assigned, " + lottery.unassigned + " unassigned.", "success");
+        await refreshOrganizerWorkshops();
+      } catch (error) {
+        showStatus("organizer-workshops-status", error.message, "error");
+      }
+    });
+
+    sendTicketsButton.addEventListener("click", async function () {
+      try {
+        var ticketResponse = await apiRequest("/api/v1/admin/workshops/send-tickets", { method: "POST" });
+        showStatus("organizer-workshops-status", "Tickets sent: " + ticketResponse.sent + " success, " + ticketResponse.skipped + " skipped, " + ticketResponse.errors + " errors.", "success");
+        await refreshOrganizerWorkshops();
+      } catch (error) {
+        showStatus("organizer-workshops-status", error.message, "error");
+      }
+    });
+
+    await refreshOrganizerWorkshops();
+  }
+
+  async function bootstrapOrganizerWorkshopApplicationsSection() {
+    var refreshButton = document.getElementById("organizer-workshop-applications-refresh");
+    var list = document.getElementById("organizer-workshop-applications-list");
+    var filter = document.getElementById("organizer-workshop-filter");
+    if (!refreshButton || !list || !filter) return;
+
+    refreshButton.addEventListener("click", refreshOrganizerWorkshopApplications);
+    filter.addEventListener("change", refreshOrganizerWorkshopApplications);
+
+    list.addEventListener("click", async function (event) {
       var deleteButton = event.target.closest("[data-delete-workshop-application]");
       if (!deleteButton) return;
       var applicationID = deleteButton.getAttribute("data-delete-workshop-application");
       if (!applicationID) return;
-
       try {
-        await apiRequest("/api/v1/admin/workshop-applications/" + encodeURIComponent(applicationID), {
-          method: "DELETE"
-        });
+        await apiRequest("/api/v1/admin/workshop-applications/" + encodeURIComponent(applicationID), { method: "DELETE" });
         showStatus("organizer-workshop-applications-status", "Workshop application deleted.", "success");
         await refreshOrganizerWorkshopApplications();
       } catch (error) {
@@ -2143,40 +2119,27 @@
       }
     });
 
-    workshopLotteryButton.addEventListener("click", async function () {
-      try {
-        var lottery = await apiRequest("/api/v1/admin/workshops/lottery", { method: "POST" });
-        showStatus("organizer-workshops-status", "Lottery complete: " + lottery.assigned + " assigned, " + lottery.unassigned + " unassigned.", "success");
-        await refreshOrganizerWorkshops();
-        await refreshOrganizerWorkshopApplications();
-        await refreshOrganizerWorkshopResults();
-      } catch (error) {
-        showStatus("organizer-workshops-status", error.message, "error");
-      }
-    });
-
-    workshopSendTicketsButton.addEventListener("click", async function () {
-      try {
-        var ticketResponse = await apiRequest("/api/v1/admin/workshops/send-tickets", { method: "POST" });
-        showStatus("organizer-workshops-status", "Tickets sent: " + ticketResponse.sent + " success, " + ticketResponse.skipped + " skipped, " + ticketResponse.errors + " errors.", "success");
-        await refreshOrganizerWorkshops();
-        await refreshOrganizerWorkshopResults();
-      } catch (error) {
-        showStatus("organizer-workshops-status", error.message, "error");
-      }
-    });
-
-    await refreshOrganizerProposals();
-    await refreshOrganizerSlots();
+    // The filter select needs workshop data to populate.
     await refreshOrganizerWorkshops();
     await refreshOrganizerWorkshopApplications();
+  }
+
+  async function bootstrapOrganizerWorkshopResultsSection() {
+    var refreshButton = document.getElementById("organizer-workshop-results-refresh");
+    var list = document.getElementById("organizer-workshop-results-list");
+    if (!refreshButton || !list) return;
+
+    refreshButton.addEventListener("click", refreshOrganizerWorkshopResults);
     await refreshOrganizerWorkshopResults();
-    resetOrganizerEditor();
-    resetSlotEditor();
-    var initialProposalID = extractOrganizerProposalRouteID();
-    if (initialProposalID) {
-      loadOrganizerProposalIntoEditor(initialProposalID);
-    }
+  }
+
+  async function bootstrapOrganizerPage() {
+    await bootstrapOrganizerShell();
+    await bootstrapOrganizerProposalsSection();
+    await bootstrapOrganizerTimetableSection();
+    await bootstrapOrganizerWorkshopsSection();
+    await bootstrapOrganizerWorkshopApplicationsSection();
+    await bootstrapOrganizerWorkshopResultsSection();
   }
 
   async function bootstrapPage() {

--- a/CfPWeb/Public/styles/app.css
+++ b/CfPWeb/Public/styles/app.css
@@ -1259,3 +1259,96 @@ body.modal-open {
     grid-template-columns: 1fr;
   }
 }
+
+/* ---- Organizer ---- */
+
+.organizer-shell .submit-shell-inner {
+  gap: 1.5rem;
+}
+
+.organizer-signed-in-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.organizer-subnav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.organizer-subnav-link {
+  padding: 0.5rem 0.9rem;
+  border-radius: 999px;
+  color: inherit;
+  text-decoration: none;
+  font-weight: 500;
+  opacity: 0.75;
+  transition: background 120ms, opacity 120ms;
+}
+
+.organizer-subnav-link:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.06);
+}
+
+.organizer-subnav-link.active {
+  background: var(--accent, #ff375f);
+  color: #fff;
+  opacity: 1;
+}
+
+.organizer-toolbar .organizer-toolbar-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.organizer-toolbar-filter {
+  flex: 1 1 14rem;
+  max-width: 22rem;
+}
+
+.organizer-toolbar-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.organizer-lookup-input-row {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.organizer-lookup-input-row input {
+  flex: 1 1 auto;
+}
+
+.organizer-checkbox-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.form-actions.split {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.timetable-list,
+.organizer-workshops-list,
+.organizer-applications-list,
+.organizer-results-list,
+.proposal-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}

--- a/CfPWeb/Sources/CfPWeb/Components/AppLayout.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/AppLayout.swift
@@ -34,7 +34,7 @@ struct AppLayout: HTMLDocument, Sendable {
     div(.class("site-shell")) {
       AppNavigation(routePath: routePath, currentPage: page, language: language)
       main(.class("content-shell")) {
-        PageContent(page: page, language: language)
+        PageContent(page: page, language: language, routePath: routePath)
       }
       footer(.class("footer")) {
         div(.class("footer-links")) {

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerProposalsContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerProposalsContent.swift
@@ -1,0 +1,284 @@
+import Elementary
+
+struct OrganizerProposalsContent: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    OrganizerProposalsToolbar(language: language)
+    OrganizerProposalsCreateCard(language: language)
+    OrganizerProposalsImportCard(language: language)
+    OrganizerProposalsListCard(language: language)
+    OrganizerProposalsEditorCard(language: language)
+  }
+}
+
+private struct OrganizerProposalsToolbar: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(.class("detail-card organizer-toolbar")) {
+      div(.class("organizer-toolbar-row")) {
+        label(.class("form-field organizer-toolbar-filter")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "カンファレンス" : "Conference") }
+          select(.id("organizer-conference-filter"), .name("conferencePath")) {}
+        }
+        div(.class("organizer-toolbar-actions")) {
+          button(.type(.button), .id("organizer-refresh"), .class("button neutral")) {
+            HTMLText(language == .ja ? "更新" : "Refresh")
+          }
+          a(.id("export-proposals-link"), .class("button neutral"), .href("#")) {
+            HTMLText(language == .ja ? "CSV エクスポート" : "Export CSV")
+          }
+          a(.id("export-speakers-link"), .class("button neutral"), .href("#")) {
+            HTMLText(language == .ja ? "スピーカー JSON" : "Export Speakers JSON")
+          }
+        }
+      }
+    }
+  }
+}
+
+private struct OrganizerProposalsCreateCard: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(.class("detail-card submit-form-card")) {
+      h3 { HTMLText(language == .ja ? "プロポーザルを追加" : "Add Proposal") }
+      p(.class("submit-form-intro")) {
+        HTMLText(language == .ja
+          ? "運営側でプロポーザルを新規登録します。GitHub ユーザー名からスピーカー情報を補完できます。"
+          : "Create a proposal on behalf of a speaker. Use GitHub lookup to auto-fill speaker info.")
+      }
+      form(.id("organizer-create-form"), .class("submit-form-grid")) {
+        div(.class("form-field submit-form-full organizer-lookup-row")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "GitHub ユーザー名" : "GitHub Username") }
+          div(.class("organizer-lookup-input-row")) {
+            input(.type(.text), .name("githubUsername"))
+            button(.type(.button), .id("organizer-lookup-button"), .class("button neutral")) {
+              HTMLText(language == .ja ? "情報を取得" : "Lookup")
+            }
+          }
+        }
+
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "カンファレンス" : "Conference") }
+          select(.id("organizer-conference-id"), .name("conferenceId"), .required) {}
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "形式" : "Format") }
+          select(.name("talkDuration"), .required) {
+            option(.value("20min")) { HTMLText(language == .ja ? "レギュラートーク (20分)" : "Regular Talk (20 min)") }
+            option(.value("LT")) { HTMLText(language == .ja ? "ライトニングトーク (5分)" : "Lightning Talk (5 min)") }
+            option(.value("workshop")) { HTMLText(language == .ja ? "ワークショップ" : "Workshop") }
+          }
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "タイトル" : "Title") }
+          input(.type(.text), .name("title"), .required)
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "概要" : "Abstract") }
+          textarea(.name("abstract"), .required, .custom(name: "rows", value: "5")) {}
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "詳細" : "Talk Details") }
+          textarea(.name("talkDetail"), .required, .custom(name: "rows", value: "8")) {}
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "登壇者名" : "Speaker Name") }
+          input(.type(.text), .name("speakerName"), .required)
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "メールアドレス" : "Speaker Email") }
+          input(.type(.email), .name("speakerEmail"), .required)
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText("Bio") }
+          textarea(.name("bio"), .required, .custom(name: "rows", value: "5")) {}
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "アイコンURL" : "Avatar URL") }
+          input(.type(.url), .name("iconURL"))
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "メモ" : "Notes for Organizers") }
+          textarea(.name("notes"), .custom(name: "rows", value: "4")) {}
+        }
+
+        OrganizerWorkshopDetailFields(
+          sectionID: "organizer-create-workshop-section",
+          coInstructor1Prefix: "organizer-create-co1",
+          coInstructor2Prefix: "organizer-create-co2",
+          language: language,
+          includeJapanese: false
+        )
+
+        div(.class("form-actions submit-form-full")) {
+          button(.type(.submit), .class("button primary")) {
+            HTMLText(language == .ja ? "プロポーザルを作成" : "Create Proposal")
+          }
+        }
+        p(.id("organizer-create-status"), .class("inline-status submit-form-full"), .hidden) {}
+      }
+    }
+  }
+}
+
+private struct OrganizerProposalsImportCard: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(.class("detail-card submit-form-card")) {
+      h3 { HTMLText(language == .ja ? "CSV / JSON をインポート" : "Import CSV / JSON") }
+      p(.class("submit-form-intro")) {
+        HTMLText(language == .ja
+          ? "プロポーザルを一括取り込みします。既存のものと重複する場合のスキップを選択できます。"
+          : "Bulk import proposals. Choose whether to skip entries that already exist.")
+      }
+      form(.id("organizer-import-form"), .class("submit-form-grid")) {
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "カンファレンス" : "Conference") }
+          select(.id("organizer-import-conference-id"), .name("conferenceId"), .required) {}
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "ファイル" : "File") }
+          input(.type(.file), .name("csvFile"), .custom(name: "accept", value: ".csv,.json"), .required)
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "GitHub ユーザー名 (任意)" : "GitHub Username (optional)") }
+          input(.type(.text), .name("githubUsername"))
+        }
+        label(.class("form-field submit-form-full organizer-checkbox-row")) {
+          input(.type(.checkbox), .name("skipDuplicates"), .custom(name: "checked", value: "checked"))
+          span { HTMLText(language == .ja ? "重複をスキップ" : "Skip duplicates") }
+        }
+        div(.class("form-actions submit-form-full")) {
+          button(.type(.submit), .class("button primary")) {
+            HTMLText(language == .ja ? "インポート" : "Import")
+          }
+        }
+        p(.id("organizer-import-status"), .class("inline-status submit-form-full"), .hidden) {}
+      }
+    }
+  }
+}
+
+private struct OrganizerProposalsListCard: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(.class("detail-card")) {
+      h3 { HTMLText(language == .ja ? "プロポーザル一覧" : "All Proposals") }
+      p(.id("organizer-status"), .class("inline-status"), .hidden) {}
+      div(.id("organizer-proposals"), .class("proposal-list")) {}
+    }
+  }
+}
+
+private struct OrganizerProposalsEditorCard: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(.class("detail-card submit-form-card")) {
+      h3 { HTMLText(language == .ja ? "プロポーザルを編集" : "Edit Proposal") }
+      p(.id("organizer-editor-placeholder"), .class("submit-form-intro")) {
+        HTMLText(language == .ja
+          ? "一覧から Edit を選ぶとフォームに読み込まれます。"
+          : "Choose Edit on a proposal above to load it here.")
+      }
+      form(.id("organizer-editor-form"), .class("submit-form-grid")) {
+        input(.type(.hidden), .name("proposalID"))
+
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "カンファレンス" : "Conference") }
+          select(.id("organizer-editor-conference-id"), .name("conferenceId"), .required) {}
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "形式" : "Format") }
+          select(.name("talkDuration"), .required) {
+            option(.value("20min")) { HTMLText(language == .ja ? "レギュラートーク (20分)" : "Regular Talk (20 min)") }
+            option(.value("LT")) { HTMLText(language == .ja ? "ライトニングトーク (5分)" : "Lightning Talk (5 min)") }
+            option(.value("workshop")) { HTMLText(language == .ja ? "ワークショップ" : "Workshop") }
+          }
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "タイトル" : "Title") }
+          input(.type(.text), .name("title"), .required)
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "タイトル (JA)" : "Title (JA)") }
+          input(.type(.text), .name("titleJA"))
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "概要" : "Abstract") }
+          textarea(.name("abstract"), .required, .custom(name: "rows", value: "5")) {}
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "概要 (JA)" : "Abstract (JA)") }
+          textarea(.name("abstractJA"), .custom(name: "rows", value: "5")) {}
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "詳細" : "Talk Details") }
+          textarea(.name("talkDetail"), .required, .custom(name: "rows", value: "8")) {}
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "登壇者名" : "Speaker Name") }
+          input(.type(.text), .name("speakerName"), .required)
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "メールアドレス" : "Speaker Email") }
+          input(.type(.email), .name("speakerEmail"), .required)
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText("Bio") }
+          textarea(.name("bio"), .required, .custom(name: "rows", value: "5")) {}
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "Bio (JA)" : "Bio (JA)") }
+          textarea(.name("bioJa"), .custom(name: "rows", value: "5")) {}
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "肩書き" : "Job Title") }
+          input(.type(.text), .name("jobTitle"))
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "肩書き (JA)" : "Job Title (JA)") }
+          input(.type(.text), .name("jobTitleJa"))
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "GitHub ユーザー名" : "GitHub Username") }
+          input(.type(.text), .name("githubUsername"))
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "アイコンURL" : "Avatar URL") }
+          input(.type(.url), .name("iconURL"))
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "メモ" : "Notes for Organizers") }
+          textarea(.name("notes"), .custom(name: "rows", value: "4")) {}
+        }
+
+        OrganizerWorkshopDetailFields(
+          sectionID: "organizer-edit-workshop-section",
+          coInstructor1Prefix: "organizer-edit-co1",
+          coInstructor2Prefix: "organizer-edit-co2",
+          language: language,
+          includeJapanese: true
+        )
+
+        div(.class("form-actions submit-form-full split")) {
+          button(.type(.button), .id("organizer-editor-reset"), .class("button neutral")) {
+            HTMLText(language == .ja ? "リセット" : "Reset")
+          }
+          button(.type(.submit), .class("button primary")) {
+            HTMLText(language == .ja ? "変更を保存" : "Save Changes")
+          }
+          button(.type(.button), .id("organizer-delete-proposal-button"), .class("button danger")) {
+            HTMLText(language == .ja ? "削除" : "Delete Proposal")
+          }
+        }
+        p(.id("organizer-editor-status"), .class("inline-status submit-form-full"), .hidden) {}
+      }
+    }
+  }
+}

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerProposalsContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerProposalsContent.swift
@@ -45,13 +45,17 @@ private struct OrganizerProposalsCreateCard: HTML, Sendable {
     article(.class("detail-card submit-form-card")) {
       h3 { HTMLText(language == .ja ? "プロポーザルを追加" : "Add Proposal") }
       p(.class("submit-form-intro")) {
-        HTMLText(language == .ja
-          ? "運営側でプロポーザルを新規登録します。GitHub ユーザー名からスピーカー情報を補完できます。"
-          : "Create a proposal on behalf of a speaker. Use GitHub lookup to auto-fill speaker info.")
+        HTMLText(
+          language == .ja
+            ? "運営側でプロポーザルを新規登録します。GitHub ユーザー名からスピーカー情報を補完できます。"
+            : "Create a proposal on behalf of a speaker. Use GitHub lookup to auto-fill speaker info."
+        )
       }
       form(.id("organizer-create-form"), .class("submit-form-grid")) {
         div(.class("form-field submit-form-full organizer-lookup-row")) {
-          span(.class("field-label")) { HTMLText(language == .ja ? "GitHub ユーザー名" : "GitHub Username") }
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "GitHub ユーザー名" : "GitHub Username")
+          }
           div(.class("organizer-lookup-input-row")) {
             input(.type(.text), .name("githubUsername"))
             button(.type(.button), .id("organizer-lookup-button"), .class("button neutral")) {
@@ -67,8 +71,12 @@ private struct OrganizerProposalsCreateCard: HTML, Sendable {
         label(.class("form-field")) {
           span(.class("field-label")) { HTMLText(language == .ja ? "形式" : "Format") }
           select(.name("talkDuration"), .required) {
-            option(.value("20min")) { HTMLText(language == .ja ? "レギュラートーク (20分)" : "Regular Talk (20 min)") }
-            option(.value("LT")) { HTMLText(language == .ja ? "ライトニングトーク (5分)" : "Lightning Talk (5 min)") }
+            option(.value("20min")) {
+              HTMLText(language == .ja ? "レギュラートーク (20分)" : "Regular Talk (20 min)")
+            }
+            option(.value("LT")) {
+              HTMLText(language == .ja ? "ライトニングトーク (5分)" : "Lightning Talk (5 min)")
+            }
             option(.value("workshop")) { HTMLText(language == .ja ? "ワークショップ" : "Workshop") }
           }
         }
@@ -131,9 +139,10 @@ private struct OrganizerProposalsImportCard: HTML, Sendable {
     article(.class("detail-card submit-form-card")) {
       h3 { HTMLText(language == .ja ? "CSV / JSON をインポート" : "Import CSV / JSON") }
       p(.class("submit-form-intro")) {
-        HTMLText(language == .ja
-          ? "プロポーザルを一括取り込みします。既存のものと重複する場合のスキップを選択できます。"
-          : "Bulk import proposals. Choose whether to skip entries that already exist.")
+        HTMLText(
+          language == .ja
+            ? "プロポーザルを一括取り込みします。既存のものと重複する場合のスキップを選択できます。"
+            : "Bulk import proposals. Choose whether to skip entries that already exist.")
       }
       form(.id("organizer-import-form"), .class("submit-form-grid")) {
         label(.class("form-field")) {
@@ -142,14 +151,18 @@ private struct OrganizerProposalsImportCard: HTML, Sendable {
         }
         label(.class("form-field submit-form-full")) {
           span(.class("field-label")) { HTMLText(language == .ja ? "ファイル" : "File") }
-          input(.type(.file), .name("csvFile"), .custom(name: "accept", value: ".csv,.json"), .required)
+          input(
+            .type(.file), .name("csvFile"), .custom(name: "accept", value: ".csv,.json"), .required)
         }
         label(.class("form-field")) {
-          span(.class("field-label")) { HTMLText(language == .ja ? "GitHub ユーザー名 (任意)" : "GitHub Username (optional)") }
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "GitHub ユーザー名 (任意)" : "GitHub Username (optional)")
+          }
           input(.type(.text), .name("githubUsername"))
         }
         label(.class("form-field submit-form-full organizer-checkbox-row")) {
-          input(.type(.checkbox), .name("skipDuplicates"), .custom(name: "checked", value: "checked"))
+          input(
+            .type(.checkbox), .name("skipDuplicates"), .custom(name: "checked", value: "checked"))
           span { HTMLText(language == .ja ? "重複をスキップ" : "Skip duplicates") }
         }
         div(.class("form-actions submit-form-full")) {
@@ -182,9 +195,10 @@ private struct OrganizerProposalsEditorCard: HTML, Sendable {
     article(.class("detail-card submit-form-card")) {
       h3 { HTMLText(language == .ja ? "プロポーザルを編集" : "Edit Proposal") }
       p(.id("organizer-editor-placeholder"), .class("submit-form-intro")) {
-        HTMLText(language == .ja
-          ? "一覧から Edit を選ぶとフォームに読み込まれます。"
-          : "Choose Edit on a proposal above to load it here.")
+        HTMLText(
+          language == .ja
+            ? "一覧から Edit を選ぶとフォームに読み込まれます。"
+            : "Choose Edit on a proposal above to load it here.")
       }
       form(.id("organizer-editor-form"), .class("submit-form-grid")) {
         input(.type(.hidden), .name("proposalID"))
@@ -196,8 +210,12 @@ private struct OrganizerProposalsEditorCard: HTML, Sendable {
         label(.class("form-field")) {
           span(.class("field-label")) { HTMLText(language == .ja ? "形式" : "Format") }
           select(.name("talkDuration"), .required) {
-            option(.value("20min")) { HTMLText(language == .ja ? "レギュラートーク (20分)" : "Regular Talk (20 min)") }
-            option(.value("LT")) { HTMLText(language == .ja ? "ライトニングトーク (5分)" : "Lightning Talk (5 min)") }
+            option(.value("20min")) {
+              HTMLText(language == .ja ? "レギュラートーク (20分)" : "Regular Talk (20 min)")
+            }
+            option(.value("LT")) {
+              HTMLText(language == .ja ? "ライトニングトーク (5分)" : "Lightning Talk (5 min)")
+            }
             option(.value("workshop")) { HTMLText(language == .ja ? "ワークショップ" : "Workshop") }
           }
         }
@@ -246,7 +264,9 @@ private struct OrganizerProposalsEditorCard: HTML, Sendable {
           input(.type(.text), .name("jobTitleJa"))
         }
         label(.class("form-field")) {
-          span(.class("field-label")) { HTMLText(language == .ja ? "GitHub ユーザー名" : "GitHub Username") }
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "GitHub ユーザー名" : "GitHub Username")
+          }
           input(.type(.text), .name("githubUsername"))
         }
         label(.class("form-field submit-form-full")) {

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerSection.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerSection.swift
@@ -24,11 +24,11 @@ enum OrganizerSection: Sendable, CaseIterable {
   func path(for language: AppLanguage) -> String {
     let prefix = language == .ja ? "/ja" : ""
     switch self {
-    case .proposals:            return "\(prefix)/organizer/proposals"
-    case .timetable:            return "\(prefix)/organizer/timetable"
-    case .workshops:            return "\(prefix)/organizer/workshops"
+    case .proposals: return "\(prefix)/organizer/proposals"
+    case .timetable: return "\(prefix)/organizer/timetable"
+    case .workshops: return "\(prefix)/organizer/workshops"
     case .workshopApplications: return "\(prefix)/organizer/workshops/applications"
-    case .workshopResults:      return "\(prefix)/organizer/workshops/results"
+    case .workshopResults: return "\(prefix)/organizer/workshops/results"
     }
   }
 

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerSection.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerSection.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+enum OrganizerSection: Sendable, CaseIterable {
+  case proposals
+  case timetable
+  case workshops
+  case workshopApplications
+  case workshopResults
+
+  static func from(routePath: String) -> OrganizerSection {
+    var path = routePath
+    if path.hasPrefix("/ja") {
+      path = String(path.dropFirst(3))
+    }
+    if path.isEmpty { path = "/" }
+
+    if path == "/organizer/timetable" { return .timetable }
+    if path == "/organizer/workshops" { return .workshops }
+    if path == "/organizer/workshops/applications" { return .workshopApplications }
+    if path == "/organizer/workshops/results" { return .workshopResults }
+    return .proposals
+  }
+
+  func path(for language: AppLanguage) -> String {
+    let prefix = language == .ja ? "/ja" : ""
+    switch self {
+    case .proposals:            return "\(prefix)/organizer/proposals"
+    case .timetable:            return "\(prefix)/organizer/timetable"
+    case .workshops:            return "\(prefix)/organizer/workshops"
+    case .workshopApplications: return "\(prefix)/organizer/workshops/applications"
+    case .workshopResults:      return "\(prefix)/organizer/workshops/results"
+    }
+  }
+
+  func navigationTitle(for language: AppLanguage) -> String {
+    switch self {
+    case .proposals:
+      return language == .ja ? "プロポーザル" : "Proposals"
+    case .timetable:
+      return language == .ja ? "タイムテーブル" : "Timetable"
+    case .workshops:
+      return language == .ja ? "ワークショップ" : "Workshops"
+    case .workshopApplications:
+      return language == .ja ? "応募" : "Applications"
+    case .workshopResults:
+      return language == .ja ? "結果" : "Results"
+    }
+  }
+}

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerSharedFields.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerSharedFields.swift
@@ -57,25 +57,49 @@ struct OrganizerWorkshopDetailFields: HTML, Sendable {
 
       label(.class("form-field")) {
         span(.class("field-label")) { HTMLText(language == .ja ? "講師数" : "Number of Tutors") }
-        input(.type(.number), .name("workshopNumberOfTutors"), .custom(name: "min", value: "1"), .value("1"))
+        input(
+          .type(.number), .name("workshopNumberOfTutors"), .custom(name: "min", value: "1"),
+          .value("1"))
       }
 
-      textareaField(name: "workshopKeyTakeaways", labelJa: "学べること", labelEn: "Key Takeaways", rows: "4")
-      textareaField(name: "workshopPrerequisites", labelJa: "前提知識", labelEn: "Prerequisites", rows: "3")
-      textareaField(name: "workshopAgendaSchedule", labelJa: "アジェンダ", labelEn: "Agenda / Schedule", rows: "5")
-      textareaField(name: "workshopParticipantRequirements", labelJa: "持ち物", labelEn: "What to Bring", rows: "3")
-      textareaField(name: "workshopRequiredSoftware", labelJa: "必要なソフトウェア", labelEn: "Required Software", rows: "3")
-      textareaField(name: "workshopNetworkRequirements", labelJa: "ネットワーク要件", labelEn: "Network Requirements", rows: "3")
+      textareaField(
+        name: "workshopKeyTakeaways", labelJa: "学べること", labelEn: "Key Takeaways", rows: "4")
+      textareaField(
+        name: "workshopPrerequisites", labelJa: "前提知識", labelEn: "Prerequisites", rows: "3")
+      textareaField(
+        name: "workshopAgendaSchedule", labelJa: "アジェンダ", labelEn: "Agenda / Schedule", rows: "5")
+      textareaField(
+        name: "workshopParticipantRequirements", labelJa: "持ち物", labelEn: "What to Bring", rows: "3"
+      )
+      textareaField(
+        name: "workshopRequiredSoftware", labelJa: "必要なソフトウェア", labelEn: "Required Software",
+        rows: "3")
+      textareaField(
+        name: "workshopNetworkRequirements", labelJa: "ネットワーク要件", labelEn: "Network Requirements",
+        rows: "3")
       textareaField(name: "workshopMotivation", labelJa: "企画意図", labelEn: "Motivation", rows: "3")
       textareaField(name: "workshopUniqueness", labelJa: "独自性", labelEn: "Uniqueness", rows: "3")
-      textareaField(name: "workshopPotentialRisks", labelJa: "懸念点", labelEn: "Potential Risks", rows: "3")
+      textareaField(
+        name: "workshopPotentialRisks", labelJa: "懸念点", labelEn: "Potential Risks", rows: "3")
 
       div(.class("submit-form-full workshop-facilities")) {
         span(.class("field-label")) { HTMLText(language == .ja ? "必要設備" : "Required Facilities") }
-        label { input(.type(.checkbox), .name("workshopFacilityProjector")); HTMLText(language == .ja ? "プロジェクター" : "Projector") }
-        label { input(.type(.checkbox), .name("workshopFacilityMicrophone")); HTMLText(language == .ja ? "マイク" : "Microphone") }
-        label { input(.type(.checkbox), .name("workshopFacilityWhiteboard")); HTMLText(language == .ja ? "ホワイトボード" : "Whiteboard") }
-        label { input(.type(.checkbox), .name("workshopFacilityPowerStrips")); HTMLText(language == .ja ? "電源タップ" : "Power Strips") }
+        label {
+          input(.type(.checkbox), .name("workshopFacilityProjector"))
+          HTMLText(language == .ja ? "プロジェクター" : "Projector")
+        }
+        label {
+          input(.type(.checkbox), .name("workshopFacilityMicrophone"))
+          HTMLText(language == .ja ? "マイク" : "Microphone")
+        }
+        label {
+          input(.type(.checkbox), .name("workshopFacilityWhiteboard"))
+          HTMLText(language == .ja ? "ホワイトボード" : "Whiteboard")
+        }
+        label {
+          input(.type(.checkbox), .name("workshopFacilityPowerStrips"))
+          HTMLText(language == .ja ? "電源タップ" : "Power Strips")
+        }
       }
 
       label(.class("form-field submit-form-full")) {
@@ -85,12 +109,24 @@ struct OrganizerWorkshopDetailFields: HTML, Sendable {
 
       if includeJapanese {
         h5 { HTMLText(language == .ja ? "日本語版の内容（任意）" : "Japanese Translations (Optional)") }
-        textareaField(name: "workshopKeyTakeawaysJa", labelJa: "学べること (JA)", labelEn: "Key Takeaways (JA)", rows: "4")
-        textareaField(name: "workshopPrerequisitesJa", labelJa: "前提知識 (JA)", labelEn: "Prerequisites (JA)", rows: "3")
-        textareaField(name: "workshopAgendaScheduleJa", labelJa: "アジェンダ (JA)", labelEn: "Agenda / Schedule (JA)", rows: "5")
-        textareaField(name: "workshopParticipantRequirementsJa", labelJa: "持ち物 (JA)", labelEn: "What to Bring (JA)", rows: "3")
-        textareaField(name: "workshopRequiredSoftwareJa", labelJa: "必要なソフトウェア (JA)", labelEn: "Required Software (JA)", rows: "3")
-        textareaField(name: "workshopNetworkRequirementsJa", labelJa: "ネットワーク要件 (JA)", labelEn: "Network Requirements (JA)", rows: "3")
+        textareaField(
+          name: "workshopKeyTakeawaysJa", labelJa: "学べること (JA)", labelEn: "Key Takeaways (JA)",
+          rows: "4")
+        textareaField(
+          name: "workshopPrerequisitesJa", labelJa: "前提知識 (JA)", labelEn: "Prerequisites (JA)",
+          rows: "3")
+        textareaField(
+          name: "workshopAgendaScheduleJa", labelJa: "アジェンダ (JA)",
+          labelEn: "Agenda / Schedule (JA)", rows: "5")
+        textareaField(
+          name: "workshopParticipantRequirementsJa", labelJa: "持ち物 (JA)",
+          labelEn: "What to Bring (JA)", rows: "3")
+        textareaField(
+          name: "workshopRequiredSoftwareJa", labelJa: "必要なソフトウェア (JA)",
+          labelEn: "Required Software (JA)", rows: "3")
+        textareaField(
+          name: "workshopNetworkRequirementsJa", labelJa: "ネットワーク要件 (JA)",
+          labelEn: "Network Requirements (JA)", rows: "3")
       }
 
       SubmitCoInstructorFields(language: language, prefix: coInstructor1Prefix)
@@ -99,7 +135,9 @@ struct OrganizerWorkshopDetailFields: HTML, Sendable {
   }
 
   @HTMLBuilder
-  private func textareaField(name: String, labelJa: String, labelEn: String, rows: String) -> some HTML {
+  private func textareaField(name: String, labelJa: String, labelEn: String, rows: String)
+    -> some HTML
+  {
     label(.class("form-field submit-form-full")) {
       span(.class("field-label")) { HTMLText(language == .ja ? labelJa : labelEn) }
       textarea(.name(name), .custom(name: "rows", value: rows)) {}

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerSharedFields.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerSharedFields.swift
@@ -1,0 +1,36 @@
+import Elementary
+
+struct SubmitCoInstructorFields: HTML, Sendable {
+  let language: AppLanguage
+  let prefix: String
+
+  var body: some HTML {
+    div(.class("submit-form-full co-instructor-fields")) {
+      h4 { HTMLText(language == .ja ? "共同講師" : "Co-Instructor") }
+      label(.class("form-field")) {
+        span(.class("field-label")) { HTMLText(language == .ja ? "名前" : "Name") }
+        input(.type(.text), .name("\(prefix)Name"))
+      }
+      label(.class("form-field")) {
+        span(.class("field-label")) { HTMLText("Email") }
+        input(.type(.email), .name("\(prefix)Email"))
+      }
+      label(.class("form-field")) {
+        span(.class("field-label")) { HTMLText("GitHub") }
+        input(.type(.text), .name("\(prefix)GithubUsername"))
+      }
+      label(.class("form-field submit-form-full")) {
+        span(.class("field-label")) { HTMLText("Bio") }
+        textarea(.name("\(prefix)Bio"), .custom(name: "rows", value: "3")) {}
+      }
+      label(.class("form-field")) {
+        span(.class("field-label")) { HTMLText("SNS") }
+        input(.type(.url), .name("\(prefix)Sns"))
+      }
+      label(.class("form-field")) {
+        span(.class("field-label")) { HTMLText(language == .ja ? "アイコンURL" : "Avatar URL") }
+        input(.type(.url), .name("\(prefix)IconURL"))
+      }
+    }
+  }
+}

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerSharedFields.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerSharedFields.swift
@@ -34,3 +34,75 @@ struct SubmitCoInstructorFields: HTML, Sendable {
     }
   }
 }
+
+struct OrganizerWorkshopDetailFields: HTML, Sendable {
+  let sectionID: String
+  let coInstructor1Prefix: String
+  let coInstructor2Prefix: String
+  let language: AppLanguage
+  let includeJapanese: Bool
+
+  var body: some HTML {
+    div(.id(sectionID), .class("submit-workshop-section submit-form-full"), .hidden) {
+      h4 { HTMLText(language == .ja ? "ワークショップ詳細" : "Workshop Details") }
+
+      label(.class("form-field")) {
+        span(.class("field-label")) { HTMLText(language == .ja ? "言語" : "Language") }
+        select(.name("workshopLanguage")) {
+          option(.value("english")) { HTMLText(language == .ja ? "英語" : "English") }
+          option(.value("japanese")) { HTMLText(language == .ja ? "日本語" : "Japanese") }
+          option(.value("bilingual")) { HTMLText(language == .ja ? "バイリンガル" : "Bilingual") }
+        }
+      }
+
+      label(.class("form-field")) {
+        span(.class("field-label")) { HTMLText(language == .ja ? "講師数" : "Number of Tutors") }
+        input(.type(.number), .name("workshopNumberOfTutors"), .custom(name: "min", value: "1"), .value("1"))
+      }
+
+      textareaField(name: "workshopKeyTakeaways", labelJa: "学べること", labelEn: "Key Takeaways", rows: "4")
+      textareaField(name: "workshopPrerequisites", labelJa: "前提知識", labelEn: "Prerequisites", rows: "3")
+      textareaField(name: "workshopAgendaSchedule", labelJa: "アジェンダ", labelEn: "Agenda / Schedule", rows: "5")
+      textareaField(name: "workshopParticipantRequirements", labelJa: "持ち物", labelEn: "What to Bring", rows: "3")
+      textareaField(name: "workshopRequiredSoftware", labelJa: "必要なソフトウェア", labelEn: "Required Software", rows: "3")
+      textareaField(name: "workshopNetworkRequirements", labelJa: "ネットワーク要件", labelEn: "Network Requirements", rows: "3")
+      textareaField(name: "workshopMotivation", labelJa: "企画意図", labelEn: "Motivation", rows: "3")
+      textareaField(name: "workshopUniqueness", labelJa: "独自性", labelEn: "Uniqueness", rows: "3")
+      textareaField(name: "workshopPotentialRisks", labelJa: "懸念点", labelEn: "Potential Risks", rows: "3")
+
+      div(.class("submit-form-full workshop-facilities")) {
+        span(.class("field-label")) { HTMLText(language == .ja ? "必要設備" : "Required Facilities") }
+        label { input(.type(.checkbox), .name("workshopFacilityProjector")); HTMLText(language == .ja ? "プロジェクター" : "Projector") }
+        label { input(.type(.checkbox), .name("workshopFacilityMicrophone")); HTMLText(language == .ja ? "マイク" : "Microphone") }
+        label { input(.type(.checkbox), .name("workshopFacilityWhiteboard")); HTMLText(language == .ja ? "ホワイトボード" : "Whiteboard") }
+        label { input(.type(.checkbox), .name("workshopFacilityPowerStrips")); HTMLText(language == .ja ? "電源タップ" : "Power Strips") }
+      }
+
+      label(.class("form-field submit-form-full")) {
+        span(.class("field-label")) { HTMLText(language == .ja ? "その他設備" : "Other Facilities") }
+        input(.type(.text), .name("workshopFacilityOther"))
+      }
+
+      if includeJapanese {
+        h5 { HTMLText(language == .ja ? "日本語版の内容（任意）" : "Japanese Translations (Optional)") }
+        textareaField(name: "workshopKeyTakeawaysJa", labelJa: "学べること (JA)", labelEn: "Key Takeaways (JA)", rows: "4")
+        textareaField(name: "workshopPrerequisitesJa", labelJa: "前提知識 (JA)", labelEn: "Prerequisites (JA)", rows: "3")
+        textareaField(name: "workshopAgendaScheduleJa", labelJa: "アジェンダ (JA)", labelEn: "Agenda / Schedule (JA)", rows: "5")
+        textareaField(name: "workshopParticipantRequirementsJa", labelJa: "持ち物 (JA)", labelEn: "What to Bring (JA)", rows: "3")
+        textareaField(name: "workshopRequiredSoftwareJa", labelJa: "必要なソフトウェア (JA)", labelEn: "Required Software (JA)", rows: "3")
+        textareaField(name: "workshopNetworkRequirementsJa", labelJa: "ネットワーク要件 (JA)", labelEn: "Network Requirements (JA)", rows: "3")
+      }
+
+      SubmitCoInstructorFields(language: language, prefix: coInstructor1Prefix)
+      SubmitCoInstructorFields(language: language, prefix: coInstructor2Prefix)
+    }
+  }
+
+  @HTMLBuilder
+  private func textareaField(name: String, labelJa: String, labelEn: String, rows: String) -> some HTML {
+    label(.class("form-field submit-form-full")) {
+      span(.class("field-label")) { HTMLText(language == .ja ? labelJa : labelEn) }
+      textarea(.name(name), .custom(name: "rows", value: rows)) {}
+    }
+  }
+}

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerShell.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerShell.swift
@@ -13,14 +13,18 @@ struct OrganizerShell: HTML, Sendable {
       div(.class("submit-shell-inner")) {
         h1 { HTMLText(CfPPage.organizer.title(for: language)) }
         p(.class("submit-lead")) {
-          HTMLText(language == .ja
-            ? "運営向けのプロポーザル・タイムテーブル・ワークショップ管理ツールです。"
-            : "Admin tools for managing proposals, timetable, and workshops.")
+          HTMLText(
+            language == .ja
+              ? "運営向けのプロポーザル・タイムテーブル・ワークショップ管理ツールです。"
+              : "Admin tools for managing proposals, timetable, and workshops.")
         }
 
         OrganizerSignInCard(language: language)
 
-        Elementary.section(.class("organizer-signed-in-wrapper"), .data("auth-signed-in-card", value: "true"), .hidden) {
+        Elementary.section(
+          .class("organizer-signed-in-wrapper"), .data("auth-signed-in-card", value: "true"),
+          .hidden
+        ) {
           OrganizerSubnav(activeSection: section, language: language)
           div(.class("organizer-section")) {
             renderActiveSection()
@@ -66,16 +70,21 @@ private struct OrganizerSignInCard: HTML, Sendable {
       p(
         .id("page-detail-copy"),
         .class("submit-auth-copy"),
-        .data("signed-out-copy", value: language == .ja
-          ? "運営向け画面にアクセスするには、権限のあるアカウントでサインインしてください。"
-          : "Sign in with an organizer account to access admin tools."),
-        .data("signed-in-copy", value: language == .ja
-          ? "GitHubアカウントとの連携が完了しています。運営向け機能をこのアカウントで利用できます。"
-          : "Your GitHub account is connected. You can access organizer tools with this account.")
+        .data(
+          "signed-out-copy",
+          value: language == .ja
+            ? "運営向け画面にアクセスするには、権限のあるアカウントでサインインしてください。"
+            : "Sign in with an organizer account to access admin tools."),
+        .data(
+          "signed-in-copy",
+          value: language == .ja
+            ? "GitHubアカウントとの連携が完了しています。運営向け機能をこのアカウントで利用できます。"
+            : "Your GitHub account is connected. You can access organizer tools with this account.")
       ) {
-        HTMLText(language == .ja
-          ? "運営向け画面にアクセスするには、権限のあるアカウントでサインインしてください。"
-          : "Sign in with an organizer account to access admin tools.")
+        HTMLText(
+          language == .ja
+            ? "運営向け画面にアクセスするには、権限のあるアカウントでサインインしてください。"
+            : "Sign in with an organizer account to access admin tools.")
       }
       p(.id("auth-status"), .class("submit-auth-status")) {
         HTMLText(language == .ja ? "サインイン状態を確認しています..." : "Checking sign-in state...")
@@ -101,7 +110,8 @@ private struct OrganizerSubnav: HTML, Sendable {
       for section in OrganizerSection.allCases {
         a(
           .href(section.path(for: language)),
-          .class(section == activeSection ? "organizer-subnav-link active" : "organizer-subnav-link")
+          .class(
+            section == activeSection ? "organizer-subnav-link active" : "organizer-subnav-link")
         ) {
           HTMLText(section.navigationTitle(for: language))
         }

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerShell.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerShell.swift
@@ -1,0 +1,111 @@
+import Elementary
+
+struct OrganizerShell: HTML, Sendable {
+  let routePath: String
+  let language: AppLanguage
+
+  private var section: OrganizerSection {
+    OrganizerSection.from(routePath: routePath)
+  }
+
+  var body: some HTML {
+    Elementary.section(.class("submit-shell organizer-shell")) {
+      div(.class("submit-shell-inner")) {
+        h1 { HTMLText(CfPPage.organizer.title(for: language)) }
+        p(.class("submit-lead")) {
+          HTMLText(language == .ja
+            ? "運営向けのプロポーザル・タイムテーブル・ワークショップ管理ツールです。"
+            : "Admin tools for managing proposals, timetable, and workshops.")
+        }
+
+        OrganizerSignInCard(language: language)
+
+        Elementary.section(.class("organizer-signed-in-wrapper"), .data("auth-signed-in-card", value: "true"), .hidden) {
+          OrganizerSubnav(activeSection: section, language: language)
+          div(.class("organizer-section")) {
+            renderActiveSection()
+          }
+        }
+      }
+    }
+  }
+
+  @HTMLBuilder
+  private func renderActiveSection() -> some HTML {
+    switch section {
+    case .proposals:
+      OrganizerProposalsContent(language: language)
+    case .timetable:
+      OrganizerTimetableContent(language: language)
+    case .workshops:
+      OrganizerWorkshopsContent(language: language)
+    case .workshopApplications:
+      OrganizerWorkshopApplicationsContent(language: language)
+    case .workshopResults:
+      OrganizerWorkshopResultsContent(language: language)
+    }
+  }
+}
+
+private struct OrganizerSignInCard: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(
+      .class("detail-card submit-auth-card auth-required-card"),
+      .data("auth-guest-card", value: "true")
+    ) {
+      p(.class("submit-auth-icon"), .custom(name: "aria-hidden", value: "true")) { "🔐" }
+      h3(
+        .id("page-description"),
+        .data("signed-out-copy", value: language == .ja ? "サインインが必要です" : "Sign In Required"),
+        .data("signed-in-copy", value: language == .ja ? "サインイン済みです" : "You're Signed In")
+      ) {
+        HTMLText(language == .ja ? "サインインが必要です" : "Sign In Required")
+      }
+      p(
+        .id("page-detail-copy"),
+        .class("submit-auth-copy"),
+        .data("signed-out-copy", value: language == .ja
+          ? "運営向け画面にアクセスするには、権限のあるアカウントでサインインしてください。"
+          : "Sign in with an organizer account to access admin tools."),
+        .data("signed-in-copy", value: language == .ja
+          ? "GitHubアカウントとの連携が完了しています。運営向け機能をこのアカウントで利用できます。"
+          : "Your GitHub account is connected. You can access organizer tools with this account.")
+      ) {
+        HTMLText(language == .ja
+          ? "運営向け画面にアクセスするには、権限のあるアカウントでサインインしてください。"
+          : "Sign in with an organizer account to access admin tools.")
+      }
+      p(.id("auth-status"), .class("submit-auth-status")) {
+        HTMLText(language == .ja ? "サインイン状態を確認しています..." : "Checking sign-in state...")
+      }
+      button(
+        .type(.button),
+        .id("submit-login-button"),
+        .class("button submit-login-button"),
+        .data("login-button", value: "true")
+      ) {
+        HTMLText(language == .ja ? "GitHubでサインイン" : "Sign in with GitHub")
+      }
+    }
+  }
+}
+
+private struct OrganizerSubnav: HTML, Sendable {
+  let activeSection: OrganizerSection
+  let language: AppLanguage
+
+  var body: some HTML {
+    nav(.class("organizer-subnav")) {
+      for section in OrganizerSection.allCases {
+        a(
+          .href(section.path(for: language)),
+          .class(section == activeSection ? "organizer-subnav-link active" : "organizer-subnav-link")
+        ) {
+          HTMLText(section.navigationTitle(for: language))
+        }
+      }
+    }
+  }
+}

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerTimetableContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerTimetableContent.swift
@@ -44,19 +44,25 @@ private struct OrganizerTimetableCreateCard: HTML, Sendable {
         }
         label(.class("form-field")) {
           span(.class("field-label")) { HTMLText(language == .ja ? "Day" : "Day") }
-          input(.type(.number), .name("day"), .custom(name: "min", value: "1"), .custom(name: "max", value: "3"), .value("1"), .required)
+          input(
+            .type(.number), .name("day"), .custom(name: "min", value: "1"),
+            .custom(name: "max", value: "3"), .value("1"), .required)
         }
         label(.class("form-field")) {
           span(.class("field-label")) { HTMLText(language == .ja ? "開始時刻" : "Start Time") }
           input(.type(.datetimeLocal), .name("startTime"), .required)
         }
         label(.class("form-field")) {
-          span(.class("field-label")) { HTMLText(language == .ja ? "終了時刻 (任意)" : "End Time (optional)") }
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "終了時刻 (任意)" : "End Time (optional)")
+          }
           input(.type(.datetimeLocal), .name("endTime"))
         }
         slotTypeSelect()
         label(.class("form-field submit-form-full")) {
-          span(.class("field-label")) { HTMLText(language == .ja ? "プロポーザル (任意)" : "Proposal (optional)") }
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "プロポーザル (任意)" : "Proposal (optional)")
+          }
           select(.id("organizer-slot-proposal-id"), .name("proposalId")) {}
         }
         label(.class("form-field")) {
@@ -113,27 +119,34 @@ private struct OrganizerTimetableEditorCard: HTML, Sendable {
     article(.class("detail-card submit-form-card")) {
       h3 { HTMLText(language == .ja ? "スロットを編集" : "Edit Slot") }
       p(.id("organizer-slot-editor-placeholder"), .class("submit-form-intro")) {
-        HTMLText(language == .ja
-          ? "一覧から Edit を選ぶとフォームに読み込まれます。"
-          : "Choose Edit on a slot above to load it here.")
+        HTMLText(
+          language == .ja
+            ? "一覧から Edit を選ぶとフォームに読み込まれます。"
+            : "Choose Edit on a slot above to load it here.")
       }
       form(.id("organizer-slot-editor-form"), .class("submit-form-grid")) {
         input(.type(.hidden), .name("slotID"))
         label(.class("form-field")) {
           span(.class("field-label")) { HTMLText(language == .ja ? "Day" : "Day") }
-          input(.type(.number), .name("day"), .custom(name: "min", value: "1"), .custom(name: "max", value: "3"), .required)
+          input(
+            .type(.number), .name("day"), .custom(name: "min", value: "1"),
+            .custom(name: "max", value: "3"), .required)
         }
         label(.class("form-field")) {
           span(.class("field-label")) { HTMLText(language == .ja ? "開始時刻" : "Start Time") }
           input(.type(.datetimeLocal), .name("startTime"))
         }
         label(.class("form-field")) {
-          span(.class("field-label")) { HTMLText(language == .ja ? "終了時刻 (任意)" : "End Time (optional)") }
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "終了時刻 (任意)" : "End Time (optional)")
+          }
           input(.type(.datetimeLocal), .name("endTime"))
         }
         slotTypeSelect()
         label(.class("form-field submit-form-full")) {
-          span(.class("field-label")) { HTMLText(language == .ja ? "プロポーザル (任意)" : "Proposal (optional)") }
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "プロポーザル (任意)" : "Proposal (optional)")
+          }
           select(.id("organizer-slot-editor-proposal-id"), .name("proposalId")) {}
         }
         label(.class("form-field")) {

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerTimetableContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerTimetableContent.swift
@@ -1,0 +1,179 @@
+import Elementary
+
+struct OrganizerTimetableContent: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    OrganizerTimetableToolbar(language: language)
+    OrganizerTimetableCreateCard(language: language)
+    OrganizerTimetableListCard(language: language)
+    OrganizerTimetableEditorCard(language: language)
+  }
+}
+
+private struct OrganizerTimetableToolbar: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(.class("detail-card organizer-toolbar")) {
+      div(.class("organizer-toolbar-row")) {
+        label(.class("form-field organizer-toolbar-filter")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "カンファレンス" : "Conference") }
+          select(.id("organizer-slot-conference-filter"), .name("conferencePath")) {}
+        }
+        div(.class("organizer-toolbar-actions")) {
+          a(.id("export-timetable-link"), .class("button neutral"), .href("#")) {
+            HTMLText(language == .ja ? "タイムテーブル JSON" : "Export Timetable JSON")
+          }
+        }
+      }
+    }
+  }
+}
+
+private struct OrganizerTimetableCreateCard: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(.class("detail-card submit-form-card")) {
+      h3 { HTMLText(language == .ja ? "スロットを追加" : "Add Timetable Slot") }
+      form(.id("organizer-slot-form"), .class("submit-form-grid")) {
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "カンファレンス" : "Conference") }
+          select(.id("organizer-slot-conference-id"), .name("conferenceId"), .required) {}
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "Day" : "Day") }
+          input(.type(.number), .name("day"), .custom(name: "min", value: "1"), .custom(name: "max", value: "3"), .value("1"), .required)
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "開始時刻" : "Start Time") }
+          input(.type(.datetimeLocal), .name("startTime"), .required)
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "終了時刻 (任意)" : "End Time (optional)") }
+          input(.type(.datetimeLocal), .name("endTime"))
+        }
+        slotTypeSelect()
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "プロポーザル (任意)" : "Proposal (optional)") }
+          select(.id("organizer-slot-proposal-id"), .name("proposalId")) {}
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "カスタムタイトル" : "Custom Title") }
+          input(.type(.text), .name("customTitle"))
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "会場" : "Place") }
+          input(.type(.text), .name("place"))
+        }
+        div(.class("form-actions submit-form-full")) {
+          button(.type(.submit), .class("button primary")) {
+            HTMLText(language == .ja ? "スロットを作成" : "Create Slot")
+          }
+        }
+        p(.id("organizer-timetable-status"), .class("inline-status submit-form-full"), .hidden) {}
+      }
+    }
+  }
+
+  @HTMLBuilder
+  private func slotTypeSelect() -> some HTML {
+    label(.class("form-field")) {
+      span(.class("field-label")) { HTMLText(language == .ja ? "種別" : "Slot Type") }
+      select(.name("slotType"), .required) {
+        option(.value("talk")) { HTMLText("Talk") }
+        option(.value("lightning_talk")) { HTMLText("Lightning Talk") }
+        option(.value("break")) { HTMLText("Break") }
+        option(.value("lunch")) { HTMLText("Lunch") }
+        option(.value("opening")) { HTMLText("Opening") }
+        option(.value("closing")) { HTMLText("Closing") }
+        option(.value("party")) { HTMLText("Party") }
+        option(.value("custom")) { HTMLText("Custom") }
+      }
+    }
+  }
+}
+
+private struct OrganizerTimetableListCard: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(.class("detail-card")) {
+      h3 { HTMLText(language == .ja ? "スロット一覧" : "Timetable Slots") }
+      div(.id("organizer-slot-list"), .class("timetable-list")) {}
+    }
+  }
+}
+
+private struct OrganizerTimetableEditorCard: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(.class("detail-card submit-form-card")) {
+      h3 { HTMLText(language == .ja ? "スロットを編集" : "Edit Slot") }
+      p(.id("organizer-slot-editor-placeholder"), .class("submit-form-intro")) {
+        HTMLText(language == .ja
+          ? "一覧から Edit を選ぶとフォームに読み込まれます。"
+          : "Choose Edit on a slot above to load it here.")
+      }
+      form(.id("organizer-slot-editor-form"), .class("submit-form-grid")) {
+        input(.type(.hidden), .name("slotID"))
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "Day" : "Day") }
+          input(.type(.number), .name("day"), .custom(name: "min", value: "1"), .custom(name: "max", value: "3"), .required)
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "開始時刻" : "Start Time") }
+          input(.type(.datetimeLocal), .name("startTime"))
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "終了時刻 (任意)" : "End Time (optional)") }
+          input(.type(.datetimeLocal), .name("endTime"))
+        }
+        slotTypeSelect()
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "プロポーザル (任意)" : "Proposal (optional)") }
+          select(.id("organizer-slot-editor-proposal-id"), .name("proposalId")) {}
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "カスタムタイトル" : "Custom Title") }
+          input(.type(.text), .name("customTitle"))
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "会場" : "Place") }
+          input(.type(.text), .name("place"))
+        }
+        div(.class("form-actions submit-form-full split")) {
+          button(.type(.button), .id("organizer-slot-editor-reset"), .class("button neutral")) {
+            HTMLText(language == .ja ? "リセット" : "Reset")
+          }
+          button(.type(.submit), .class("button primary")) {
+            HTMLText(language == .ja ? "変更を保存" : "Save Changes")
+          }
+          button(.type(.button), .id("organizer-slot-reorder-button"), .class("button neutral")) {
+            HTMLText(language == .ja ? "この日の順序を保存" : "Apply Day Order")
+          }
+        }
+        p(.id("organizer-slot-editor-status"), .class("inline-status submit-form-full"), .hidden) {}
+      }
+    }
+  }
+
+  @HTMLBuilder
+  private func slotTypeSelect() -> some HTML {
+    label(.class("form-field")) {
+      span(.class("field-label")) { HTMLText(language == .ja ? "種別" : "Slot Type") }
+      select(.name("slotType"), .required) {
+        option(.value("talk")) { HTMLText("Talk") }
+        option(.value("lightning_talk")) { HTMLText("Lightning Talk") }
+        option(.value("break")) { HTMLText("Break") }
+        option(.value("lunch")) { HTMLText("Lunch") }
+        option(.value("opening")) { HTMLText("Opening") }
+        option(.value("closing")) { HTMLText("Closing") }
+        option(.value("party")) { HTMLText("Party") }
+        option(.value("custom")) { HTMLText("Custom") }
+      }
+    }
+  }
+}

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerTimetableContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerTimetableContent.swift
@@ -43,7 +43,7 @@ private struct OrganizerTimetableCreateCard: HTML, Sendable {
           select(.id("organizer-slot-conference-id"), .name("conferenceId"), .required) {}
         }
         label(.class("form-field")) {
-          span(.class("field-label")) { HTMLText(language == .ja ? "Day" : "Day") }
+          span(.class("field-label")) { HTMLText(language == .ja ? "開催日" : "Day") }
           input(
             .type(.number), .name("day"), .custom(name: "min", value: "1"),
             .custom(name: "max", value: "3"), .value("1"), .required)
@@ -127,7 +127,7 @@ private struct OrganizerTimetableEditorCard: HTML, Sendable {
       form(.id("organizer-slot-editor-form"), .class("submit-form-grid")) {
         input(.type(.hidden), .name("slotID"))
         label(.class("form-field")) {
-          span(.class("field-label")) { HTMLText(language == .ja ? "Day" : "Day") }
+          span(.class("field-label")) { HTMLText(language == .ja ? "開催日" : "Day") }
           input(
             .type(.number), .name("day"), .custom(name: "min", value: "1"),
             .custom(name: "max", value: "3"), .required)

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerWorkshopApplicationsContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerWorkshopApplicationsContent.swift
@@ -1,0 +1,28 @@
+import Elementary
+
+struct OrganizerWorkshopApplicationsContent: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(.class("detail-card organizer-toolbar")) {
+      h3 { HTMLText(language == .ja ? "ワークショップ応募" : "Workshop Applications") }
+      div(.class("organizer-toolbar-row")) {
+        label(.class("form-field organizer-toolbar-filter")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "ワークショップ絞り込み" : "Filter") }
+          select(.id("organizer-workshop-filter"), .name("workshopID")) {}
+        }
+        div(.class("organizer-toolbar-actions")) {
+          button(.type(.button), .id("organizer-workshop-applications-refresh"), .class("button neutral")) {
+            HTMLText(language == .ja ? "更新" : "Refresh")
+          }
+        }
+      }
+      p(.id("organizer-workshop-applications-status"), .class("inline-status"), .hidden) {}
+    }
+
+    article(.class("detail-card")) {
+      h3 { HTMLText(language == .ja ? "応募一覧" : "Applications") }
+      div(.id("organizer-workshop-applications-list"), .class("organizer-applications-list")) {}
+    }
+  }
+}

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerWorkshopApplicationsContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerWorkshopApplicationsContent.swift
@@ -12,7 +12,9 @@ struct OrganizerWorkshopApplicationsContent: HTML, Sendable {
           select(.id("organizer-workshop-filter"), .name("workshopID")) {}
         }
         div(.class("organizer-toolbar-actions")) {
-          button(.type(.button), .id("organizer-workshop-applications-refresh"), .class("button neutral")) {
+          button(
+            .type(.button), .id("organizer-workshop-applications-refresh"), .class("button neutral")
+          ) {
             HTMLText(language == .ja ? "更新" : "Refresh")
           }
         }

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerWorkshopResultsContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerWorkshopResultsContent.swift
@@ -8,7 +8,9 @@ struct OrganizerWorkshopResultsContent: HTML, Sendable {
       h3 { HTMLText(language == .ja ? "抽選結果" : "Workshop Results") }
       div(.class("organizer-toolbar-row")) {
         div(.class("organizer-toolbar-actions")) {
-          button(.type(.button), .id("organizer-workshop-results-refresh"), .class("button neutral")) {
+          button(
+            .type(.button), .id("organizer-workshop-results-refresh"), .class("button neutral")
+          ) {
             HTMLText(language == .ja ? "更新" : "Refresh")
           }
         }

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerWorkshopResultsContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerWorkshopResultsContent.swift
@@ -1,0 +1,24 @@
+import Elementary
+
+struct OrganizerWorkshopResultsContent: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(.class("detail-card organizer-toolbar")) {
+      h3 { HTMLText(language == .ja ? "抽選結果" : "Workshop Results") }
+      div(.class("organizer-toolbar-row")) {
+        div(.class("organizer-toolbar-actions")) {
+          button(.type(.button), .id("organizer-workshop-results-refresh"), .class("button neutral")) {
+            HTMLText(language == .ja ? "更新" : "Refresh")
+          }
+        }
+      }
+      p(.id("organizer-workshop-results-status"), .class("inline-status"), .hidden) {}
+    }
+
+    article(.class("detail-card")) {
+      h3 { HTMLText(language == .ja ? "結果一覧" : "Results") }
+      div(.id("organizer-workshop-results-list"), .class("organizer-results-list")) {}
+    }
+  }
+}

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerWorkshopsContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerWorkshopsContent.swift
@@ -15,10 +15,13 @@ struct OrganizerWorkshopsContent: HTML, Sendable {
           button(.type(.button), .id("organizer-workshops-refresh"), .class("button neutral")) {
             HTMLText(language == .ja ? "更新" : "Refresh")
           }
-          button(.type(.button), .id("organizer-workshop-lottery-button"), .class("button primary")) {
+          button(.type(.button), .id("organizer-workshop-lottery-button"), .class("button primary"))
+          {
             HTMLText(language == .ja ? "抽選を実行" : "Run Lottery")
           }
-          button(.type(.button), .id("organizer-workshop-send-tickets-button"), .class("button primary")) {
+          button(
+            .type(.button), .id("organizer-workshop-send-tickets-button"), .class("button primary")
+          ) {
             HTMLText(language == .ja ? "チケットを送信" : "Send Tickets")
           }
         }

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerWorkshopsContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerWorkshopsContent.swift
@@ -1,0 +1,34 @@
+import Elementary
+
+struct OrganizerWorkshopsContent: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(.class("detail-card organizer-toolbar")) {
+      h3 { HTMLText(language == .ja ? "ワークショップ管理" : "Workshop Management") }
+      div(.class("organizer-toolbar-row")) {
+        label(.class("form-field organizer-toolbar-filter")) {
+          span(.class("field-label")) { HTMLText(language == .ja ? "ワークショップ絞り込み" : "Filter") }
+          select(.id("organizer-workshop-filter"), .name("workshopID")) {}
+        }
+        div(.class("organizer-toolbar-actions")) {
+          button(.type(.button), .id("organizer-workshops-refresh"), .class("button neutral")) {
+            HTMLText(language == .ja ? "更新" : "Refresh")
+          }
+          button(.type(.button), .id("organizer-workshop-lottery-button"), .class("button primary")) {
+            HTMLText(language == .ja ? "抽選を実行" : "Run Lottery")
+          }
+          button(.type(.button), .id("organizer-workshop-send-tickets-button"), .class("button primary")) {
+            HTMLText(language == .ja ? "チケットを送信" : "Send Tickets")
+          }
+        }
+      }
+      p(.id("organizer-workshops-status"), .class("inline-status"), .hidden) {}
+    }
+
+    article(.class("detail-card")) {
+      h3 { HTMLText(language == .ja ? "ワークショップ一覧" : "Workshops") }
+      div(.id("organizer-workshops-list"), .class("organizer-workshops-list")) {}
+    }
+  }
+}

--- a/CfPWeb/Sources/CfPWeb/Components/PageContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/PageContent.swift
@@ -24,7 +24,7 @@ struct PageContent: HTML, Sendable {
     case .login:
       AuthRequiredPageContent(page: page, language: language)
     case .organizer:
-      AuthRequiredPageContent(page: page, language: language)  // replaced in Task 10
+      OrganizerShell(routePath: routePath, language: language)
     }
   }
 }

--- a/CfPWeb/Sources/CfPWeb/Components/PageContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/PageContent.swift
@@ -652,41 +652,6 @@ private struct SubmitWorkshopFields: HTML, Sendable {
   }
 }
 
-private struct SubmitCoInstructorFields: HTML, Sendable {
-  let language: AppLanguage
-  let prefix: String
-
-  var body: some HTML {
-    div(.class("submit-form-full co-instructor-fields")) {
-      h4 { HTMLText(language == .ja ? "共同講師" : "Co-Instructor") }
-      label(.class("form-field")) {
-        span(.class("field-label")) { HTMLText(language == .ja ? "名前" : "Name") }
-        input(.type(.text), .name("\(prefix)Name"))
-      }
-      label(.class("form-field")) {
-        span(.class("field-label")) { HTMLText("Email") }
-        input(.type(.email), .name("\(prefix)Email"))
-      }
-      label(.class("form-field")) {
-        span(.class("field-label")) { HTMLText("GitHub") }
-        input(.type(.text), .name("\(prefix)GithubUsername"))
-      }
-      label(.class("form-field submit-form-full")) {
-        span(.class("field-label")) { HTMLText("Bio") }
-        textarea(.name("\(prefix)Bio"), .custom(name: "rows", value: "3")) {}
-      }
-      label(.class("form-field")) {
-        span(.class("field-label")) { HTMLText("SNS") }
-        input(.type(.url), .name("\(prefix)Sns"))
-      }
-      label(.class("form-field")) {
-        span(.class("field-label")) { HTMLText(language == .ja ? "アイコンURL" : "Avatar URL") }
-        input(.type(.url), .name("\(prefix)IconURL"))
-      }
-    }
-  }
-}
-
 private struct WorkshopsContent: HTML, Sendable {
   let language: AppLanguage
 

--- a/CfPWeb/Sources/CfPWeb/Components/PageContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/PageContent.swift
@@ -3,6 +3,7 @@ import Elementary
 struct PageContent: HTML, Sendable {
   let page: CfPPage
   let language: AppLanguage
+  let routePath: String
 
   var body: some HTML {
     switch page {
@@ -20,8 +21,10 @@ struct PageContent: HTML, Sendable {
       MyProposalsContent(language: language)
     case .feedback:
       FeedbackContent(language: language)
-    case .login, .organizer:
+    case .login:
       AuthRequiredPageContent(page: page, language: language)
+    case .organizer:
+      AuthRequiredPageContent(page: page, language: language)  // replaced in Task 10
     }
   }
 }


### PR DESCRIPTION
## Summary
- PR #450 でサーバーサイドレンダリングのOrganizerページが削除されたあと、CfPWebに5セクション（Proposals / Timetable / Workshops / Applications / Results）のHTMLを復元しました
- `OrganizerSection` enum + `OrganizerShell` を追加し、URLごとにセクションをディスパッチします
- `app.js` の `bootstrapOrganizerPage` をセクション別の6関数に分割し、各URLで必要なハンドラーだけが動くようにしました

## Why
PR #450 後、`/organizer` はサインインカードしか表示されず、`bootstrapOrganizerPage` は必要なDOMが存在しないため早期リターンしていました。PR #453 でトップバーのメニューリンクは復元されましたが、その遷移先の画面がまだ欠けていたため、本PRで復元します。

Spec: `docs/superpowers/specs/2026-04-21-organizer-content-restore-design.md`
Plan: `docs/superpowers/plans/2026-04-21-organizer-content-restoration.md`

## Test plan
- [x] `cd CfPWeb && swift build` 成功
- [x] `cd CfPWeb && CFP_API_BASE_URL=http://127.0.0.1:8080 swift run` 成功
- [x] 5セクション + JA版、全13URLが生成される
- [x] `/organizer/timetable` にProposalsフォームが含まれない（URLディスパッチ検証）
- [x] サブナビの `active` クラスが正しく付与される
- [x] `node --check CfPWeb/Public/scripts/app.js` 成功
- [ ] 本番相当環境でadminとしてログイン → Proposals一覧が読み込まれる
- [ ] サブナビでセクション間を遷移し、それぞれ自セクションのみレンダリングされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)