### PR TITLE
Add organizer CfP toggle UI and Markdown-rendered descriptions

### DIFF
--- a/CfPWeb/Public/scripts/app.js
+++ b/CfPWeb/Public/scripts/app.js
@@ -259,6 +259,23 @@
     return startText || endText;
   }
 
+  function renderMarkdown(text) {
+    if (!text) return "";
+    if (typeof window === "undefined" || typeof window.marked === "undefined") {
+      return escapeHTML(String(text)).replace(/\n/g, "<br>");
+    }
+    try {
+      var html = window.marked.parse(String(text), { breaks: true, gfm: true });
+      // Demote headings so card content stays subordinate to the card title.
+      return html.replace(/<(\/?)h([1-6])(\s|>)/g, function (_, slash, level, tail) {
+        var demoted = Math.min(parseInt(level, 10) + 3, 6);
+        return "<" + slash + "h" + demoted + tail;
+      });
+    } catch (_error) {
+      return escapeHTML(String(text)).replace(/\n/g, "<br>");
+    }
+  }
+
   function localizedConferenceDescription(conference) {
     var description = conference && conference.description;
     if (!description) return "";
@@ -302,7 +319,7 @@
     var html = "";
     conferences.forEach(function (conference) {
       var displayName = escapeHTML(String(conference.displayName || ""));
-      var description = escapeHTML(localizedConferenceDescription(conference));
+      var description = renderMarkdown(localizedConferenceDescription(conference));
       var deadline = escapeHTML(formatEventDate(conference.deadline));
       var dateRange = escapeHTML(formatEventDateRange(conference.startDate, conference.endDate));
       var location = escapeHTML(String(conference.location || ""));
@@ -315,7 +332,7 @@
       html += '<span class="event-status-badge open">' + escapeHTML(openBadgeText) + "</span>";
       html += "</div>";
       if (description) {
-        html += '<p class="event-description">' + description + "</p>";
+        html += '<div class="event-description">' + description + "</div>";
       }
       html += '<dl class="event-meta">';
       if (deadline) {

--- a/CfPWeb/Public/scripts/app.js
+++ b/CfPWeb/Public/scripts/app.js
@@ -259,9 +259,18 @@
     return startText || endText;
   }
 
+  var MARKDOWN_ALLOWED_TAGS = [
+    "p", "br", "strong", "em", "del", "code", "pre",
+    "ul", "ol", "li",
+    "a",
+    "h4", "h5", "h6",
+    "blockquote", "hr"
+  ];
+  var MARKDOWN_ALLOWED_ATTR = ["href", "title"];
+
   function renderMarkdown(text) {
     if (!text) return "";
-    var fallback = escapeHTML(String(text)).replace(/\n/g, "<br>");
+    var fallback = escapeHTML(String(text)).replace(/\r\n|\r|\n/g, "<br>");
     if (typeof window === "undefined" || typeof window.marked === "undefined") {
       return fallback;
     }
@@ -277,7 +286,10 @@
         var demoted = Math.min(parseInt(level, 10) + 3, 6);
         return "<" + slash + "h" + demoted + tail;
       });
-      return window.DOMPurify.sanitize(html);
+      return window.DOMPurify.sanitize(html, {
+        ALLOWED_TAGS: MARKDOWN_ALLOWED_TAGS,
+        ALLOWED_ATTR: MARKDOWN_ALLOWED_ATTR
+      });
     } catch (_error) {
       return fallback;
     }
@@ -2431,9 +2443,8 @@
       showStatus("organizer-conferences-status", successMessage, "success");
     } catch (error) {
       showStatus("organizer-conferences-status", error.message, "error");
-      if (button) {
-        button.disabled = false;
-      }
+      // renderOrganizerConferencesTable() rebuilds the row, replacing the
+      // button reference, so no manual re-enable is needed here.
       renderOrganizerConferencesTable();
     }
   }

