### PR TITLE
Deploy CfPWeb to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-cfpweb.yml
+++ b/.github/workflows/deploy-cfpweb.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  deployments: write
 
 concurrency:
   group: cfpweb-deploy
@@ -39,7 +40,7 @@ jobs:
       - name: Build static site
         run: |
           cd CfPWeb
-          swift run CfPWeb --api-base-url https://api.tryswift.jp --output Build
+          swift run CfPWeb --api-base-url https://api.tryswift.jp
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3

--- a/Server/DEPLOYMENT.md
+++ b/Server/DEPLOYMENT.md
@@ -151,7 +151,7 @@ fly certs show api.tryswift.jp --app tryswift-api-prod
 
 ### Cloudflare DNS
 
-1. Add a CNAME record: `api` → `tryswift-api-prod.fly.dev` (Proxy enabled / orange cloud)
+1. Add a CNAME record: `api` → `tryswift-cfp-api-prod.fly.dev` (Proxy enabled / orange cloud)
 2. SSL/TLS mode: **Full (Strict)** (fly.io terminates TLS on its end)
 3. Cache: API responses are not cached by default (dynamic content bypass)
 4. Security: Enable WAF / Rate Limiting as needed


### PR DESCRIPTION
## Summary
- Add a GitHub Actions workflow that builds and deploys the CfPWeb static site to Cloudflare Pages
- Align the API CNAME instructions in \`Server/DEPLOYMENT.md\` with the production Fly app name

## Test plan
- [ ] On merge, the new workflow runs on \`main\` and pushes the latest CfPWeb build to Cloudflare Pages
- [ ] DNS instructions in \`Server/DEPLOYMENT.md\` resolve to the actual Fly app

🤖 Generated with [Claude Code](https://claude.com/claude-code)