### PR TITLE
Hide unpublished conferences from public consumers

### DIFF
--- a/CfPWeb/Public/scripts/app.js
+++ b/CfPWeb/Public/scripts/app.js
@@ -434,7 +434,9 @@
   }
 
   async function loadAllConferences() {
-    state.conferences = await apiRequest("/api/v1/conferences");
+    // Organizer-only endpoint that includes unpublished drafts. Public callers
+    // continue to use /api/v1/conferences via loadOpenConferences().
+    state.conferences = await apiRequest("/api/v1/conferences/admin/all");
     return state.conferences;
   }
 
@@ -2365,21 +2367,40 @@
       var year = escapeHTML(String(conference.year || ""));
       var deadline = formatEventDate(conference.deadline) || (ja ? "未設定" : "—");
       var isOpen = conference.isOpen === true;
-      var statusClass = isOpen ? "event-status-badge open" : "event-status-badge closed";
-      var statusLabel = isOpen ? (ja ? "募集中" : "Open") : (ja ? "終了" : "Closed");
-      var actionLabel = isOpen ? (ja ? "受付を閉じる" : "Close CfP") : (ja ? "受付を開ける" : "Open CfP");
-      var actionClass = isOpen ? "button neutral" : "button primary";
+      var isPublished = conference.isPublished !== false;
 
-      html += '<tr data-conference-path="' + pathAttr + '">';
+      var openStatusClass = isOpen ? "event-status-badge open" : "event-status-badge closed";
+      var openStatusLabel = isOpen ? (ja ? "募集中" : "Open") : (ja ? "終了" : "Closed");
+      var openActionLabel = isOpen ? (ja ? "受付を閉じる" : "Close CfP") : (ja ? "受付を開ける" : "Open CfP");
+      var openActionClass = isOpen ? "button neutral" : "button primary";
+
+      var publishStatusBadge = isPublished
+        ? ""
+        : '<span class="event-status-badge unpublished">' + escapeHTML(ja ? "未公開" : "Unpublished") + "</span>";
+      var publishActionLabel = isPublished ? (ja ? "非公開にする" : "Unpublish") : (ja ? "公開する" : "Publish");
+      var publishActionClass = isPublished ? "button neutral" : "button primary";
+
+      var rowClass = isPublished ? "" : ' class="organizer-conferences-row-unpublished"';
+
+      html += "<tr" + rowClass + ' data-conference-path="' + pathAttr + '">';
       html += "<td>" + displayName + "</td>";
       html += "<td>" + year + "</td>";
       html += "<td>" + escapeHTML(deadline) + "</td>";
-      html += '<td><span class="' + statusClass + '">' + escapeHTML(statusLabel) + "</span></td>";
+      html += '<td><div class="organizer-conferences-status-cell">';
+      html += publishStatusBadge;
+      html += '<span class="' + openStatusClass + '">' + escapeHTML(openStatusLabel) + "</span>";
+      html += "</div></td>";
       html += '<td class="organizer-conferences-actions-col">';
-      html += '<button type="button" class="' + actionClass + '"';
-      html += ' data-toggle-conference="' + pathAttr + '">';
-      html += escapeHTML(actionLabel);
+      html += '<div class="organizer-conferences-actions-stack">';
+      html += '<button type="button" class="' + publishActionClass + '"';
+      html += ' data-toggle-published="' + pathAttr + '">';
+      html += escapeHTML(publishActionLabel);
       html += "</button>";
+      html += '<button type="button" class="' + openActionClass + '"';
+      html += ' data-toggle-conference="' + pathAttr + '">';
+      html += escapeHTML(openActionLabel);
+      html += "</button>";
+      html += "</div>";
       html += "</td>";
       html += "</tr>";
     });
@@ -2396,50 +2417,43 @@
     }
   }
 