--- a/CfPWeb/Public/scripts/app.js
+++ b/CfPWeb/Public/scripts/app.js
@@ -2308,6 +2308,130 @@
     await refreshOrganizerWorkshopResults();
   }
 
+  function renderOrganizerConferencesTable() {
+    var tbody = document.getElementById("organizer-conferences-tbody");
+    var emptyMessage = document.getElementById("organizer-conferences-empty");
+    if (!tbody) return;
+
+    var conferences = state.conferences || [];
+    if (!conferences.length) {
+      tbody.innerHTML = "";
+      if (emptyMessage) emptyMessage.hidden = false;
+      return;
+    }
+
+    if (emptyMessage) emptyMessage.hidden = true;
+    var ja = currentLanguage() === "ja";
+    var html = "";
+    conferences.forEach(function (conference) {
+      var pathAttr = escapeHTML(String(conference.path || ""));
+      var displayName = escapeHTML(String(conference.displayName || conference.path || ""));
+      var year = escapeHTML(String(conference.year || ""));
+      var deadline = formatEventDate(conference.deadline) || (ja ? "未設定" : "—");
+      var isOpen = conference.isOpen === true;
+      var statusClass = isOpen ? "event-status-badge open" : "event-status-badge closed";
+      var statusLabel = isOpen ? (ja ? "募集中" : "Open") : (ja ? "終了" : "Closed");
+      var actionLabel = isOpen ? (ja ? "受付を閉じる" : "Close CfP") : (ja ? "受付を開ける" : "Open CfP");
+      var actionClass = isOpen ? "button neutral" : "button primary";
+
+      html += '<tr data-conference-path="' + pathAttr + '">';
+      html += "<td>" + displayName + "</td>";
+      html += "<td>" + year + "</td>";
+      html += "<td>" + escapeHTML(deadline) + "</td>";
+      html += '<td><span class="' + statusClass + '">' + escapeHTML(statusLabel) + "</span></td>";
+      html += '<td class="organizer-conferences-actions-col">';
+      html += '<button type="button" class="' + actionClass + '"';
+      html += ' data-toggle-conference="' + pathAttr + '">';
+      html += escapeHTML(actionLabel);
+      html += "</button>";
+      html += "</td>";
+      html += "</tr>";
+    });
+    tbody.innerHTML = html;
+  }
+
+  async function refreshOrganizerConferences() {
+    try {
+      await loadAllConferences();
+      renderOrganizerConferencesTable();
+      showStatus("organizer-conferences-status", "", null);
+    } catch (error) {
+      showStatus("organizer-conferences-status", error.message, "error");
+    }
+  }
+
+  async function toggleOrganizerConferenceOpen(path, button) {
+    var conference = (state.conferences || []).find(function (item) {
+      return item.path === path;
+    });
+    if (!conference) return;
+
+    var nextIsOpen = !conference.isOpen;
+    var ja = currentLanguage() === "ja";
+    if (button) {
+      button.disabled = true;
+      button.textContent = ja ? "更新中…" : "Updating…";
+    }
+
+    var payload = {
+      path: conference.path,
+      displayName: conference.displayName,
+      descriptionEn: conference.description ? conference.description.en : null,
+      descriptionJa: conference.description ? conference.description.ja : null,
+      year: conference.year,
+      isOpen: nextIsOpen,
+      deadline: conference.deadline || null,
+      startDate: conference.startDate || null,
+      endDate: conference.endDate || null,
+      location: conference.location || null,
+      websiteURL: conference.websiteURL || null
+    };
+
+    try {
+      var updated = await apiRequest("/api/v1/conferences/" + encodeURIComponent(path), {
+        method: "PUT",
+        body: JSON.stringify(payload)
+      });
+      var index = state.conferences.findIndex(function (item) { return item.path === path; });
+      if (index >= 0) state.conferences[index] = updated;
+      renderOrganizerConferencesTable();
+      var successMessage = nextIsOpen
+        ? localizedCopy(
+          conference.displayName + " is now accepting proposals.",
+          conference.displayName + " の応募受付を開始しました。"
+        )
+        : localizedCopy(
+          conference.displayName + " has stopped accepting proposals.",
+          conference.displayName + " の応募受付を停止しました。"
+        );
+      showStatus("organizer-conferences-status", successMessage, "success");
+    } catch (error) {
+      showStatus("organizer-conferences-status", error.message, "error");
+      if (button) {
+        button.disabled = false;
+      }
+      renderOrganizerConferencesTable();
+    }
+  }
+
+  async function bootstrapOrganizerConferencesSection() {
+    var tbody = document.getElementById("organizer-conferences-tbody");
+    var refreshButton = document.getElementById("organizer-conferences-refresh");
+    if (!tbody || !refreshButton) return;
+
+    refreshButton.addEventListener("click", refreshOrganizerConferences);
+
+    tbody.addEventListener("click", function (event) {
+      var button = event.target.closest("[data-toggle-conference]");
+      if (!button) return;
+      var path = button.getAttribute("data-toggle-conference");
+      if (!path) return;
+      toggleOrganizerConferenceOpen(path, button);
+    });
+
+    renderOrganizerConferencesTable();
+  }
+
   async function bootstrapOrganizerPage() {
     await bootstrapOrganizerShell();
     await bootstrapOrganizerProposalsSection();
@@ -2315,6 +2439,7 @@
     await bootstrapOrganizerWorkshopsSection();
     await bootstrapOrganizerWorkshopApplicationsSection();
     await bootstrapOrganizerWorkshopResultsSection();
+    await bootstrapOrganizerConferencesSection();
   }
 
   async function bootstrapPage() {

--- a/CfPWeb/Public/scripts/app.js
+++ b/CfPWeb/Public/scripts/app.js
@@ -261,18 +261,25 @@
 
   function renderMarkdown(text) {
     if (!text) return "";
+    var fallback = escapeHTML(String(text)).replace(/\n/g, "<br>");
     if (typeof window === "undefined" || typeof window.marked === "undefined") {
-      return escapeHTML(String(text)).replace(/\n/g, "<br>");
+      return fallback;
+    }
+    // Without DOMPurify, marked would pass raw HTML and javascript: URLs from
+    // API-supplied descriptions through to innerHTML, so refuse to render.
+    if (typeof window.DOMPurify === "undefined") {
+      return fallback;
     }
     try {
       var html = window.marked.parse(String(text), { breaks: true, gfm: true });
       // Demote headings so card content stays subordinate to the card title.
-      return html.replace(/<(\/?)h([1-6])(\s|>)/g, function (_, slash, level, tail) {
+      html = html.replace(/<(\/?)h([1-6])(\s|>)/g, function (_, slash, level, tail) {
         var demoted = Math.min(parseInt(level, 10) + 3, 6);
         return "<" + slash + "h" + demoted + tail;
       });
+      return window.DOMPurify.sanitize(html);
     } catch (_error) {
-      return escapeHTML(String(text)).replace(/\n/g, "<br>");
+      return fallback;
     }
   }
 
@@ -2446,7 +2453,7 @@
       toggleOrganizerConferenceOpen(path, button);
     });
 
-    renderOrganizerConferencesTable();
+    await refreshOrganizerConferences();
   }
 
   async function bootstrapOrganizerPage() {

--- a/CfPWeb/Public/styles/app.css
+++ b/CfPWeb/Public/styles/app.css
@@ -1438,3 +1438,54 @@ body.modal-open {
   flex-direction: column;
   gap: 0.75rem;
 }
+
+.organizer-conferences-card .organizer-conferences-header {
+  margin-bottom: 0.75rem;
+}
+
+.organizer-conferences-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 0.75rem;
+}
+
+.organizer-conferences-table-wrapper {
+  overflow-x: auto;
+}
+
+.organizer-conferences-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 0.25rem;
+}
+
+.organizer-conferences-table th,
+.organizer-conferences-table td {
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  vertical-align: middle;
+}
+
+.organizer-conferences-table th {
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  color: var(--muted);
+}
+
+.organizer-conferences-table .organizer-conferences-actions-col {
+  text-align: right;
+  white-space: nowrap;
+}
+
+.event-status-badge.closed {
+  background: rgba(120, 120, 128, 0.18);
+  color: #6b6b75;
+}
+
+.organizer-conferences-empty {
+  margin: 0.75rem 0 0;
+  color: var(--muted);
+  font-style: italic;
+}

