### PR TITLE
Render open conferences dynamically on CfPWeb landing

### DIFF
--- a/CfPWeb/Public/scripts/app.js
+++ b/CfPWeb/Public/scripts/app.js
@@ -229,10 +229,25 @@
 
   function formatEventDate(value) {
     if (!value) return "";
+    var locale = currentLanguage() === "ja" ? "ja-JP" : "en-US";
+    var formatOptions = { year: "numeric", month: "long", day: "numeric", timeZone: "UTC" };
+
+    // Format the calendar date as authored by the API (ISO `YYYY-MM-DD...`),
+    // ignoring the viewer's local timezone so a +09:00 conference date does
+    // not render off-by-one for users in earlier timezones.
+    if (typeof value === "string") {
+      var match = value.match(/^(\d{4})-(\d{2})-(\d{2})/);
+      if (match) {
+        var fromParts = new Date(Date.UTC(parseInt(match[1], 10), parseInt(match[2], 10) - 1, parseInt(match[3], 10)));
+        if (!isNaN(fromParts.getTime())) {
+          return fromParts.toLocaleDateString(locale, formatOptions);
+        }
+      }
+    }
+
     var date = new Date(value);
     if (isNaN(date.getTime())) return "";
-    var locale = currentLanguage() === "ja" ? "ja-JP" : "en-US";
-    return date.toLocaleDateString(locale, { year: "numeric", month: "long", day: "numeric" });
+    return date.toLocaleDateString(locale, formatOptions);
   }
 
   function formatEventDateRange(start, end) {
@@ -354,10 +369,18 @@
     if (!document.getElementById("cfp-events-list")) return;
     try {
       await loadOpenConferences();
+      renderCfPEventsList();
     } catch (_error) {
       state.openConferences = [];
+      var statusEl = document.getElementById("cfp-events-status");
+      if (statusEl) {
+        statusEl.textContent = localizedCopy(
+          "Failed to load open calls for proposals. Please try again later.",
+          "募集中のイベントを読み込めませんでした。時間をおいて再度お試しください。"
+        );
+        statusEl.hidden = false;
+      }
     }
-    renderCfPEventsList();
   }
 
   function preselectConferenceFromQuery(conferences) {

--- a/CfPWeb/Public/scripts/app.js
+++ b/CfPWeb/Public/scripts/app.js
@@ -227,6 +227,153 @@
     return state.openConferences;
   }
 