-  async function toggleOrganizerConferenceOpen(path, button) {
-    var conference = (state.conferences || []).find(function (item) {
-      return item.path === path;
-    });
-    if (!conference) return;
-
-    var nextIsOpen = !conference.isOpen;
-    var ja = currentLanguage() === "ja";
-    if (button) {
-      button.disabled = true;
-      button.textContent = ja ? "更新中…" : "Updating…";
-    }
-
+  function buildConferenceUpdatePayload(conference, overrides) {
     var payload = {
       path: conference.path,
       displayName: conference.displayName,
       descriptionEn: conference.description ? conference.description.en : null,
       descriptionJa: conference.description ? conference.description.ja : null,
       year: conference.year,
-      isOpen: nextIsOpen,
+      isOpen: conference.isOpen,
+      isPublished: conference.isPublished !== false,
       deadline: conference.deadline || null,
       startDate: conference.startDate || null,
       endDate: conference.endDate || null,
       location: conference.location || null,
       websiteURL: conference.websiteURL || null
     };
+    if (overrides) {
+      Object.keys(overrides).forEach(function (key) { payload[key] = overrides[key]; });
+    }
+    return payload;
+  }
 
+  async function applyConferenceUpdate(conference, overrides, button, successMessage) {
+    var ja = currentLanguage() === "ja";
+    if (button) {
+      button.disabled = true;
+      button.textContent = ja ? "更新中…" : "Updating…";
+    }
+
+    var payload = buildConferenceUpdatePayload(conference, overrides);
     try {
-      var updated = await apiRequest("/api/v1/conferences/" + encodeURIComponent(path), {
+      var updated = await apiRequest("/api/v1/conferences/" + encodeURIComponent(conference.path), {
         method: "PUT",
         body: JSON.stringify(payload)
       });
-      var index = state.conferences.findIndex(function (item) { return item.path === path; });
+      var index = state.conferences.findIndex(function (item) { return item.path === conference.path; });
       if (index >= 0) state.conferences[index] = updated;
       renderOrganizerConferencesTable();
-      var successMessage = nextIsOpen
-        ? localizedCopy(
-          conference.displayName + " is now accepting proposals.",
-          conference.displayName + " の応募受付を開始しました。"
-        )
-        : localizedCopy(
-          conference.displayName + " has stopped accepting proposals.",
-          conference.displayName + " の応募受付を停止しました。"
-        );
       showStatus("organizer-conferences-status", successMessage, "success");
     } catch (error) {
       showStatus("organizer-conferences-status", error.message, "error");
@@ -2447,6 +2461,42 @@
       // button reference, so no manual re-enable is needed here.
       renderOrganizerConferencesTable();
     }
+  }
+
+  function findOrganizerConference(path) {
+    return (state.conferences || []).find(function (item) { return item.path === path; });
+  }
+
+  async function toggleOrganizerConferenceOpen(path, button) {
+    var conference = findOrganizerConference(path);
+    if (!conference) return;
+    var nextIsOpen = !conference.isOpen;
+    var successMessage = nextIsOpen
+      ? localizedCopy(
+        conference.displayName + " is now accepting proposals.",
+        conference.displayName + " の応募受付を開始しました。"
+      )
+      : localizedCopy(
+        conference.displayName + " has stopped accepting proposals.",
+        conference.displayName + " の応募受付を停止しました。"
+      );
+    await applyConferenceUpdate(conference, { isOpen: nextIsOpen }, button, successMessage);
+  }
+
+  async function toggleOrganizerConferencePublished(path, button) {
+    var conference = findOrganizerConference(path);
+    if (!conference) return;
+    var nextIsPublished = !(conference.isPublished !== false);
+    var successMessage = nextIsPublished
+      ? localizedCopy(
+        conference.displayName + " is now public.",
+        conference.displayName + " を公開しました。"
+      )
+      : localizedCopy(
+        conference.displayName + " is now hidden from public listings.",
+        conference.displayName + " を非公開にしました。"
+      );
+    await applyConferenceUpdate(conference, { isPublished: nextIsPublished }, button, successMessage);
   }
 
   async function bootstrapOrganizerConferencesSection() {
@@ -2457,11 +2507,17 @@
     refreshButton.addEventListener("click", refreshOrganizerConferences);
 
     tbody.addEventListener("click", function (event) {
-      var button = event.target.closest("[data-toggle-conference]");
-      if (!button) return;
-      var path = button.getAttribute("data-toggle-conference");
-      if (!path) return;
-      toggleOrganizerConferenceOpen(path, button);
+      var openButton = event.target.closest("[data-toggle-conference]");
+      if (openButton) {
+        var openPath = openButton.getAttribute("data-toggle-conference");
+        if (openPath) toggleOrganizerConferenceOpen(openPath, openButton);
+        return;
+      }
+      var publishButton = event.target.closest("[data-toggle-published]");
+      if (publishButton) {
+        var publishPath = publishButton.getAttribute("data-toggle-published");
+        if (publishPath) toggleOrganizerConferencePublished(publishPath, publishButton);
+      }
     });
 
     await refreshOrganizerConferences();

--- a/CfPWeb/Public/scripts/app.js
+++ b/CfPWeb/Public/scripts/app.js
@@ -435,7 +435,7 @@
 
   async function loadAllConferences() {
     // Organizer-only endpoint that includes unpublished drafts. Public callers
-    // continue to use /api/v1/conferences via loadOpenConferences().
+    // continue to use /api/v1/conferences/open via loadOpenConferences().
     state.conferences = await apiRequest("/api/v1/conferences/admin/all");
     return state.conferences;
   }

--- a/CfPWeb/Public/styles/app.css
+++ b/CfPWeb/Public/styles/app.css
@@ -1530,6 +1530,34 @@ body.modal-open {
   color: #6b6b75;
 }
 
+.event-status-badge.unpublished {
+  background: rgba(180, 35, 24, 0.12);
+  color: #b42318;
+}
+
+.organizer-conferences-status-cell {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.organizer-conferences-actions-stack {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+}
+
+.organizer-conferences-actions-stack .button {
+  width: 100%;
+  justify-content: center;
+}
+
+.organizer-conferences-row-unpublished td {
+  background: rgba(180, 35, 24, 0.04);
+}
+
 .organizer-conferences-empty {
   margin: 0.75rem 0 0;
   color: var(--muted);

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerConferencesContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerConferencesContent.swift
@@ -10,8 +10,8 @@ struct OrganizerConferencesContent: HTML, Sendable {
         p(.class("submit-form-intro")) {
           HTMLText(
             language == .ja
-              ? "各カンファレンスの CfP の受付状態を切り替えます。"
-              : "Toggle whether each conference is currently accepting proposals."
+              ? "各カンファレンスの公開状態と CfP 受付状態を切り替えます。未公開のカンファレンスは運営にしか表示されません。"
+              : "Toggle each conference's published state and CfP availability. Unpublished conferences are visible only to organizers."
           )
         }
       }

--- a/Server/Sources/Server/Controllers/ConferenceController.swift
+++ b/Server/Sources/Server/Controllers/ConferenceController.swift
@@ -22,6 +22,7 @@ struct ConferenceDTOContent: Content {
   let description: LocalizedStringContent?
   let year: Int
   let isOpen: Bool
+  let isPublished: Bool
   let deadline: Date?
   let startDate: Date?
   let endDate: Date?
@@ -37,6 +38,7 @@ struct ConferenceDTOContent: Content {
     self.description = dto.description.map { LocalizedStringContent(from: $0) }
     self.year = dto.year
     self.isOpen = dto.isOpen
+    self.isPublished = dto.isPublished
     self.deadline = dto.deadline
     self.startDate = dto.startDate
     self.endDate = dto.endDate
@@ -55,6 +57,7 @@ struct CreateConferenceRequestContent: Content {
   let descriptionJa: String?
   let year: Int
   let isOpen: Bool?
+  let isPublished: Bool?
   let deadline: Date?
   let startDate: Date?
   let endDate: Date?
@@ -67,22 +70,37 @@ struct ConferenceController: RouteCollection {
   func boot(routes: RoutesBuilder) throws {
     let conferences = routes.grouped("conferences")
 
-    // Public routes
+    // Public routes (only published conferences are exposed)
     conferences.get(use: getAllConferences)
     conferences.get("open", use: getOpenConferences)
     conferences.get(":path", use: getConference)
 
     // Admin-only routes (Organizer access)
     let adminOnly = conferences.grouped(AuthMiddleware()).grouped(OrganizerMiddleware())
+    adminOnly.get("admin", "all", use: getAllConferencesAdmin)
     adminOnly.post(use: createConference)
     adminOnly.put(":path", use: updateConference)
     adminOnly.delete(":path", use: deleteConference)
   }
 
-  /// Get all conferences
+  /// Get all published conferences.
   /// GET /conferences
   @Sendable
   func getAllConferences(req: Request) async throws -> [ConferenceDTOContent] {
+    let conferences = try await Conference.query(on: req.db)
+      .filter(\.$isPublished == true)
+      .sort(\.$year, .descending)
+      .all()
+
+    return try conferences.map { conference in
+      ConferenceDTOContent(from: try conference.toDTO())
+    }
+  }
+
+  /// Get every conference, including unpublished drafts, for organizers.
+  /// GET /conferences/admin/all
+  @Sendable
+  func getAllConferencesAdmin(req: Request) async throws -> [ConferenceDTOContent] {
     let conferences = try await Conference.query(on: req.db)
       .sort(\.$year, .descending)
       .all()
@@ -98,6 +116,7 @@ struct ConferenceController: RouteCollection {
   func getOpenConferences(req: Request) async throws -> [ConferenceDTOContent] {
     let conferences = try await Conference.query(on: req.db)
       .filter(\.$isOpen == true)
+      .filter(\.$isPublished == true)
       .sort(\.$year, .descending)
       .all()
 
@@ -106,7 +125,8 @@ struct ConferenceController: RouteCollection {
     }
   }
 
-  /// Get a specific conference by path
+  /// Get a specific conference by path. Unpublished conferences are hidden
+  /// behind a 404 from public consumers.
   /// GET /conferences/:path
   @Sendable
   func getConference(req: Request) async throws -> ConferenceDTOContent {
@@ -117,6 +137,7 @@ struct ConferenceController: RouteCollection {
     guard
       let conference = try await Conference.query(on: req.db)
         .filter(\.$path == path)
+        .filter(\.$isPublished == true)
         .first()
     else {
       throw Abort(.notFound, reason: "Conference not found")
@@ -147,6 +168,7 @@ struct ConferenceController: RouteCollection {
       descriptionJa: request.descriptionJa,
       year: request.year,
       isOpen: request.isOpen ?? true,
+      isPublished: request.isPublished ?? true,
       deadline: request.deadline,
       startDate: request.startDate,
       endDate: request.endDate,
@@ -183,6 +205,7 @@ struct ConferenceController: RouteCollection {
     conference.descriptionJa = request.descriptionJa
     conference.year = request.year
     conference.isOpen = request.isOpen ?? conference.isOpen
+    conference.isPublished = request.isPublished ?? conference.isPublished
     conference.deadline = request.deadline
     conference.startDate = request.startDate
     conference.endDate = request.endDate

--- a/Server/Sources/Server/Controllers/ProposalController.swift
+++ b/Server/Sources/Server/Controllers/ProposalController.swift
@@ -186,16 +186,18 @@ struct ProposalController: RouteCollection {
       guard
         let found = try await Conference.query(on: req.db)
           .filter(\.$path == path)
+          .filter(\.$isPublished == true)
           .first()
       else {
         throw Abort(.notFound, reason: "Conference not found: \(path)")
       }
       conference = found
     } else {
-      // Get the current open conference
+      // Get the current open and published conference
       guard
         let current = try await Conference.query(on: req.db)
           .filter(\.$isOpen == true)
+          .filter(\.$isPublished == true)
           .sort(\.$year, .descending)
           .first()
       else {
@@ -358,6 +360,7 @@ struct ProposalController: RouteCollection {
     guard
       let conference = try await Conference.query(on: req.db)
         .filter(\.$path == conferencePath)
+        .filter(\.$isPublished == true)
         .first()
     else {
       throw Abort(.notFound, reason: "Conference not found")

--- a/Server/Sources/Server/Migrations/AddConferenceIsPublished.swift
+++ b/Server/Sources/Server/Migrations/AddConferenceIsPublished.swift
@@ -1,0 +1,16 @@
+import Fluent
+
+/// Migration to add is_published flag to conferences table.
+struct AddConferenceIsPublished: AsyncMigration {
+  func prepare(on database: Database) async throws {
+    try await database.schema(Conference.schema)
+      .field("is_published", .bool, .required, .sql(.default(true)))
+      .update()
+  }
+
+  func revert(on database: Database) async throws {
+    try await database.schema(Conference.schema)
+      .deleteField("is_published")
+      .update()
+  }
+}

--- a/Server/Sources/Server/Models/Conference.swift
+++ b/Server/Sources/Server/Models/Conference.swift
@@ -33,6 +33,12 @@ final class Conference: Model, Content, @unchecked Sendable {
   @Field(key: "is_open")
   var isOpen: Bool
 
+  /// Whether the conference is visible to the public. Unpublished conferences
+  /// are returned only to organizer endpoints so admins can stage them before
+  /// announcing them to the world.
+  @Field(key: "is_published")
+  var isPublished: Bool
+
   /// Submission deadline.
   @OptionalField(key: "deadline")
   var deadline: Date?
@@ -78,6 +84,7 @@ final class Conference: Model, Content, @unchecked Sendable {
     descriptionJa: String? = nil,
     year: Int,
     isOpen: Bool = true,
+    isPublished: Bool = true,
     deadline: Date? = nil,
     startDate: Date? = nil,
     endDate: Date? = nil,
@@ -91,6 +98,7 @@ final class Conference: Model, Content, @unchecked Sendable {
     self.descriptionJa = descriptionJa
     self.year = year
     self.isOpen = isOpen
+    self.isPublished = isPublished
     self.deadline = deadline
     self.startDate = startDate
     self.endDate = endDate
@@ -124,6 +132,7 @@ final class Conference: Model, Content, @unchecked Sendable {
       description: description,
       year: year,
       isOpen: isOpen,
+      isPublished: isPublished,
       deadline: deadline,
       startDate: startDate,
       endDate: endDate,

--- a/Server/Sources/Server/configure.swift
+++ b/Server/Sources/Server/configure.swift
@@ -43,9 +43,10 @@ enum AppConfiguration {
     app.migrations.add(CreateUser())
     app.migrations.add(CreateConference())
     app.migrations.add(CreateProposal())
-    // Adding is_published before the seed so fresh databases have the column
+    // Add is_published before the seed so fresh databases have the column
     // when SeedTrySwiftTokyo2026 saves through the Conference model. Existing
-    // databases will simply pick this migration up at the end of their queue.
+    // databases apply this on their next startup if it is still pending,
+    // following Fluent's registered migration order.
     app.migrations.add(AddConferenceIsPublished())
     app.migrations.add(SeedTrySwiftTokyo2026())
     app.migrations.add(AddUserEmail())

--- a/Server/Sources/Server/configure.swift
+++ b/Server/Sources/Server/configure.swift
@@ -43,6 +43,10 @@ enum AppConfiguration {
     app.migrations.add(CreateUser())
     app.migrations.add(CreateConference())
     app.migrations.add(CreateProposal())
+    // Adding is_published before the seed so fresh databases have the column
+    // when SeedTrySwiftTokyo2026 saves through the Conference model. Existing
+    // databases will simply pick this migration up at the end of their queue.
+    app.migrations.add(AddConferenceIsPublished())
     app.migrations.add(SeedTrySwiftTokyo2026())
     app.migrations.add(AddUserEmail())
     app.migrations.add(AddProposalSpeakerInfo())

--- a/Server/Tests/ServerTests/AdminAPITests.swift
+++ b/Server/Tests/ServerTests/AdminAPITests.swift
@@ -37,6 +37,7 @@ private struct CreateAdminAPITestSchema: AsyncMigration {
       .field("description_ja", .string)
       .field("year", .int, .required)
       .field("is_open", .bool, .required)
+      .field("is_published", .bool, .required, .sql(.default(true)))
       .field("deadline", .datetime)
       .field("start_date", .datetime)
       .field("end_date", .datetime)

--- a/Server/Tests/ServerTests/ConferenceAPITests.swift
+++ b/Server/Tests/ServerTests/ConferenceAPITests.swift
@@ -1,0 +1,204 @@
+import Fluent
+import FluentSQLiteDriver
+import JWT
+import Testing
+import Vapor
+import VaporTesting
+
+@testable import Server
+
+/// Schema migration that creates only the user and conference tables for the
+/// ConferenceController tests.
+private struct CreateConferenceAPITestSchema: AsyncMigration {
+  var name: String { "CreateConferenceAPITestSchema" }
+
+  func prepare(on database: Database) async throws {
+    try await database.schema(User.schema)
+      .id()
+      .field("github_id", .int, .required)
+      .field("username", .string, .required)
+      .field("role", .string, .required)
+      .field("display_name", .string)
+      .field("email", .string)
+      .field("bio", .string)
+      .field("url", .string)
+      .field("organization", .string)
+      .field("avatar_url", .string)
+      .field("created_at", .datetime)
+      .field("updated_at", .datetime)
+      .create()
+
+    try await database.schema(Conference.schema)
+      .id()
+      .field("path", .string, .required)
+      .field("display_name", .string, .required)
+      .field("description_en", .string)
+      .field("description_ja", .string)
+      .field("year", .int, .required)
+      .field("is_open", .bool, .required)
+      .field("is_published", .bool, .required, .sql(.default(true)))
+      .field("deadline", .datetime)
+      .field("start_date", .datetime)
+      .field("end_date", .datetime)
+      .field("location", .string)
+      .field("website_url", .string)
+      .field("created_at", .datetime)
+      .field("updated_at", .datetime)
+      .create()
+  }
+
+  func revert(on database: Database) async throws {
+    try await database.schema(Conference.schema).delete()
+    try await database.schema(User.schema).delete()
+  }
+}
+
+@Suite("Conference API Tests")
+struct ConferenceAPITests {
+  private let jwtSecret = "conference-api-test-secret"
+
+  private func makeApp() async throws -> Application {
+    let app = try await Application.make(.testing)
+    app.databases.use(.sqlite(.memory), as: .sqlite)
+    app.migrations.add(CreateConferenceAPITestSchema())
+    try await app.autoMigrate()
+    await app.jwt.keys.add(hmac: HMACKey(from: jwtSecret), digestAlgorithm: .sha256)
+
+    let api = app.grouped("api", "v1")
+    try api.register(collection: ConferenceController())
+
+    return app
+  }
+
+  private func withTestApp(_ body: (Application) async throws -> Void) async throws {
+    let app = try await makeApp()
+    do {
+      try await body(app)
+    } catch {
+      try await app.asyncShutdown()
+      throw error
+    }
+    try await app.asyncShutdown()
+  }
+
+  private func makeToken(for user: User, on app: Application) async throws -> String {
+    try await app.jwt.keys.sign(
+      UserJWTPayload(userID: try user.requireID(), role: user.role, username: user.username)
+    )
+  }
+
+  private func seedConferences(on db: Database) async throws {
+    try await Conference(
+      path: "published-open",
+      displayName: "Published Open",
+      year: 2027,
+      isOpen: true,
+      isPublished: true
+    ).save(on: db)
+
+    try await Conference(
+      path: "published-closed",
+      displayName: "Published Closed",
+      year: 2025,
+      isOpen: false,
+      isPublished: true
+    ).save(on: db)
+
+    try await Conference(
+      path: "draft-open",
+      displayName: "Draft Open",
+      year: 2028,
+      isOpen: true,
+      isPublished: false
+    ).save(on: db)
+  }
+
+  @Test("GET /conferences excludes unpublished drafts")
+  func publicListExcludesUnpublished() async throws {
+    try await withTestApp { app in
+      try await seedConferences(on: app.db)
+
+      try await app.testing().test(.GET, "api/v1/conferences") { res in
+        #expect(res.status == .ok)
+        let body = try res.content.decode([ConferenceDTOContent].self)
+        let paths = body.map(\.path).sorted()
+        #expect(paths == ["published-closed", "published-open"])
+      }
+    }
+  }
+
+  @Test("GET /conferences/open requires both isOpen and isPublished")
+  func publicOpenListRequiresPublished() async throws {
+    try await withTestApp { app in
+      try await seedConferences(on: app.db)
+
+      try await app.testing().test(.GET, "api/v1/conferences/open") { res in
+        #expect(res.status == .ok)
+        let body = try res.content.decode([ConferenceDTOContent].self)
+        let paths = body.map(\.path)
+        #expect(paths == ["published-open"])
+      }
+    }
+  }
+
+  @Test("GET /conferences/:path returns 404 for unpublished conferences")
+  func publicLookupHidesDrafts() async throws {
+    try await withTestApp { app in
+      try await seedConferences(on: app.db)
+
+      try await app.testing().test(.GET, "api/v1/conferences/draft-open") { res in
+        #expect(res.status == .notFound)
+      }
+
+      try await app.testing().test(.GET, "api/v1/conferences/published-open") { res in
+        #expect(res.status == .ok)
+        let body = try res.content.decode(ConferenceDTOContent.self)
+        #expect(body.path == "published-open")
+        #expect(body.isPublished == true)
+      }
+    }
+  }
+
+  @Test("GET /conferences/admin/all returns every conference for organizers")
+  func adminListReturnsAll() async throws {
+    try await withTestApp { app in
+      try await seedConferences(on: app.db)
+
+      let admin = User(githubID: 1, username: "organizer", role: .admin)
+      try await admin.save(on: app.db)
+      let token = try await makeToken(for: admin, on: app)
+
+      try await app.testing().test(
+        .GET, "api/v1/conferences/admin/all",
+        beforeRequest: { req in
+          req.headers.bearerAuthorization = .init(token: token)
+        }
+      ) { res in
+        #expect(res.status == .ok)
+        let body = try res.content.decode([ConferenceDTOContent].self)
+        let paths = body.map(\.path).sorted()
+        #expect(paths == ["draft-open", "published-closed", "published-open"])
+      }
+    }
+  }
+
+  @Test("GET /conferences/admin/all rejects non-admin callers")
+  func adminListRejectsNonAdmin() async throws {
+    try await withTestApp { app in
+      try await seedConferences(on: app.db)
+
+      let speaker = User(githubID: 2, username: "speaker", role: .speaker)
+      try await speaker.save(on: app.db)
+      let token = try await makeToken(for: speaker, on: app)
+
+      try await app.testing().test(
+        .GET, "api/v1/conferences/admin/all",
+        beforeRequest: { req in
+          req.headers.bearerAuthorization = .init(token: token)
+        }
+      ) { res in
+        #expect(res.status == .forbidden)
+      }
+    }
+  }
+}

--- a/Server/Tests/ServerTests/FavoritesAndFeedbackTests.swift
+++ b/Server/Tests/ServerTests/FavoritesAndFeedbackTests.swift
@@ -38,6 +38,7 @@ private struct CreateFavoritesTestSchema: AsyncMigration {
       .field("description_ja", .string)
       .field("year", .int, .required)
       .field("is_open", .bool, .required)
+      .field("is_published", .bool, .required, .sql(.default(true)))
       .field("deadline", .datetime)
       .field("start_date", .datetime)
       .field("end_date", .datetime)

--- a/Server/Tests/ServerTests/LotteryServiceTests.swift
+++ b/Server/Tests/ServerTests/LotteryServiceTests.swift
@@ -36,6 +36,7 @@ private struct CreateTestLotterySchema: AsyncMigration {
       .field("description_ja", .string)
       .field("year", .int, .required)
       .field("is_open", .bool, .required)
+      .field("is_published", .bool, .required, .sql(.default(true)))
       .field("deadline", .datetime)
       .field("start_date", .datetime)
       .field("end_date", .datetime)

--- a/Server/Tests/ServerTests/OrganizerProposalTests.swift
+++ b/Server/Tests/ServerTests/OrganizerProposalTests.swift
@@ -69,6 +69,7 @@ struct ResolveSpeakerIDTests {
     app.migrations.add(CreateUser())
     app.migrations.add(AddUserEmail())
     app.migrations.add(CreateConference())
+    app.migrations.add(AddConferenceIsPublished())
     app.migrations.add(SeedTrySwiftTokyo2026())
     app.migrations.add(AddPaperCallImportUser())
     app.migrations.add(CreateTestProposalSchema())

--- a/Server/Tests/ServerTests/ProposalAPITests.swift
+++ b/Server/Tests/ServerTests/ProposalAPITests.swift
@@ -39,6 +39,7 @@ private struct CreateProposalAPITestSchema: AsyncMigration {
       .field("description_ja", .string)
       .field("year", .int, .required)
       .field("is_open", .bool, .required)
+      .field("is_published", .bool, .required, .sql(.default(true)))
       .field("deadline", .datetime)
       .field("start_date", .datetime)
       .field("end_date", .datetime)

--- a/Server/Tests/ServerTests/WorkshopAPITests.swift
+++ b/Server/Tests/ServerTests/WorkshopAPITests.swift
@@ -39,6 +39,7 @@ private struct CreateWorkshopAPITestSchema: AsyncMigration {
       .field("description_ja", .string)
       .field("year", .int, .required)
       .field("is_open", .bool, .required)
+      .field("is_published", .bool, .required, .sql(.default(true)))
       .field("deadline", .datetime)
       .field("start_date", .datetime)
       .field("end_date", .datetime)

--- a/SharedModels/Sources/SharedModels/CfP/ConferenceDTO.swift
+++ b/SharedModels/Sources/SharedModels/CfP/ConferenceDTO.swift
@@ -32,6 +32,10 @@
     public let year: Int
     /// Whether CfP is currently open for this conference
     public let isOpen: Bool
+    /// Whether the conference is visible to public consumers. Defaults to
+    /// `true` when decoding responses from older servers that don't yet emit
+    /// the field.
+    public let isPublished: Bool
     /// CfP submission deadline
     public let deadline: Date?
     /// Conference start date
@@ -53,6 +57,7 @@
       description: LocalizedString? = nil,
       year: Int,
       isOpen: Bool = true,
+      isPublished: Bool = true,
       deadline: Date? = nil,
       startDate: Date? = nil,
       endDate: Date? = nil,
@@ -67,6 +72,7 @@
       self.description = description
       self.year = year
       self.isOpen = isOpen
+      self.isPublished = isPublished
       self.deadline = deadline
       self.startDate = startDate
       self.endDate = endDate
@@ -74,6 +80,41 @@
       self.websiteURL = websiteURL
       self.createdAt = createdAt
       self.updatedAt = updatedAt
+    }
+
+    private enum CodingKeys: String, CodingKey {
+      case id
+      case path
+      case displayName
+      case description
+      case year
+      case isOpen
+      case isPublished
+      case deadline
+      case startDate
+      case endDate
+      case location
+      case websiteURL
+      case createdAt
+      case updatedAt
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      self.id = try container.decode(UUID.self, forKey: .id)
+      self.path = try container.decode(String.self, forKey: .path)
+      self.displayName = try container.decode(String.self, forKey: .displayName)
+      self.description = try container.decodeIfPresent(LocalizedString.self, forKey: .description)
+      self.year = try container.decode(Int.self, forKey: .year)
+      self.isOpen = try container.decode(Bool.self, forKey: .isOpen)
+      self.isPublished = try container.decodeIfPresent(Bool.self, forKey: .isPublished) ?? true
+      self.deadline = try container.decodeIfPresent(Date.self, forKey: .deadline)
+      self.startDate = try container.decodeIfPresent(Date.self, forKey: .startDate)
+      self.endDate = try container.decodeIfPresent(Date.self, forKey: .endDate)
+      self.location = try container.decodeIfPresent(String.self, forKey: .location)
+      self.websiteURL = try container.decodeIfPresent(String.self, forKey: .websiteURL)
+      self.createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt)
+      self.updatedAt = try container.decodeIfPresent(Date.self, forKey: .updatedAt)
     }
   }
 
@@ -84,6 +125,7 @@
     public let description: LocalizedString?
     public let year: Int
     public let isOpen: Bool
+    public let isPublished: Bool?
     public let deadline: Date?
     public let startDate: Date?
     public let endDate: Date?
@@ -96,6 +138,7 @@
       description: LocalizedString? = nil,
       year: Int,
       isOpen: Bool = true,
+      isPublished: Bool? = nil,
       deadline: Date? = nil,
       startDate: Date? = nil,
       endDate: Date? = nil,
@@ -107,6 +150,7 @@
       self.description = description
       self.year = year
       self.isOpen = isOpen
+      self.isPublished = isPublished
       self.deadline = deadline
       self.startDate = startDate
       self.endDate = endDate


### PR DESCRIPTION
## Summary

- 運営は **未公開** 状態のカンファレンスを準備でき、公開後にだけ一般ユーザーに見えるようにする
- Organizer 向けに「未公開」バッジ + 公開/非公開トグルを追加し、`isOpen`（受付状態）と独立して操作できるようにする

## Changes

### Server
- `Conference.is_published` カラムを追加（マイグレーション `AddConferenceIsPublished`、`DEFAULT true`）。`SeedTrySwiftTokyo2026` がカラム生成後に走るよう、登録順を seed の前に挿入
- 公開エンドポイント `GET /conferences`, `/conferences/open`, `/conferences/:path` を `is_published = true` でフィルタ
- 新規 admin-only エンドポイント `GET /conferences/admin/all`（全件、未公開を含む）
- `POST /conferences` / `PUT /conferences/:path` で `isPublished` を受領（partial update）

### SharedModels
- `ConferenceDTO.isPublished: Bool` 追加。custom `init(from:)` で旧サーバの payload に対しては `true` をデフォルト
- `CreateConferenceRequest.isPublished: Bool?`

### CfPWeb (Organizer)
- `loadAllConferences()` を `/api/v1/conferences/admin/all` に切替
- カンファレンス管理テーブルに「未公開」バッジ + 「公開する/非公開にする」ボタンを追加
- 受信した PUT を共通化する `buildConferenceUpdatePayload` ヘルパーで重複削減

### Server tests
- 各テストの inline test schema に `is_published` カラムを追加
- `OrganizerProposalTests` のマイグレーションリストに `AddConferenceIsPublished` を追加

## Test plan

- [x] `cd Server && swift test` 全 pass（94 tests）
- [x] `cd CfPWeb && swift build` pass
- [x] `cd Website && swift build` pass
- [x] `cd Android && INCLUDE_SKIP=1 swift build` pass
- [ ] CI: format / test-api-server / test-website / build-android
- [ ] Organizer ページで:
  - [ ] 未公開カンファレンスが表示され、行が dim される
  - [ ] 「未公開」バッジ + 「公開する」ボタンが見える
  - [ ] 公開/非公開トグルが API に反映される
  - [ ] 受付の開閉トグルは独立して機能する
- [ ] 公開カンファレンスのみが home の「募集中のイベント」に出る

## Backward compatibility

- 既存 DB ロウは migration の `DEFAULT true` ですべて公開状態のまま
- 旧 SharedModels を使っているクライアントが新 API レスポンスを decode → 余分なフィールドは無視されるので問題なし
- 新 SharedModels が旧サーバの payload を decode → `isPublished` 欠落時は `true` をデフォルトにするので問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)