--- a/CfPWeb/Public/styles/app.css
+++ b/CfPWeb/Public/styles/app.css
@@ -968,7 +968,53 @@ body.modal-open {
 .event-description {
   margin: 0;
   color: var(--muted);
-  line-height: 1.5;
+  line-height: 1.6;
+}
+
+.event-description > :first-child {
+  margin-top: 0;
+}
+
+.event-description > :last-child {
+  margin-bottom: 0;
+}
+
+.event-description p {
+  margin: 0 0 0.6rem;
+}
+
+.event-description h4,
+.event-description h5,
+.event-description h6 {
+  margin: 0.8rem 0 0.4rem;
+  color: inherit;
+  font-weight: 600;
+}
+
+.event-description h4 { font-size: 1rem; }
+.event-description h5 { font-size: 0.95rem; }
+.event-description h6 { font-size: 0.9rem; }
+
+.event-description ul,
+.event-description ol {
+  margin: 0 0 0.6rem;
+  padding-left: 1.25rem;
+}
+
+.event-description li {
+  margin-bottom: 0.25rem;
+}
+
+.event-description code {
+  background: rgba(127, 127, 127, 0.15);
+  padding: 0.05rem 0.35rem;
+  border-radius: 4px;
+  font-size: 0.9em;
+}
+
+.event-description a {
+  color: inherit;
+  text-decoration: underline;
 }
 
 .event-meta {

--- a/CfPWeb/Sources/CfPWeb/Components/AppLayout.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/AppLayout.swift
@@ -33,14 +33,24 @@ struct AppLayout: HTMLDocument, Sendable {
     link(
       .rel(.icon), .custom(name: "type", value: "image/png"),
       .href("https://tryswift.jp/images/favicon.png"))
-    script(
-      .src("https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"),
-      .custom(name: "defer", value: "defer")
-    ) {}
-    script(
-      .src("https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"),
-      .custom(name: "defer", value: "defer")
-    ) {}
+    if page == .home {
+      script(
+        .src("https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"),
+        .custom(
+          name: "integrity",
+          value: "sha384-/TQbtLCAerC3jgaim+N78RZSDYV7ryeoBCVqTuzRrFec2akfBkHS7ACQ3PQhvMVi"),
+        .custom(name: "crossorigin", value: "anonymous"),
+        .custom(name: "defer", value: "defer")
+      ) {}
+      script(
+        .src("https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"),
+        .custom(
+          name: "integrity",
+          value: "sha384-+VfUPEb0PdtChMwmBcBmykRMDd+v6D/oFmB3rZM/puCMDYcIvF968OimRh4KQY9a"),
+        .custom(name: "crossorigin", value: "anonymous"),
+        .custom(name: "defer", value: "defer")
+      ) {}
+    }
     script(.src("/scripts/app.js"), .custom(name: "defer", value: "defer")) {}
     script(.src("https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js")) {}
     meta(.custom(name: "name", value: "cfp-api-base-url"), .content(apiBaseURL))

--- a/CfPWeb/Sources/CfPWeb/Components/AppLayout.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/AppLayout.swift
@@ -33,6 +33,10 @@ struct AppLayout: HTMLDocument, Sendable {
     link(
       .rel(.icon), .custom(name: "type", value: "image/png"),
       .href("https://tryswift.jp/images/favicon.png"))
+    script(
+      .src("https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"),
+      .custom(name: "defer", value: "defer")
+    ) {}
     script(.src("/scripts/app.js"), .custom(name: "defer", value: "defer")) {}
     script(.src("https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js")) {}
     meta(.custom(name: "name", value: "cfp-api-base-url"), .content(apiBaseURL))

--- a/CfPWeb/Sources/CfPWeb/Components/AppLayout.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/AppLayout.swift
@@ -37,6 +37,10 @@ struct AppLayout: HTMLDocument, Sendable {
       .src("https://cdn.jsdelivr.net/npm/marked@12.0.2/marked.min.js"),
       .custom(name: "defer", value: "defer")
     ) {}
+    script(
+      .src("https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"),
+      .custom(name: "defer", value: "defer")
+    ) {}
     script(.src("/scripts/app.js"), .custom(name: "defer", value: "defer")) {}
     script(.src("https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js")) {}
     meta(.custom(name: "name", value: "cfp-api-base-url"), .content(apiBaseURL))

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerConferencesContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerConferencesContent.swift
@@ -1,0 +1,60 @@
+import Elementary
+
+struct OrganizerConferencesContent: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(.class("detail-card organizer-conferences-card")) {
+      header(.class("organizer-conferences-header")) {
+        h3 { HTMLText(language == .ja ? "カンファレンス管理" : "Conference Management") }
+        p(.class("submit-form-intro")) {
+          HTMLText(
+            language == .ja
+              ? "各カンファレンスの CfP の受付状態を切り替えます。"
+              : "Toggle whether each conference is currently accepting proposals."
+          )
+        }
+      }
+
+      div(.class("organizer-conferences-toolbar")) {
+        button(
+          .type(.button), .id("organizer-conferences-refresh"),
+          .class("button neutral")
+        ) {
+          HTMLText(language == .ja ? "更新" : "Refresh")
+        }
+      }
+
+      p(
+        .id("organizer-conferences-status"),
+        .class("inline-status"),
+        .hidden
+      ) {}
+
+      div(.class("organizer-conferences-table-wrapper")) {
+        table(.class("organizer-conferences-table")) {
+          thead {
+            tr {
+              th { HTMLText(language == .ja ? "カンファレンス" : "Conference") }
+              th { HTMLText(language == .ja ? "年" : "Year") }
+              th { HTMLText(language == .ja ? "応募締切" : "Deadline") }
+              th { HTMLText(language == .ja ? "状態" : "Status") }
+              th(.class("organizer-conferences-actions-col")) {
+                HTMLText(language == .ja ? "操作" : "Actions")
+              }
+            }
+          }
+          tbody(.id("organizer-conferences-tbody")) {}
+        }
+      }
+
+      p(
+        .id("organizer-conferences-empty"),
+        .class("organizer-conferences-empty"),
+        .hidden
+      ) {
+        HTMLText(language == .ja ? "カンファレンスが登録されていません。" : "No conferences registered.")
+      }
+    }
+  }
+}

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerSection.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerSection.swift
@@ -6,6 +6,7 @@ enum OrganizerSection: Sendable, CaseIterable {
   case workshops
   case workshopApplications
   case workshopResults
+  case conferences
 
   static func from(routePath: String) -> OrganizerSection {
     var path = routePath
@@ -18,6 +19,7 @@ enum OrganizerSection: Sendable, CaseIterable {
     if path == "/organizer/workshops" { return .workshops }
     if path == "/organizer/workshops/applications" { return .workshopApplications }
     if path == "/organizer/workshops/results" { return .workshopResults }
+    if path == "/organizer/conferences" { return .conferences }
     return .proposals
   }
 
@@ -29,6 +31,7 @@ enum OrganizerSection: Sendable, CaseIterable {
     case .workshops: return "\(prefix)/organizer/workshops"
     case .workshopApplications: return "\(prefix)/organizer/workshops/applications"
     case .workshopResults: return "\(prefix)/organizer/workshops/results"
+    case .conferences: return "\(prefix)/organizer/conferences"
     }
   }
 
@@ -44,6 +47,8 @@ enum OrganizerSection: Sendable, CaseIterable {
       return language == .ja ? "応募" : "Applications"
     case .workshopResults:
       return language == .ja ? "結果" : "Results"
+    case .conferences:
+      return language == .ja ? "カンファレンス" : "Conferences"
     }
   }
 }

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerShell.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerShell.swift
@@ -47,6 +47,8 @@ struct OrganizerShell: HTML, Sendable {
       OrganizerWorkshopApplicationsContent(language: language)
     case .workshopResults:
       OrganizerWorkshopResultsContent(language: language)
+    case .conferences:
+      OrganizerConferencesContent(language: language)
     }
   }
 }