+  function formatEventDate(value) {
+    if (!value) return "";
+    var date = new Date(value);
+    if (isNaN(date.getTime())) return "";
+    var locale = currentLanguage() === "ja" ? "ja-JP" : "en-US";
+    return date.toLocaleDateString(locale, { year: "numeric", month: "long", day: "numeric" });
+  }
+
+  function formatEventDateRange(start, end) {
+    var startText = formatEventDate(start);
+    var endText = formatEventDate(end);
+    if (startText && endText && startText !== endText) {
+      return startText + " – " + endText;
+    }
+    return startText || endText;
+  }
+
+  function localizedConferenceDescription(conference) {
+    var description = conference && conference.description;
+    if (!description) return "";
+    return currentLanguage() === "ja"
+      ? (description.ja || description.en || "")
+      : (description.en || description.ja || "");
+  }
+
+  function renderCfPEventsList() {
+    var container = document.getElementById("cfp-events-list");
+    if (!container) return;
+
+    var statusEl = document.getElementById("cfp-events-status");
+    var conferences = state.openConferences || [];
+
+    if (!conferences.length) {
+      container.innerHTML = "";
+      if (statusEl) {
+        statusEl.textContent = localizedCopy(
+          "There are no open calls for proposals right now.",
+          "現在募集中のイベントはありません。"
+        );
+        statusEl.hidden = false;
+      }
+      return;
+    }
+
+    if (statusEl) {
+      statusEl.hidden = true;
+      statusEl.textContent = "";
+    }
+
+    var deadlineLabel = localizedCopy("Submission Deadline", "応募締切");
+    var datesLabel = localizedCopy("Conference Dates", "開催日");
+    var locationLabel = localizedCopy("Location", "会場");
+    var openBadgeText = localizedCopy("Open", "募集中");
+    var submitButtonText = localizedCopy("Submit a Proposal", "このイベントに応募");
+    var detailsButtonText = localizedCopy("Event Details ↗", "イベント詳細 ↗");
+    var submitBasePath = isJapanese() ? "/ja/submit" : "/submit";
+
+    var html = "";
+    conferences.forEach(function (conference) {
+      var displayName = escapeHTML(String(conference.displayName || ""));
+      var description = escapeHTML(localizedConferenceDescription(conference));
+      var deadline = escapeHTML(formatEventDate(conference.deadline));
+      var dateRange = escapeHTML(formatEventDateRange(conference.startDate, conference.endDate));
+      var location = escapeHTML(String(conference.location || ""));
+      var path = encodeURIComponent(String(conference.path || ""));
+      var websiteURL = conference.websiteURL ? safeExternalURL(conference.websiteURL) : "";
+
+      html += '<article class="detail-card event-card">';
+      html += '<div class="event-card-header">';
+      html += "<h3>" + displayName + "</h3>";
+      html += '<span class="event-status-badge open">' + escapeHTML(openBadgeText) + "</span>";
+      html += "</div>";
+      if (description) {
+        html += '<p class="event-description">' + description + "</p>";
+      }
+      html += '<dl class="event-meta">';
+      if (deadline) {
+        html += '<div class="event-meta-row">';
+        html += "<dt>" + escapeHTML(deadlineLabel) + "</dt>";
+        html += "<dd>" + deadline + "</dd>";
+        html += "</div>";
+      }
+      if (dateRange) {
+        html += '<div class="event-meta-row">';
+        html += "<dt>" + escapeHTML(datesLabel) + "</dt>";
+        html += "<dd>" + dateRange + "</dd>";
+        html += "</div>";
+      }
+      if (location) {
+        html += '<div class="event-meta-row">';
+        html += "<dt>" + escapeHTML(locationLabel) + "</dt>";
+        html += "<dd>" + location + "</dd>";
+        html += "</div>";
+      }
+      html += "</dl>";
+      html += '<div class="event-actions">';
+      html += '<a class="button primary button-link" href="' + submitBasePath + "?conference=" + path + '">';
+      html += escapeHTML(submitButtonText);
+      html += "</a>";
+      if (websiteURL) {
+        html += '<a class="button light button-link" target="_blank" rel="noopener" href="' + escapeHTML(websiteURL) + '">';
+        html += escapeHTML(detailsButtonText);
+        html += "</a>";
+      }
+      html += "</div>";
+      html += "</article>";
+    });
+
+    container.innerHTML = html;
+  }
+
+  function safeExternalURL(value) {
+    try {
+      var url = new URL(value, window.location.origin);
+      if (url.protocol === "http:" || url.protocol === "https:") {
+        return url.href;
+      }
+    } catch (_error) {
+      return "";
+    }
+    return "";
+  }
+
+  async function bootstrapHomePage() {
+    if (!document.getElementById("cfp-events-list")) return;
+    try {
+      await loadOpenConferences();
+    } catch (_error) {
+      state.openConferences = [];
+    }
+    renderCfPEventsList();
+  }
+
+  function preselectConferenceFromQuery(conferences) {
+    var select = document.getElementById("submit-conference-path");
+    if (!select) return;
+    var params = new URLSearchParams(window.location.search);
+    var requested = params.get("conference");
+    if (!requested) return;
+    var match = (conferences || []).some(function (item) {
+      return String(item.path) === requested;
+    });
+    if (match) {
+      select.value = requested;
+    }
+  }
+
   async function loadAllConferences() {
     state.conferences = await apiRequest("/api/v1/conferences");
     return state.conferences;
@@ -1147,6 +1294,7 @@
     try {
       var openConferences = await loadOpenConferences();
       populateSelect("submit-conference-path", openConferences, null, "path", "displayName");
+      preselectConferenceFromQuery(openConferences);
       prefillSpeakerFields(form, state.user);
       if (!openConferences.length) {
         showStatus("submit-status", "There is no open conference right now.", "error");
@@ -2149,6 +2297,10 @@
   async function bootstrapPage() {
     var path = normalizedPathname();
 
+    if (path === "/") {
+      await bootstrapHomePage();
+      return;
+    }
     if (path === "/profile") {
       await bootstrapProfilePage();
       return;

--- a/CfPWeb/Public/styles/app.css
+++ b/CfPWeb/Public/styles/app.css
@@ -920,6 +920,90 @@ body.modal-open {
   grid-template-columns: repeat(3, minmax(0, 1fr));
 }
 
+.events-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  align-items: stretch;
+}
+
+.events-status {
+  display: block;
+  margin: 0 0 16px;
+  text-align: center;
+  color: var(--muted);
+}
+
+.event-card {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  text-align: left;
+}
+
+.event-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.event-card-header h3 {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 700;
+  flex: 1 1 auto;
+}
+
+.event-status-badge {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  background: rgba(33, 150, 83, 0.12);
+  color: #1f7a3a;
+  white-space: nowrap;
+}
+
+.event-description {
+  margin: 0;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.event-meta {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 6px;
+}
+
+.event-meta-row {
+  display: grid;
+  grid-template-columns: minmax(0, 90px) minmax(0, 1fr);
+  gap: 8px;
+  margin: 0;
+  font-size: 0.95rem;
+}
+
+.event-meta-row dt {
+  margin: 0;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.event-meta-row dd {
+  margin: 0;
+  color: inherit;
+}
+
+.event-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: auto;
+}
+
 .detail-card,
 .status-card {
   background: #fff;
@@ -1151,7 +1235,8 @@ body.modal-open {
   }
 
   .dates-grid,
-  .info-grid {
+  .info-grid,
+  .events-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
@@ -1255,7 +1340,8 @@ body.modal-open {
   }
 
   .dates-grid,
-  .info-grid {
+  .info-grid,
+  .events-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/CfPWeb/Sources/CfPWeb/Components/AppLayout.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/AppLayout.swift
@@ -16,15 +16,23 @@ struct AppLayout: HTMLDocument, Sendable {
     meta(.charset(.utf8))
     meta(.name(.viewport), .content("width=device-width, initial-scale=1"))
     meta(.name(.description), .content(page.description(for: language)))
-    meta(.property("og:title"), .content("\(page.title(for: language)) - try! Swift Tokyo 2026"))
-    meta(.property("og:description"), .content("Submit your talk proposal for try! Swift Tokyo 2026. Share your Swift expertise with developers from around the world."))
+    meta(.property("og:title"), .content("\(page.title(for: language)) - try! Swift Tokyo CfP"))
+    meta(
+      .property("og:description"),
+      .content(
+        "Submit your talk proposal for try! Swift Tokyo events. Share your Swift expertise with developers from around the world."
+      ))
     meta(.property("og:image"), .content("https://tryswift.jp/images/ogp.jpg"))
     meta(.name("twitter:card"), .content("summary_large_image"))
-    meta(.name("twitter:title"), .content("\(page.title(for: language)) - try! Swift Tokyo 2026"))
+    meta(.name("twitter:title"), .content("\(page.title(for: language)) - try! Swift Tokyo CfP"))
     meta(.name("twitter:image"), .content("https://tryswift.jp/images/ogp.jpg"))
-    link(.rel(.stylesheet), .href("https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"))
+    link(
+      .rel(.stylesheet),
+      .href("https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css"))
     link(.rel(.stylesheet), .href("/styles/app.css"))
-    link(.rel(.icon), .custom(name: "type", value: "image/png"), .href("https://tryswift.jp/images/favicon.png"))
+    link(
+      .rel(.icon), .custom(name: "type", value: "image/png"),
+      .href("https://tryswift.jp/images/favicon.png"))
     script(.src("/scripts/app.js"), .custom(name: "defer", value: "defer")) {}
     script(.src("https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js")) {}
     meta(.custom(name: "name", value: "cfp-api-base-url"), .content(apiBaseURL))
@@ -39,8 +47,12 @@ struct AppLayout: HTMLDocument, Sendable {
       footer(.class("footer")) {
         div(.class("footer-links")) {
           a(.href("https://tryswift.jp")) { HTMLText(language == .ja ? "メインサイト" : "Main Website") }
-          a(.href("https://tryswift.jp/code-of-conduct")) { HTMLText(language == .ja ? "行動規範" : "Code of Conduct") }
-          a(.href("https://tryswift.jp/privacy-policy")) { HTMLText(language == .ja ? "プライバシーポリシー" : "Privacy Policy") }
+          a(.href("https://tryswift.jp/code-of-conduct")) {
+            HTMLText(language == .ja ? "行動規範" : "Code of Conduct")
+          }
+          a(.href("https://tryswift.jp/privacy-policy")) {
+            HTMLText(language == .ja ? "プライバシーポリシー" : "Privacy Policy")
+          }
         }
         div(.class("footer-links social")) {
           a(.href("https://x.com/tryswiftconf")) { "X" }

--- a/CfPWeb/Sources/CfPWeb/Components/PageContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/PageContent.swift
@@ -114,9 +114,10 @@ private struct SubmitContent: HTML, Sendable {
       div(.class("submit-shell-inner")) {
         h1 { HTMLText(language == .ja ? "プロポーザルを提出" : "Submit Your Proposal") }
         p(.class("submit-lead")) {
-          HTMLText(language == .ja
-            ? "あなたのSwiftの知見を、世界中の開発者と共有しませんか。"
-            : "Share your Swift expertise with developers from around the world.")
+          HTMLText(
+            language == .ja
+              ? "あなたのSwiftの知見を、世界中の開発者と共有しませんか。"
+              : "Share your Swift expertise with developers from around the world.")
         }
         SignInPromptCard(
           language: language,
@@ -143,7 +144,10 @@ private struct SignInPromptCard: HTML, Sendable {
 
   var body: some HTML {
     if togglesWithSignedInContent {
-      article(.class("detail-card submit-auth-card \(extraClasses)"), .data("auth-guest-card", value: "true")) {
+      article(
+        .class("detail-card submit-auth-card \(extraClasses)"),
+        .data("auth-guest-card", value: "true")
+      ) {
         cardBody
       }
     } else {
@@ -189,12 +193,16 @@ private struct SubmitFormCard: HTML, Sendable {
   let language: AppLanguage
 
   var body: some HTML {
-    article(.id("submit-form-card"), .class("detail-card submit-form-card"), .data("auth-signed-in-card", value: "true"), .hidden) {
+    article(
+      .id("submit-form-card"), .class("detail-card submit-form-card"),
+      .data("auth-signed-in-card", value: "true"), .hidden
+    ) {
       h3 { HTMLText(language == .ja ? "プロポーザル詳細" : "Proposal Details") }
       p(.class("submit-form-intro")) {
-        HTMLText(language == .ja
-          ? "タイトル、概要、スピーカー情報を入力して応募できます。"
-          : "Fill in your talk details and speaker information to submit.")
+        HTMLText(
+          language == .ja
+            ? "タイトル、概要、スピーカー情報を入力して応募できます。"
+            : "Fill in your talk details and speaker information to submit.")
       }
 
       form(.id("submit-form"), .class("submit-form-grid")) {
@@ -219,9 +227,10 @@ private struct ProfileContent: HTML, Sendable {
       div(.class("submit-shell-inner")) {
         h1 { HTMLText(language == .ja ? "プロフィール" : "Profile") }
         p(.class("submit-lead")) {
-          HTMLText(language == .ja
-            ? "スピーカープロフィールを更新して、応募情報に反映できます。"
-            : "Update your speaker profile and keep your submission details current.")
+          HTMLText(
+            language == .ja
+              ? "スピーカープロフィールを更新して、応募情報に反映できます。"
+              : "Update your speaker profile and keep your submission details current.")
         }
         SignInPromptCard(
           language: language,
@@ -233,12 +242,16 @@ private struct ProfileContent: HTML, Sendable {
             : "Your GitHub account is connected. You can manage your speaker profile with this account.",
           togglesWithSignedInContent: true
         )
-        article(.class("detail-card submit-form-card"), .data("auth-signed-in-card", value: "true"), .hidden) {
+        article(
+          .class("detail-card submit-form-card"), .data("auth-signed-in-card", value: "true"),
+          .hidden
+        ) {
           h3 { HTMLText(language == .ja ? "プロフィール情報" : "Profile Details") }
           p(.class("submit-form-intro")) {
-            HTMLText(language == .ja
-              ? "表示名や自己紹介など、CfP で利用するプロフィールを更新できます。"
-              : "Update the profile information used across the CfP experience.")
+            HTMLText(
+              language == .ja
+                ? "表示名や自己紹介など、CfP で利用するプロフィールを更新できます。"
+                : "Update the profile information used across the CfP experience.")
           }
           form(.id("profile-form"), .class("submit-form-grid")) {
             label(.class("form-field")) {
@@ -264,7 +277,11 @@ private struct ProfileContent: HTML, Sendable {
             div(.class("form-field avatar-field submit-form-full")) {
               span(.class("field-label")) { HTMLText(language == .ja ? "アイコンURL" : "Avatar URL") }
               div(.class("avatar-field-row")) {
-                input(.type(.url), .name("avatarURL"), .placeholder(language == .ja ? "https://example.com/avatar.png" : "https://example.com/avatar.png"))
+                input(
+                  .type(.url), .name("avatarURL"),
+                  .placeholder(
+                    language == .ja
+                      ? "https://example.com/avatar.png" : "https://example.com/avatar.png"))
                 div(.class("avatar-preview"), .id("profile-avatar-preview")) {
                   img(
                     .id("profile-avatar-image"),
@@ -295,9 +312,10 @@ private struct MyProposalsContent: HTML, Sendable {
       div(.class("submit-shell-inner")) {
         h1 { HTMLText(language == .ja ? "応募履歴" : "My Proposals") }
         p(.class("submit-lead")) {
-          HTMLText(language == .ja
-            ? "応募したプロポーザルの確認や編集、取り下げができます。"
-            : "Review, edit, or withdraw the proposals linked to your account.")
+          HTMLText(
+            language == .ja
+              ? "応募したプロポーザルの確認や編集、取り下げができます。"
+              : "Review, edit, or withdraw the proposals linked to your account.")
         }
         SignInPromptCard(
           language: language,
@@ -314,9 +332,10 @@ private struct MyProposalsContent: HTML, Sendable {
             p(.id("my-proposals-status"), .class("inline-status"), .hidden) {}
             article(.id("my-proposals-empty"), .class("detail-card empty-state"), .hidden) {
               p {
-                HTMLText(language == .ja
-                  ? "まだプロポーザルはありません。Submit ページから応募できます。"
-                  : "No proposals found yet. You can submit one from the Submit page.")
+                HTMLText(
+                  language == .ja
+                    ? "まだプロポーザルはありません。Submit ページから応募できます。"
+                    : "No proposals found yet. You can submit one from the Submit page.")
               }
             }
             div(.id("my-proposals-list"), .class("proposal-list")) {}
@@ -335,13 +354,19 @@ private struct MyProposalEditorPage: HTML, Sendable {
     section(.id("my-proposals-detail-view"), .hidden) {
       article(.class("detail-card submit-form-card")) {
         div(.class("editor-header-row")) {
-          a(.id("proposal-editor-back-link"), .href(CfPPage.myProposals.path(for: language)), .class("button neutral button-link")) {
+          a(
+            .id("proposal-editor-back-link"), .href(CfPPage.myProposals.path(for: language)),
+            .class("button neutral button-link")
+          ) {
             span(.custom(name: "aria-hidden", value: "true")) { "←" }
           }
           h3 { HTMLText(language == .ja ? "応募内容を編集" : "Edit Proposal") }
         }
         p(.class("submit-form-intro")) {
-          HTMLText(language == .ja ? "内容を更新すると、このアカウントの応募に反映されます。" : "Update the details for this proposal in your account.")
+          HTMLText(
+            language == .ja
+              ? "内容を更新すると、このアカウントの応募に反映されます。"
+              : "Update the details for this proposal in your account.")
         }
         form(.id("proposal-editor-form"), .class("submit-form-grid")) {
           input(.type(.hidden), .name("proposalID"))
@@ -360,8 +385,12 @@ private struct MyProposalEditorPage: HTML, Sendable {
           label(.class("form-field")) {
             span(.class("field-label")) { HTMLText(language == .ja ? "形式" : "Format") }
             select(.name("talkDuration"), .required) {
-              option(.value("20min")) { HTMLText(language == .ja ? "レギュラートーク (20分)" : "Regular Talk (20 min)") }
-              option(.value("LT")) { HTMLText(language == .ja ? "ライトニングトーク (5分)" : "Lightning Talk (5 min)") }
+              option(.value("20min")) {
+                HTMLText(language == .ja ? "レギュラートーク (20分)" : "Regular Talk (20 min)")
+              }
+              option(.value("LT")) {
+                HTMLText(language == .ja ? "ライトニングトーク (5分)" : "Lightning Talk (5 min)")
+              }
               option(.value("workshop")) { HTMLText(language == .ja ? "ワークショップ" : "Workshop") }
             }
           }
@@ -380,7 +409,11 @@ private struct MyProposalEditorPage: HTML, Sendable {
           div(.class("form-field avatar-field submit-form-full")) {
             span(.class("field-label")) { HTMLText(language == .ja ? "アイコンURL" : "Avatar URL") }
             div(.class("avatar-field-row")) {
-              input(.type(.url), .name("iconURL"), .placeholder(language == .ja ? "https://example.com/avatar.png" : "https://example.com/avatar.png"))
+              input(
+                .type(.url), .name("iconURL"),
+                .placeholder(
+                  language == .ja
+                    ? "https://example.com/avatar.png" : "https://example.com/avatar.png"))
               div(.class("avatar-preview")) {
                 img(
                   .id("proposal-avatar-image"),
@@ -391,7 +424,9 @@ private struct MyProposalEditorPage: HTML, Sendable {
             }
           }
           label(.class("form-field submit-form-full")) {
-            span(.class("field-label")) { HTMLText(language == .ja ? "メモ" : "Notes for Organizers") }
+            span(.class("field-label")) {
+              HTMLText(language == .ja ? "メモ" : "Notes for Organizers")
+            }
             textarea(.name("notes"), .custom(name: "rows", value: "4")) {}
           }
           EditWorkshopFields(language: language)
@@ -414,7 +449,10 @@ private struct EditWorkshopFields: HTML, Sendable {
   let language: AppLanguage
 
   var body: some HTML {
-    div(.id("speaker-edit-workshop-section"), .class("submit-workshop-section submit-form-full"), .hidden) {
+    div(
+      .id("speaker-edit-workshop-section"), .class("submit-workshop-section submit-form-full"),
+      .hidden
+    ) {
       h4 { HTMLText(language == .ja ? "ワークショップ詳細" : "Workshop Details") }
       label(.class("form-field")) {
         span(.class("field-label")) { HTMLText(language == .ja ? "言語" : "Language") }
@@ -426,7 +464,9 @@ private struct EditWorkshopFields: HTML, Sendable {
       }
       label(.class("form-field")) {
         span(.class("field-label")) { HTMLText(language == .ja ? "講師数" : "Number of Tutors") }
-        input(.type(.number), .name("workshopNumberOfTutors"), .custom(name: "min", value: "1"), .value("1"))
+        input(
+          .type(.number), .name("workshopNumberOfTutors"), .custom(name: "min", value: "1"),
+          .value("1"))
       }
       label(.class("form-field submit-form-full")) {
         span(.class("field-label")) { HTMLText(language == .ja ? "学べること" : "Key Takeaways") }
@@ -445,11 +485,15 @@ private struct EditWorkshopFields: HTML, Sendable {
         textarea(.name("workshopParticipantRequirements"), .custom(name: "rows", value: "3")) {}
       }
       label(.class("form-field submit-form-full")) {
-        span(.class("field-label")) { HTMLText(language == .ja ? "必要なソフトウェア" : "Required Software") }
+        span(.class("field-label")) {
+          HTMLText(language == .ja ? "必要なソフトウェア" : "Required Software")
+        }
         textarea(.name("workshopRequiredSoftware"), .custom(name: "rows", value: "3")) {}
       }
       label(.class("form-field submit-form-full")) {
-        span(.class("field-label")) { HTMLText(language == .ja ? "ネットワーク要件" : "Network Requirements") }
+        span(.class("field-label")) {
+          HTMLText(language == .ja ? "ネットワーク要件" : "Network Requirements")
+        }
         textarea(.name("workshopNetworkRequirements"), .custom(name: "rows", value: "3")) {}
       }
       label(.class("form-field submit-form-full")) {
@@ -466,10 +510,22 @@ private struct EditWorkshopFields: HTML, Sendable {
       }
       div(.class("submit-form-full workshop-facilities")) {
         span(.class("field-label")) { HTMLText(language == .ja ? "必要設備" : "Required Facilities") }
-        label { input(.type(.checkbox), .name("workshopFacilityProjector")); HTMLText(language == .ja ? "プロジェクター" : "Projector") }
-        label { input(.type(.checkbox), .name("workshopFacilityMicrophone")); HTMLText(language == .ja ? "マイク" : "Microphone") }
-        label { input(.type(.checkbox), .name("workshopFacilityWhiteboard")); HTMLText(language == .ja ? "ホワイトボード" : "Whiteboard") }
-        label { input(.type(.checkbox), .name("workshopFacilityPowerStrips")); HTMLText(language == .ja ? "電源タップ" : "Power Strips") }
+        label {
+          input(.type(.checkbox), .name("workshopFacilityProjector"))
+          HTMLText(language == .ja ? "プロジェクター" : "Projector")
+        }
+        label {
+          input(.type(.checkbox), .name("workshopFacilityMicrophone"))
+          HTMLText(language == .ja ? "マイク" : "Microphone")
+        }
+        label {
+          input(.type(.checkbox), .name("workshopFacilityWhiteboard"))
+          HTMLText(language == .ja ? "ホワイトボード" : "Whiteboard")
+        }
+        label {
+          input(.type(.checkbox), .name("workshopFacilityPowerStrips"))
+          HTMLText(language == .ja ? "電源タップ" : "Power Strips")
+        }
       }
       label(.class("form-field submit-form-full")) {
         span(.class("field-label")) { HTMLText(language == .ja ? "その他設備" : "Other Facilities") }
@@ -489,9 +545,10 @@ private struct FeedbackContent: HTML, Sendable {
       div(.class("submit-shell-inner")) {
         h1 { HTMLText(language == .ja ? "フィードバック" : "Feedback") }
         p(.class("submit-lead")) {
-          HTMLText(language == .ja
-            ? "あなたのセッションに届いたフィードバックを確認できます。"
-            : "Review feedback submitted for your accepted sessions.")
+          HTMLText(
+            language == .ja
+              ? "あなたのセッションに届いたフィードバックを確認できます。"
+              : "Review feedback submitted for your accepted sessions.")
         }
         SignInPromptCard(
           language: language,
@@ -512,9 +569,10 @@ private struct FeedbackContent: HTML, Sendable {
           p(.id("feedback-status"), .class("inline-status"), .hidden) {}
           article(.id("feedback-empty"), .class("detail-card empty-state"), .hidden) {
             p {
-              HTMLText(language == .ja
-                ? "まだフィードバックは届いていません。"
-                : "No feedback has been submitted for your talks yet.")
+              HTMLText(
+                language == .ja
+                  ? "まだフィードバックは届いていません。"
+                  : "No feedback has been submitted for your talks yet.")
             }
           }
           div(.id("feedback-list"), .class("proposal-list")) {}
@@ -535,8 +593,12 @@ private struct SubmitBasicFields: HTML, Sendable {
     label(.class("form-field")) {
       span(.class("field-label")) { HTMLText(language == .ja ? "形式" : "Format") }
       select(.name("talkDuration"), .required) {
-        option(.value("20min")) { HTMLText(language == .ja ? "レギュラートーク (20分)" : "Regular Talk (20 min)") }
-        option(.value("LT")) { HTMLText(language == .ja ? "ライトニングトーク (5分)" : "Lightning Talk (5 min)") }
+        option(.value("20min")) {
+          HTMLText(language == .ja ? "レギュラートーク (20分)" : "Regular Talk (20 min)")
+        }
+        option(.value("LT")) {
+          HTMLText(language == .ja ? "ライトニングトーク (5分)" : "Lightning Talk (5 min)")
+        }
         option(.value("workshop")) { HTMLText(language == .ja ? "ワークショップ" : "Workshop") }
       }
     }
@@ -567,7 +629,10 @@ private struct SubmitBasicFields: HTML, Sendable {
     div(.class("form-field avatar-field submit-form-full")) {
       span(.class("field-label")) { HTMLText(language == .ja ? "アイコンURL" : "Avatar URL") }
       div(.class("avatar-field-row")) {
-        input(.type(.url), .name("iconURL"), .placeholder(language == .ja ? "https://example.com/avatar.png" : "https://example.com/avatar.png"))
+        input(
+          .type(.url), .name("iconURL"),
+          .placeholder(
+            language == .ja ? "https://example.com/avatar.png" : "https://example.com/avatar.png"))
         div(.class("avatar-preview"), .id("submit-avatar-preview")) {
           img(
             .id("submit-avatar-image"),
@@ -588,7 +653,8 @@ private struct SubmitWorkshopFields: HTML, Sendable {
   let language: AppLanguage
 
   var body: some HTML {
-    div(.id("submit-workshop-section"), .class("submit-workshop-section submit-form-full"), .hidden) {
+    div(.id("submit-workshop-section"), .class("submit-workshop-section submit-form-full"), .hidden)
+    {
       h4 { HTMLText(language == .ja ? "ワークショップ詳細" : "Workshop Details") }
       label(.class("form-field")) {
         span(.class("field-label")) { HTMLText(language == .ja ? "言語" : "Language") }
@@ -600,7 +666,9 @@ private struct SubmitWorkshopFields: HTML, Sendable {
       }
       label(.class("form-field")) {
         span(.class("field-label")) { HTMLText(language == .ja ? "講師数" : "Number of Tutors") }
-        input(.type(.number), .name("workshopNumberOfTutors"), .custom(name: "min", value: "1"), .value("1"))
+        input(
+          .type(.number), .name("workshopNumberOfTutors"), .custom(name: "min", value: "1"),
+          .value("1"))
       }
       label(.class("form-field submit-form-full")) {
         span(.class("field-label")) { HTMLText(language == .ja ? "学べること" : "Key Takeaways") }
@@ -619,11 +687,15 @@ private struct SubmitWorkshopFields: HTML, Sendable {
         textarea(.name("workshopParticipantRequirements"), .custom(name: "rows", value: "3")) {}
       }
       label(.class("form-field submit-form-full")) {
-        span(.class("field-label")) { HTMLText(language == .ja ? "必要なソフトウェア" : "Required Software") }
+        span(.class("field-label")) {
+          HTMLText(language == .ja ? "必要なソフトウェア" : "Required Software")
+        }
         textarea(.name("workshopRequiredSoftware"), .custom(name: "rows", value: "3")) {}
       }
       label(.class("form-field submit-form-full")) {
-        span(.class("field-label")) { HTMLText(language == .ja ? "ネットワーク要件" : "Network Requirements") }
+        span(.class("field-label")) {
+          HTMLText(language == .ja ? "ネットワーク要件" : "Network Requirements")
+        }
         textarea(.name("workshopNetworkRequirements"), .custom(name: "rows", value: "3")) {}
       }
       label(.class("form-field submit-form-full")) {
@@ -640,10 +712,22 @@ private struct SubmitWorkshopFields: HTML, Sendable {
       }
       div(.class("submit-form-full workshop-facilities")) {
         span(.class("field-label")) { HTMLText(language == .ja ? "必要設備" : "Required Facilities") }
-        label { input(.type(.checkbox), .name("workshopFacilityProjector")); HTMLText(language == .ja ? "プロジェクター" : "Projector") }
-        label { input(.type(.checkbox), .name("workshopFacilityMicrophone")); HTMLText(language == .ja ? "マイク" : "Microphone") }
-        label { input(.type(.checkbox), .name("workshopFacilityWhiteboard")); HTMLText(language == .ja ? "ホワイトボード" : "Whiteboard") }
-        label { input(.type(.checkbox), .name("workshopFacilityPowerStrips")); HTMLText(language == .ja ? "電源タップ" : "Power Strips") }
+        label {
+          input(.type(.checkbox), .name("workshopFacilityProjector"))
+          HTMLText(language == .ja ? "プロジェクター" : "Projector")
+        }
+        label {
+          input(.type(.checkbox), .name("workshopFacilityMicrophone"))
+          HTMLText(language == .ja ? "マイク" : "Microphone")
+        }
+        label {
+          input(.type(.checkbox), .name("workshopFacilityWhiteboard"))
+          HTMLText(language == .ja ? "ホワイトボード" : "Whiteboard")
+        }
+        label {
+          input(.type(.checkbox), .name("workshopFacilityPowerStrips"))
+          HTMLText(language == .ja ? "電源タップ" : "Power Strips")
+        }
       }
       label(.class("form-field submit-form-full")) {
         span(.class("field-label")) { HTMLText(language == .ja ? "その他設備" : "Other Facilities") }
@@ -663,9 +747,11 @@ private struct WorkshopsContent: HTML, Sendable {
       div(.class("workshops-shell-inner")) {
         h1 { HTMLText(language == .ja ? "ワークショップ" : "Workshops") }
         p(.class("workshops-lead")) {
-          HTMLText(language == .ja
-            ? "try! Swift Tokyo 2026 のワークショップに応募できます。第3希望まで選択でき、割り当ては抽選で決定されます。"
-            : "Apply for try! Swift Tokyo 2026 workshops. You can select up to 3 preferences, and assignments are determined by lottery.")
+          HTMLText(
+            language == .ja
+              ? "try! Swift Tokyo のワークショップに応募できます。第3希望まで選択でき、割り当ては抽選で決定されます。"
+              : "Apply for try! Swift Tokyo workshops. You can select up to 3 preferences, and assignments are determined by lottery."
+          )
         }
 
         p(.id("workshops-status"), .class("status-banner"), .hidden) {}
@@ -676,8 +762,15 @@ private struct WorkshopsContent: HTML, Sendable {
 
         section(.id("workshop-modal"), .class("workshop-modal"), .hidden) {
           div(.class("workshop-modal-backdrop"), .data("workshop-modal-close", value: "true")) {}
-          div(.class("workshop-modal-dialog"), .custom(name: "role", value: "dialog"), .custom(name: "aria-modal", value: "true")) {
-            button(.type(.button), .class("workshop-modal-close"), .data("workshop-modal-close", value: "true"), .custom(name: "aria-label", value: language == .ja ? "閉じる" : "Close")) { "×" }
+          div(
+            .class("workshop-modal-dialog"), .custom(name: "role", value: "dialog"),
+            .custom(name: "aria-modal", value: "true")
+          ) {
+            button(
+              .type(.button), .class("workshop-modal-close"),
+              .data("workshop-modal-close", value: "true"),
+              .custom(name: "aria-label", value: language == .ja ? "閉じる" : "Close")
+            ) { "×" }
             div(.id("workshop-modal-body"), .class("workshop-modal-body")) {}
           }
         }
@@ -686,15 +779,21 @@ private struct WorkshopsContent: HTML, Sendable {
           article(.id("workshop-apply"), .class("detail-card workshop-tool-card")) {
             h3 { HTMLText(language == .ja ? "ワークショップに応募する" : "Apply for Workshops") }
             p {
-              HTMLText(language == .ja
-                ? "チケット購入時に使用したメールアドレスを入力して、応募手続きを開始してください。"
-                : "Enter the email address you used for your ticket to begin your workshop application.")
+              HTMLText(
+                language == .ja
+                  ? "チケット購入時に使用したメールアドレスを入力して、応募手続きを開始してください。"
+                  : "Enter the email address you used for your ticket to begin your workshop application."
+              )
             }
 
             form(.id("workshop-verify-form"), .class("workshop-form")) {
               label(.class("form-field")) {
-                span(.class("field-label")) { HTMLText(language == .ja ? "メールアドレス" : "Email Address") }
-                input(.type(.email), .name("email"), .required, .placeholder(language == .ja ? "you@example.com" : "you@example.com"))
+                span(.class("field-label")) {
+                  HTMLText(language == .ja ? "メールアドレス" : "Email Address")
+                }
+                input(
+                  .type(.email), .name("email"), .required,
+                  .placeholder(language == .ja ? "you@example.com" : "you@example.com"))
               }
               div(.class("form-actions")) {
                 button(.type(.submit), .class("button primary")) {
@@ -708,7 +807,9 @@ private struct WorkshopsContent: HTML, Sendable {
             form(.id("workshop-apply-form"), .class("workshop-form"), .hidden) {
               input(.type(.hidden), .name("verifyToken"))
               label(.class("form-field")) {
-                span(.class("field-label")) { HTMLText(language == .ja ? "参加者名" : "Applicant Name") }
+                span(.class("field-label")) {
+                  HTMLText(language == .ja ? "参加者名" : "Applicant Name")
+                }
                 input(.type(.text), .name("applicantName"), .required)
               }
               label(.class("form-field")) {
@@ -734,15 +835,21 @@ private struct WorkshopsContent: HTML, Sendable {
           article(.id("workshop-status"), .class("detail-card workshop-tool-card")) {
             h3 { HTMLText(language == .ja ? "応募状況を確認する" : "Check Application Status") }
             p {
-              HTMLText(language == .ja
-                ? "メールアドレスを入力すると、現在の応募状況や割り当て結果を確認できます。"
-                : "Enter your email address to check your current workshop application or assignment.")
+              HTMLText(
+                language == .ja
+                  ? "メールアドレスを入力すると、現在の応募状況や割り当て結果を確認できます。"
+                  : "Enter your email address to check your current workshop application or assignment."
+              )
             }
 
             form(.id("workshop-status-form"), .class("workshop-form")) {
               label(.class("form-field")) {
-                span(.class("field-label")) { HTMLText(language == .ja ? "メールアドレス" : "Email Address") }
-                input(.type(.email), .name("email"), .required, .placeholder(language == .ja ? "you@example.com" : "you@example.com"))
+                span(.class("field-label")) {
+                  HTMLText(language == .ja ? "メールアドレス" : "Email Address")
+                }
+                input(
+                  .type(.email), .name("email"), .required,
+                  .placeholder(language == .ja ? "you@example.com" : "you@example.com"))
               }
               div(.class("form-actions")) {
                 button(.type(.submit), .class("button primary")) {
@@ -766,12 +873,14 @@ private struct HomeLanding: HTML, Sendable {
   var body: some HTML {
     section(.class("hero-card hero-landing")) {
       div(.class("section-inner")) {
-        p(.class("eyebrow")) { "try! Swift Tokyo 2026" }
+        p(.class("eyebrow")) { "try! Swift Tokyo CfP" }
         h1 { HTMLText(language == .ja ? "プロポーザル募集" : "Call for Proposals") }
         p(.class("hero-copy")) {
-          HTMLText(language == .ja
-            ? "あなたのSwiftの知識を世界中の開発者と共有しませんか？try! Swift Tokyo 2026でトークプロポーザルを提出してください！"
-            : "Share your Swift expertise with developers from around the world. Submit your talk proposal for try! Swift Tokyo 2026!")
+          HTMLText(
+            language == .ja
+              ? "あなたのSwiftの知識を世界中の開発者と共有しませんか？try! Swift Tokyo の各イベントにトークプロポーザルを提出してください！"
+              : "Share your Swift expertise with developers from around the world. Submit your talk proposal to try! Swift Tokyo events!"
+          )
         }
         div(.class("hero-actions")) {
           a(.href(CfPPage.submit.path(for: language)), .class("button primary button-link")) {
@@ -789,18 +898,9 @@ private struct HomeLanding: HTML, Sendable {
 
     section(.class("content-section")) {
       div(.class("section-inner")) {
-        h2 { HTMLText(language == .ja ? "重要な日程" : "Important Dates") }
-        div(.class("card-grid dates-grid")) {
-          for item in importantDates {
-            article(.class("detail-card center-card")) {
-              h5 { HTMLText(item.title) }
-              p(.class("date-copy")) { HTMLText(item.date) }
-              if item.emoji != nil {
-                p(.class("date-emoji")) { HTMLText(item.emoji!) }
-              }
-            }
-          }
-        }
+        h2 { HTMLText(language == .ja ? "募集中のイベント" : "Open Calls for Proposals") }
+        p(.id("cfp-events-status"), .class("inline-status events-status"), .hidden) {}
+        div(.id("cfp-events-list"), .class("card-grid events-grid")) {}
       }
     }
 
@@ -840,44 +940,43 @@ private struct HomeLanding: HTML, Sendable {
 
     section(.class("cta-card")) {
       div(.class("cta-card-inner")) {
-      h2 { HTMLText(language == .ja ? "あなたの知識を共有しませんか？" : "Ready to Share Your Knowledge?") }
-      p {
-        HTMLText(language == .ja
-          ? "経験レベルに関係なく、すべてのスピーカーを歓迎します。初めての登壇者の方も、ぜひご応募ください！"
-          : "We welcome speakers of all experience levels. First-time speakers are encouraged to apply!")
-      }
-      a(.href(CfPPage.submit.path(for: language)), .class("button primary button-link")) {
-        HTMLText(language == .ja ? "プロポーザルを提出する" : "Submit Your Proposal")
-      }
+        h2 { HTMLText(language == .ja ? "あなたの知識を共有しませんか？" : "Ready to Share Your Knowledge?") }
+        p {
+          HTMLText(
+            language == .ja
+              ? "経験レベルに関係なく、すべてのスピーカーを歓迎します。初めての登壇者の方も、ぜひご応募ください！"
+              : "We welcome speakers of all experience levels. First-time speakers are encouraged to apply!"
+          )
+        }
+        a(.href(CfPPage.submit.path(for: language)), .class("button primary button-link")) {
+          HTMLText(language == .ja ? "プロポーザルを提出する" : "Submit Your Proposal")
+        }
       }
     }
   }
 
-  private var importantDates: [(title: String, date: String, emoji: String?)] {
+  private var talkFormats: [(emoji: String?, title: String, duration: String, description: String)]
+  {
     language == .ja
       ? [
-        ("CfP開始", "2026年1月15日", "📅"),
-        ("応募締切", "2026年2月1日", "⏰"),
-        ("結果発表", "2026年2月8日", "📣"),
-        ("カンファレンス", "2026年4月12-14日", "🎤"),
+        (
+          "🎯", "レギュラートーク", "20分",
+          "特定のトピックについて詳しく解説し、具体的な例やライブデモを交えてお話しください。Swiftの開発に関する包括的な知識を共有するのに最適です。"
+        ),
+        (
+          "⚡", "ライトニングトーク", "5分",
+          "1つのアイデア、ヒント、ツールに焦点を当てた短くて集中したプレゼンテーションです。初めての登壇者や、ちょっとしたアイデアの共有に最適です！"
+        ),
       ]
       : [
-        ("CfP Opens", "January 15, 2026", "📅"),
-        ("Submission Deadline", "February 1, 2026", "⏰"),
-        ("Notifications", "February 8, 2026", "📣"),
-        ("Conference", "April 12-14, 2026", "🎤"),
-      ]
-  }
-
-  private var talkFormats: [(emoji: String?, title: String, duration: String, description: String)] {
-    language == .ja
-      ? [
-        ("🎯", "レギュラートーク", "20分", "特定のトピックについて詳しく解説し、具体的な例やライブデモを交えてお話しください。Swiftの開発に関する包括的な知識を共有するのに最適です。"),
-        ("⚡", "ライトニングトーク", "5分", "1つのアイデア、ヒント、ツールに焦点を当てた短くて集中したプレゼンテーションです。初めての登壇者や、ちょっとしたアイデアの共有に最適です！"),
-      ]
-      : [
-        ("🎯", "Regular Talk", "20 minutes", "Deep dive into a specific topic with detailed examples and live demos. Perfect for sharing comprehensive knowledge about Swift development."),
-        ("⚡", "Lightning Talk", "5 minutes", "Quick, focused presentation on a single idea, tip, or tool. Great for first-time speakers or sharing quick wins!"),
+        (
+          "🎯", "Regular Talk", "20 minutes",
+          "Deep dive into a specific topic with detailed examples and live demos. Perfect for sharing comprehensive knowledge about Swift development."
+        ),
+        (
+          "⚡", "Lightning Talk", "5 minutes",
+          "Quick, focused presentation on a single idea, tip, or tool. Great for first-time speakers or sharing quick wins!"
+        ),
       ]
   }
 
@@ -909,9 +1008,11 @@ private struct GuidelinesContent: HTML, Sendable {
     section(.class("hero-card")) {
       h1 { HTMLText(language == .ja ? "応募ガイドライン" : "Submission Guidelines") }
       p(.id("page-description")) {
-        HTMLText(language == .ja
-          ? "try! Swift Tokyo 2026にトークプロポーザルを提出するために必要な情報をまとめました。"
-          : "Everything you need to know about submitting a talk proposal for try! Swift Tokyo 2026.")
+        HTMLText(
+          language == .ja
+            ? "try! Swift Tokyo にトークプロポーザルを提出するために必要な情報をまとめました。"
+            : "Everything you need to know about submitting a talk proposal for try! Swift Tokyo."
+        )
       }
     }
 
@@ -950,93 +1051,158 @@ private struct GuidelinesContent: HTML, Sendable {
     }
   }
 
-  private var sections: [(title: String, intro: String?, bullets: [String], items: [(title: String, copy: String)])] {
+  private var sections:
+    [(title: String, intro: String?, bullets: [String], items: [(title: String, copy: String)])]
+  {
     if language == .ja {
       return [
-        ("私たちが求めているもの", nil, [
-          "他の主要なカンファレンスで発表されていないオリジナルコンテンツ",
-          "参加者が実際の仕事に活かせる実践的な知識",
-          "聴衆にとって明確な学習成果",
-          "デモを含む、よく構成されたプレゼンテーション",
-          "Swiftコミュニティに関連するトピック",
-        ], []),
-        ("トーク形式", nil, [], [
-          ("レギュラートーク（20分）", "トピックを深く掘り下げる包括的なセッションです。コンテキスト、例、重要なポイントを含める時間があります。ライブコーディングやデモも歓迎します！"),
-          ("ライトニングトーク（5分）", "1つのコンセプト、ツール、またはヒントをカバーする、焦点を絞った短いプレゼンテーションです。新しいアイデアの紹介や、ちょっとした発見の共有に最適です。"),
-        ]),
-        ("プロポーザルの要件", nil, [], [
-          ("タイトル", "トーク内容を正確に表す、明確で説明的なタイトル。"),
-          ("概要", "トークが採択された場合に公開される2〜3文の要約。参加者が何を学べるかを説明してください。"),
-          ("トークの詳細", "レビュアー向けのトークの詳細な説明。アウトライン、重要なポイント、予定しているデモなどを含めてください。これはあなたのビジョンを理解するのに役立ちます。"),
-          ("スピーカー自己紹介", "あなたについて教えてください！経歴、経験、このトピックに興味を持った理由などを書いてください。"),
-          ("備考（任意）", "主催者への追加情報。アクセシビリティの要件、スケジュールの制約、以前にこのトークを行ったことがあるかどうかなど。"),
-        ]),
-        ("選考基準", "レビュー委員会は以下の基準でプロポーザルを評価します：", [
-          "Swiftコミュニティへの関連性",
-          "コンテンツの独自性とユニークさ",
-          "プロポーザルと学習成果の明確さ",
-          "スピーカーの専門知識とプレゼンテーション能力",
-          "カンファレンスプログラム全体でのトピックの多様性",
-        ], []),
-        ("素晴らしいプロポーザルのためのヒント", nil, [
-          "参加者が何を学ぶか具体的に書く",
-          "明確なアウトラインや構成を含める",
-          "デモやライブコーディングの予定があれば記載する",
-          "トピックへの情熱を示す",
-          "提出前によく校正する",
-          "複数のプロポーザルを提出することをためらわない！",
-        ], []),
-        ("スピーカー特典", nil, [
-          "カンファレンスチケット無料",
-          "他のスピーカーや主催者とのスピーカーディナー",
-          "海外からのスピーカーには渡航サポートあり",
-          "トークのプロフェッショナルなビデオ撮影",
-          "世界中のSwift開発者とのネットワーキングの機会",
-        ], []),
+        (
+          "私たちが求めているもの", nil,
+          [
+            "他の主要なカンファレンスで発表されていないオリジナルコンテンツ",
+            "参加者が実際の仕事に活かせる実践的な知識",
+            "聴衆にとって明確な学習成果",
+            "デモを含む、よく構成されたプレゼンテーション",
+            "Swiftコミュニティに関連するトピック",
+          ], []
+        ),
+        (
+          "トーク形式", nil, [],
+          [
+            (
+              "レギュラートーク（20分）",
+              "トピックを深く掘り下げる包括的なセッションです。コンテキスト、例、重要なポイントを含める時間があります。ライブコーディングやデモも歓迎します！"
+            ),
+            (
+              "ライトニングトーク（5分）",
+              "1つのコンセプト、ツール、またはヒントをカバーする、焦点を絞った短いプレゼンテーションです。新しいアイデアの紹介や、ちょっとした発見の共有に最適です。"
+            ),
+          ]
+        ),
+        (
+          "プロポーザルの要件", nil, [],
+          [
+            ("タイトル", "トーク内容を正確に表す、明確で説明的なタイトル。"),
+            ("概要", "トークが採択された場合に公開される2〜3文の要約。参加者が何を学べるかを説明してください。"),
+            (
+              "トークの詳細",
+              "レビュアー向けのトークの詳細な説明。アウトライン、重要なポイント、予定しているデモなどを含めてください。これはあなたのビジョンを理解するのに役立ちます。"
+            ),
+            ("スピーカー自己紹介", "あなたについて教えてください！経歴、経験、このトピックに興味を持った理由などを書いてください。"),
+            ("備考（任意）", "主催者への追加情報。アクセシビリティの要件、スケジュールの制約、以前にこのトークを行ったことがあるかどうかなど。"),
+          ]
+        ),
+        (
+          "選考基準", "レビュー委員会は以下の基準でプロポーザルを評価します：",
+          [
+            "Swiftコミュニティへの関連性",
+            "コンテンツの独自性とユニークさ",
+            "プロポーザルと学習成果の明確さ",
+            "スピーカーの専門知識とプレゼンテーション能力",
+            "カンファレンスプログラム全体でのトピックの多様性",
+          ], []
+        ),
+        (
+          "素晴らしいプロポーザルのためのヒント", nil,
+          [
+            "参加者が何を学ぶか具体的に書く",
+            "明確なアウトラインや構成を含める",
+            "デモやライブコーディングの予定があれば記載する",
+            "トピックへの情熱を示す",
+            "提出前によく校正する",
+            "複数のプロポーザルを提出することをためらわない！",
+          ], []
+        ),
+        (
+          "スピーカー特典", nil,
+          [
+            "カンファレンスチケット無料",
+            "他のスピーカーや主催者とのスピーカーディナー",
+            "海外からのスピーカーには渡航サポートあり",
+            "トークのプロフェッショナルなビデオ撮影",
+            "世界中のSwift開発者とのネットワーキングの機会",
+          ], []
+        ),
       ]
     }
 
     return [
-      ("What We're Looking For", nil, [
-        "Original content that hasn't been presented at other major conferences",
-        "Practical knowledge that attendees can apply in their work",
-        "Clear learning outcomes for the audience",
-        "Well-structured presentations with demos when applicable",
-        "Topics relevant to the Swift community",
-      ], []),
-      ("Talk Formats", nil, [], [
-        ("Regular Talk (20 minutes)", "A comprehensive session covering a topic in depth. Include time for context, examples, and key takeaways. Live coding and demos are welcome!"),
-        ("Lightning Talk (5 minutes)", "A focused, fast-paced presentation covering a single concept, tool, or tip. Perfect for sharing quick wins or introducing new ideas."),
-      ]),
-      ("Proposal Requirements", nil, [], [
-        ("Title", "A clear, descriptive title that accurately represents your talk content."),
-        ("Abstract", "A 2-3 sentence summary that will be shown publicly if your talk is accepted. This should explain what attendees will learn."),
-        ("Talk Details", "A detailed description of your talk for reviewers. Include your outline, key points, and any demos you plan to show. This helps us understand your vision."),
-        ("Speaker Bio", "Tell us about yourself! Your background, experience, and what makes you excited about this topic."),
-        ("Notes (Optional)", "Any additional information for organizers, such as accessibility needs, scheduling constraints, or whether you've given this talk before."),
-      ]),
-      ("Selection Criteria", "Our review committee evaluates proposals based on:", [
-        "Relevance to the Swift community",
-        "Originality and uniqueness of content",
-        "Clarity of proposal and learning outcomes",
-        "Speaker's expertise and presentation ability",
-        "Diversity of topics across the conference program",
-      ], []),
-      ("Tips for a Great Proposal", nil, [
-        "Be specific about what attendees will learn",
-        "Include a clear outline or structure",
-        "Mention any demos or live coding",
-        "Show your passion for the topic",
-        "Proofread your submission carefully",
-        "Don't be afraid to submit multiple proposals!",
-      ], []),
-      ("Speaker Benefits", nil, [
-        "Free conference ticket",
-        "Speaker dinner with other speakers and organizers",
-        "Travel support available for international speakers",
-        "Professional video recording of your talk",
-        "Networking opportunities with Swift developers worldwide",
-      ], []),
+      (
+        "What We're Looking For", nil,
+        [
+          "Original content that hasn't been presented at other major conferences",
+          "Practical knowledge that attendees can apply in their work",
+          "Clear learning outcomes for the audience",
+          "Well-structured presentations with demos when applicable",
+          "Topics relevant to the Swift community",
+        ], []
+      ),
+      (
+        "Talk Formats", nil, [],
+        [
+          (
+            "Regular Talk (20 minutes)",
+            "A comprehensive session covering a topic in depth. Include time for context, examples, and key takeaways. Live coding and demos are welcome!"
+          ),
+          (
+            "Lightning Talk (5 minutes)",
+            "A focused, fast-paced presentation covering a single concept, tool, or tip. Perfect for sharing quick wins or introducing new ideas."
+          ),
+        ]
+      ),
+      (
+        "Proposal Requirements", nil, [],
+        [
+          ("Title", "A clear, descriptive title that accurately represents your talk content."),
+          (
+            "Abstract",
+            "A 2-3 sentence summary that will be shown publicly if your talk is accepted. This should explain what attendees will learn."
+          ),
+          (
+            "Talk Details",
+            "A detailed description of your talk for reviewers. Include your outline, key points, and any demos you plan to show. This helps us understand your vision."
+          ),
+          (
+            "Speaker Bio",
+            "Tell us about yourself! Your background, experience, and what makes you excited about this topic."
+          ),
+          (
+            "Notes (Optional)",
+            "Any additional information for organizers, such as accessibility needs, scheduling constraints, or whether you've given this talk before."
+          ),
+        ]
+      ),
+      (
+        "Selection Criteria", "Our review committee evaluates proposals based on:",
+        [
+          "Relevance to the Swift community",
+          "Originality and uniqueness of content",
+          "Clarity of proposal and learning outcomes",
+          "Speaker's expertise and presentation ability",
+          "Diversity of topics across the conference program",
+        ], []
+      ),
+      (
+        "Tips for a Great Proposal", nil,
+        [
+          "Be specific about what attendees will learn",
+          "Include a clear outline or structure",
+          "Mention any demos or live coding",
+          "Show your passion for the topic",
+          "Proofread your submission carefully",
+          "Don't be afraid to submit multiple proposals!",
+        ], []
+      ),
+      (
+        "Speaker Benefits", nil,
+        [
+          "Free conference ticket",
+          "Speaker dinner with other speakers and organizers",
+          "Travel support available for international speakers",
+          "Professional video recording of your talk",
+          "Networking opportunities with Swift developers worldwide",
+        ], []
+      ),
     ]
   }
 }

--- a/CfPWeb/Sources/CfPWeb/Pages/CfPPage.swift
+++ b/CfPWeb/Sources/CfPWeb/Pages/CfPPage.swift
@@ -70,12 +70,12 @@ enum CfPPage: String, CaseIterable, Sendable {
     switch self {
     case .home:
       return language == .ja
-        ? "try! Swift Tokyo 2026 のセッション提案を募集しています。"
-        : "Submit your talk proposal for try! Swift Tokyo 2026."
+        ? "try! Swift Tokyo の各イベントへのセッション提案を募集しています。"
+        : "Submit your talk proposal for try! Swift Tokyo events."
     case .guidelines:
       return language == .ja
-        ? "try! Swift Tokyo 2026 の応募に必要な情報をまとめています。"
-        : "Everything you need to know about submitting a talk proposal for try! Swift Tokyo 2026."
+        ? "try! Swift Tokyo への応募に必要な情報をまとめています。"
+        : "Everything you need to know about submitting a talk proposal for try! Swift Tokyo."
     default:
       return title(for: language)
     }


### PR DESCRIPTION
## Summary
- Replace the hardcoded 2026 "important dates" section with a dynamic events list rendered from `GET /api/v1/conferences/open`, so the landing can show multiple concurrent calls (regional, WWDC Recap, Tokyo 2027) without code changes
- Neutralize hero / guidelines / workshops / OGP copy that hardcoded `try! Swift Tokyo 2026`
- Submit form now honors `?conference=<path>` so cards can pre-select an event when navigating to `/submit`

## Implementation notes
- `HomeLanding` no longer renders a static date table; it emits an empty `#cfp-events-list` container and a status placeholder
- `app.js` adds `bootstrapHomePage()` + `renderCfPEventsList()` that consume the existing `state.openConferences` (already loaded for the submit dropdown), with localized labels via the existing `localizedCopy` helper
- Server is already complete for multi-conference; once 3 records are inserted via the admin API, all three CfPs appear on the landing automatically

## Out of scope (follow-up)
- Website / SharedModels / DataClient / `ConferenceYear.year2027` updates
- Populating the actual conference rows in the production database (operational task)

## Test plan
- [ ] `swift run CfPWeb` generates `Build/index.html` and `Build/ja/index.html` with `<div id="cfp-events-list">` and no `2026` strings outside of the footer copyright
- [ ] Against a local Server with three open conferences inserted, the landing renders three cards in EN and JA
- [ ] "Submit a Proposal" buttons on the cards pre-select the corresponding option in the `submit-conference-path` dropdown
- [ ] When `/api/v1/conferences/open` returns `[]`, the empty-state message is shown without layout breakage

🤖 Generated with [Claude Code](https://claude.com/claude-code)