--- a/CfPWeb/Sources/CfPWeb/Support/SiteRoutes.swift
+++ b/CfPWeb/Sources/CfPWeb/Support/SiteRoutes.swift
@@ -29,6 +29,7 @@ enum SiteRoutes {
       SiteRoute(path: "/organizer/workshops", page: .organizer),
       SiteRoute(path: "/organizer/workshops/applications", page: .organizer),
       SiteRoute(path: "/organizer/workshops/results", page: .organizer),
+      SiteRoute(path: "/organizer/conferences", page: .organizer),
     ]
 
     let japanese: [SiteRoute] = [
@@ -47,6 +48,7 @@ enum SiteRoutes {
       SiteRoute(path: "/ja/organizer/workshops", page: .organizer),
       SiteRoute(path: "/ja/organizer/workshops/applications", page: .organizer),
       SiteRoute(path: "/ja/organizer/workshops/results", page: .organizer),
+      SiteRoute(path: "/ja/organizer/conferences", page: .organizer),
     ]
 
     return english + japanese


### PR DESCRIPTION
## Summary

- 運営向けに **Conferences** セクションを追加し、各カンファレンスの CfP 受付を 1 クリックで開閉できるようにする
- ホームの **募集中のイベント** カードの description を Markdown としてレンダリング（これまでは raw な記法がそのまま見えていた）

## Details

### Organizer CfP toggle UI

- `OrganizerSection` に `.conferences` ケースを追加し、subnav に「カンファレンス / Conferences」を表示
- 新規 `OrganizerConferencesContent` でカンファレンス一覧テーブル（displayName / 年 / 締切 / 状態 / 操作）を表示
- 操作ボタン押下で `PUT /api/v1/conferences/:path` を呼び `isOpen` のみ反転（その他フィールドは取得済み値を再送）。Server / SharedModels は変更なし
- ルーティング: `/organizer/conferences` と `/ja/organizer/conferences` を追加

### Markdown rendering on home

- `AppLayout` に `marked@12.0.2` を CDN から `defer` 読み込み
- `app.js` に `renderMarkdown()` ヘルパーを追加。見出しは正規表現で h1–h6 → h4–h6 に自動降格してカード見出し `<h3>` 配下に収める
- `marked` の読み込みに失敗した場合は `escapeHTML + <br>` のフォールバック

## Test plan

- [ ] `cd CfPWeb && swift build` がエラーなく完了する
- [ ] `swift run CfPWeb` で生成された静的サイトをローカル配信
  - [ ] `/organizer/conferences` と `/ja/organizer/conferences` の subnav に新セクションが表示される
  - [ ] admin としてサインイン後、各 Conference の行に状態バッジと開閉ボタンが出る
  - [ ] ボタン押下で `PUT /api/v1/conferences/:path` が呼ばれ、状態が反転する
  - [ ] ホームの events list で、Markdown の `## 見出し` / `**強調**` / `- リスト` が描画される
- [ ] CI: format / Build CfPWeb / CodeQL が pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)