### PR TITLE
Let organizers create, edit, and delete conferences in the browser

### DIFF
--- a/CfPWeb/Public/scripts/app.js
+++ b/CfPWeb/Public/scripts/app.js
@@ -2400,6 +2400,10 @@
       html += ' data-toggle-conference="' + pathAttr + '">';
       html += escapeHTML(openActionLabel);
       html += "</button>";
+      html += '<button type="button" class="button light"';
+      html += ' data-edit-conference="' + pathAttr + '">';
+      html += escapeHTML(ja ? "編集" : "Edit");
+      html += "</button>";
       html += "</div>";
       html += "</td>";
       html += "</tr>";
@@ -2499,12 +2503,225 @@
     await applyConferenceUpdate(conference, { isPublished: nextIsPublished }, button, successMessage);
   }
 
+  function pad2(value) {
+    var str = String(value);
+    return str.length >= 2 ? str : "0" + str;
+  }
+
+  function isoToConferenceDateInputValue(iso) {
+    if (!iso) return "";
+    var date = new Date(iso);
+    if (isNaN(date.getTime())) return "";
+    return date.getUTCFullYear() + "-" + pad2(date.getUTCMonth() + 1) + "-" + pad2(date.getUTCDate());
+  }
+
+  function isoToConferenceUTCDatetimeString(iso) {
+    if (!iso) return "";
+    var date = new Date(iso);
+    if (isNaN(date.getTime())) return "";
+    return date.getUTCFullYear() + "-" + pad2(date.getUTCMonth() + 1) + "-" + pad2(date.getUTCDate())
+      + "T" + pad2(date.getUTCHours()) + ":" + pad2(date.getUTCMinutes());
+  }
+
+  function conferenceDateInputToIso(value) {
+    if (!value) return null;
+    var match = String(value).match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) return null;
+    return match[1] + "-" + match[2] + "-" + match[3] + "T00:00:00Z";
+  }
+
+  function conferenceUTCDatetimeToIso(value) {
+    if (!value) return null;
+    var trimmed = String(value).trim();
+    if (!trimmed) return null;
+    var match = trimmed.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/);
+    if (match) {
+      var seconds = match[6] || "00";
+      return match[1] + "-" + match[2] + "-" + match[3] + "T" + match[4] + ":" + match[5] + ":" + seconds + "Z";
+    }
+    var fallback = new Date(trimmed);
+    if (!isNaN(fallback.getTime())) return fallback.toISOString();
+    return null;
+  }
+
+  function showOrganizerConferenceForm(conference) {
+    var card = document.getElementById("organizer-conference-form-card");
+    var form = document.getElementById("organizer-conference-form");
+    if (!card || !form) return;
+
+    var ja = currentLanguage() === "ja";
+    var titleEl = document.getElementById("organizer-conference-form-title");
+    var deleteButton = document.getElementById("organizer-conference-form-delete");
+    var submitButton = document.getElementById("organizer-conference-form-submit");
+
+    form.reset();
+    if (conference) {
+      form.dataset.mode = "edit";
+      if (titleEl) {
+        titleEl.textContent = ja
+          ? "編集: " + conference.displayName
+          : "Edit: " + conference.displayName;
+      }
+      form.elements.originalPath.value = conference.path;
+      form.elements.path.value = conference.path;
+      form.elements.displayName.value = conference.displayName || "";
+      form.elements.year.value = String(conference.year || "");
+      form.elements.deadline.value = isoToConferenceUTCDatetimeString(conference.deadline);
+      form.elements.startDate.value = isoToConferenceDateInputValue(conference.startDate);
+      form.elements.endDate.value = isoToConferenceDateInputValue(conference.endDate);
+      form.elements.location.value = conference.location || "";
+      form.elements.websiteURL.value = conference.websiteURL || "";
+      form.elements.isOpen.checked = conference.isOpen === true;
+      form.elements.isPublished.checked = conference.isPublished !== false;
+      form.elements.descriptionEn.value = conference.description ? conference.description.en : "";
+      form.elements.descriptionJa.value = conference.description ? conference.description.ja : "";
+      if (deleteButton) deleteButton.hidden = false;
+      if (submitButton) submitButton.textContent = ja ? "保存" : "Save";
+    } else {
+      form.dataset.mode = "create";
+      if (titleEl) titleEl.textContent = ja ? "新規カンファレンス" : "New Conference";
+      form.elements.originalPath.value = "";
+      form.elements.isOpen.checked = false;
+      form.elements.isPublished.checked = false;
+      if (deleteButton) deleteButton.hidden = true;
+      if (submitButton) submitButton.textContent = ja ? "作成" : "Create";
+    }
+
+    showStatus("organizer-conference-form-status", "", null);
+    card.hidden = false;
+    card.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  function hideOrganizerConferenceForm() {
+    var card = document.getElementById("organizer-conference-form-card");
+    var form = document.getElementById("organizer-conference-form");
+    if (form) {
+      form.reset();
+      form.dataset.mode = "create";
+    }
+    if (card) card.hidden = true;
+    showStatus("organizer-conference-form-status", "", null);
+  }
+
+  function readOrganizerConferenceForm(form) {
+    var year = parseInt(form.elements.year.value, 10);
+    return {
+      path: form.elements.path.value.trim(),
+      displayName: form.elements.displayName.value.trim(),
+      descriptionEn: (form.elements.descriptionEn.value || "").trim() || null,
+      descriptionJa: (form.elements.descriptionJa.value || "").trim() || null,
+      year: isNaN(year) ? null : year,
+      isOpen: form.elements.isOpen.checked,
+      isPublished: form.elements.isPublished.checked,
+      deadline: conferenceUTCDatetimeToIso(form.elements.deadline.value),
+      startDate: conferenceDateInputToIso(form.elements.startDate.value),
+      endDate: conferenceDateInputToIso(form.elements.endDate.value),
+      location: (form.elements.location.value || "").trim() || null,
+      websiteURL: (form.elements.websiteURL.value || "").trim() || null
+    };
+  }
+
+  async function submitOrganizerConferenceForm() {
+    var form = document.getElementById("organizer-conference-form");
+    if (!form) return;
+    var payload = readOrganizerConferenceForm(form);
+    var mode = form.dataset.mode || "create";
+    var originalPath = form.elements.originalPath.value;
+
+    if (!payload.path || !payload.displayName || payload.year === null) {
+      showStatus(
+        "organizer-conference-form-status",
+        localizedCopy(
+          "Path, display name, and year are required.",
+          "スラッグ・表示名・年度は必須です。"
+        ),
+        "error"
+      );
+      return;
+    }
+
+    var url, method;
+    if (mode === "edit" && originalPath) {
+      url = "/api/v1/conferences/" + encodeURIComponent(originalPath);
+      method = "PUT";
+    } else {
+      url = "/api/v1/conferences";
+      method = "POST";
+    }
+
+    try {
+      await apiRequest(url, { method: method, body: JSON.stringify(payload) });
+      var successMessage = mode === "edit"
+        ? localizedCopy(
+          payload.displayName + " was updated.",
+          payload.displayName + " を更新しました。"
+        )
+        : localizedCopy(
+          payload.displayName + " was created.",
+          payload.displayName + " を作成しました。"
+        );
+      hideOrganizerConferenceForm();
+      await refreshOrganizerConferences();
+      showStatus("organizer-conferences-status", successMessage, "success");
+    } catch (error) {
+      showStatus("organizer-conference-form-status", error.message, "error");
+    }
+  }
+
+  async function deleteOrganizerConferenceFromForm() {
+    var form = document.getElementById("organizer-conference-form");
+    if (!form || form.dataset.mode !== "edit") return;
+    var path = form.elements.originalPath.value;
+    if (!path) return;
+    var conference = findOrganizerConference(path);
+    var displayName = conference ? conference.displayName : path;
+    var confirmMessage = localizedCopy(
+      'Delete conference "' + displayName + '"? This cannot be undone.',
+      "「" + displayName + "」を削除しますか？この操作は取り消せません。"
+    );
+    if (!window.confirm(confirmMessage)) return;
+    try {
+      await apiRequest("/api/v1/conferences/" + encodeURIComponent(path), { method: "DELETE" });
+      hideOrganizerConferenceForm();
+      await refreshOrganizerConferences();
+      showStatus(
+        "organizer-conferences-status",
+        localizedCopy(
+          displayName + " was deleted.",
+          displayName + " を削除しました。"
+        ),
+        "success"
+      );
+    } catch (error) {
+      showStatus("organizer-conference-form-status", error.message, "error");
+    }
+  }
+
   async function bootstrapOrganizerConferencesSection() {
     var tbody = document.getElementById("organizer-conferences-tbody");
     var refreshButton = document.getElementById("organizer-conferences-refresh");
     if (!tbody || !refreshButton) return;
 
     refreshButton.addEventListener("click", refreshOrganizerConferences);
+
+    var addButton = document.getElementById("organizer-conference-add");
+    var form = document.getElementById("organizer-conference-form");
+    var cancelButton = document.getElementById("organizer-conference-form-cancel");
+    var deleteButton = document.getElementById("organizer-conference-form-delete");
+
+    if (addButton) {
+      addButton.addEventListener("click", function () {
+        showOrganizerConferenceForm(null);
+      });
+    }
+    if (cancelButton) cancelButton.addEventListener("click", hideOrganizerConferenceForm);
+    if (deleteButton) deleteButton.addEventListener("click", deleteOrganizerConferenceFromForm);
+    if (form) {
+      form.addEventListener("submit", function (event) {
+        event.preventDefault();
+        submitOrganizerConferenceForm();
+      });
+    }
 
     tbody.addEventListener("click", function (event) {
       var openButton = event.target.closest("[data-toggle-conference]");
@@ -2517,6 +2734,15 @@
       if (publishButton) {
         var publishPath = publishButton.getAttribute("data-toggle-published");
         if (publishPath) toggleOrganizerConferencePublished(publishPath, publishButton);
+        return;
+      }
+      var editButton = event.target.closest("[data-edit-conference]");
+      if (editButton) {
+        var editPath = editButton.getAttribute("data-edit-conference");
+        if (editPath) {
+          var conference = findOrganizerConference(editPath);
+          if (conference) showOrganizerConferenceForm(conference);
+        }
       }
     });
 

--- a/CfPWeb/Public/styles/app.css
+++ b/CfPWeb/Public/styles/app.css
@@ -1563,3 +1563,31 @@ body.modal-open {
   color: var(--muted);
   font-style: italic;
 }
+
+.organizer-conferences-toolbar {
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.organizer-conference-form-card {
+  margin-top: 1rem;
+}
+
+.organizer-conference-form-card textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 8rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.95rem;
+}
+
+.organizer-conference-form-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
+}
+
+.organizer-conference-form-actions .button.danger {
+  margin-left: auto;
+}

--- a/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerConferencesContent.swift
+++ b/CfPWeb/Sources/CfPWeb/Components/Organizer/OrganizerConferencesContent.swift
@@ -18,6 +18,12 @@ struct OrganizerConferencesContent: HTML, Sendable {
 
       div(.class("organizer-conferences-toolbar")) {
         button(
+          .type(.button), .id("organizer-conference-add"),
+          .class("button primary")
+        ) {
+          HTMLText(language == .ja ? "カンファレンスを追加" : "Add Conference")
+        }
+        button(
           .type(.button), .id("organizer-conferences-refresh"),
           .class("button neutral")
         ) {
@@ -54,6 +60,179 @@ struct OrganizerConferencesContent: HTML, Sendable {
         .hidden
       ) {
         HTMLText(language == .ja ? "カンファレンスが登録されていません。" : "No conferences registered.")
+      }
+    }
+
+    OrganizerConferenceFormCard(language: language)
+  }
+}
+
+private struct OrganizerConferenceFormCard: HTML, Sendable {
+  let language: AppLanguage
+
+  var body: some HTML {
+    article(
+      .id("organizer-conference-form-card"),
+      .class("detail-card submit-form-card organizer-conference-form-card"),
+      .hidden
+    ) {
+      header(.class("editor-header-row")) {
+        h3(.id("organizer-conference-form-title")) {
+          HTMLText(language == .ja ? "新規カンファレンス" : "New Conference")
+        }
+      }
+      p(.class("submit-form-intro")) {
+        HTMLText(
+          language == .ja
+            ? "日時は UTC で扱います。説明欄は Markdown が使えます。"
+            : "All dates and times are stored in UTC. Description fields accept Markdown."
+        )
+      }
+      form(.id("organizer-conference-form"), .class("submit-form-grid")) {
+        input(.type(.hidden), .name("originalPath"))
+
+        label(.class("form-field")) {
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "スラッグ (path)" : "Slug (path)")
+          }
+          input(
+            .type(.text), .name("path"),
+            .custom(name: "pattern", value: "[a-z0-9-]+"),
+            .required,
+            .custom(
+              name: "placeholder",
+              value: "tryswift-tokyo-2027")
+          )
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "表示名" : "Display Name")
+          }
+          input(
+            .type(.text), .name("displayName"), .required,
+            .custom(name: "placeholder", value: "try! Swift Tokyo 2027")
+          )
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "年度" : "Year")
+          }
+          input(
+            .type(.number), .name("year"), .required,
+            .custom(name: "min", value: "2000"),
+            .custom(name: "max", value: "2100")
+          )
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "応募締切 (UTC)" : "Submission Deadline (UTC)")
+          }
+          input(
+            .type(.text), .name("deadline"),
+            .custom(name: "placeholder", value: "YYYY-MM-DDTHH:mm")
+          )
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "開始日 (UTC)" : "Start Date (UTC)")
+          }
+          input(
+            .type(.date), .name("startDate")
+          )
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "終了日 (UTC)" : "End Date (UTC)")
+          }
+          input(
+            .type(.date), .name("endDate")
+          )
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "会場" : "Location")
+          }
+          input(
+            .type(.text), .name("location"),
+            .custom(name: "placeholder", value: "Tokyo, Japan")
+          )
+        }
+        label(.class("form-field")) {
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "ウェブサイト URL" : "Website URL")
+          }
+          input(
+            .type(.url), .name("websiteURL"),
+            .custom(name: "placeholder", value: "https://tryswift.jp")
+          )
+        }
+
+        label(.class("form-field organizer-checkbox-row submit-form-full")) {
+          input(.type(.checkbox), .name("isOpen"))
+          span {
+            HTMLText(language == .ja ? "CfP の応募を受け付ける" : "Accept proposals (CfP open)")
+          }
+        }
+        label(.class("form-field organizer-checkbox-row submit-form-full")) {
+          input(.type(.checkbox), .name("isPublished"))
+          span {
+            HTMLText(
+              language == .ja
+                ? "公開する（オフのままだと未公開ドラフトになります）"
+                : "Publish (leave off to keep as an unpublished draft)"
+            )
+          }
+        }
+
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "説明 (英語, Markdown)" : "Description (English, Markdown)")
+          }
+          textarea(
+            .name("descriptionEn"),
+            .custom(name: "rows", value: "6")
+          ) {}
+        }
+        label(.class("form-field submit-form-full")) {
+          span(.class("field-label")) {
+            HTMLText(language == .ja ? "説明 (日本語, Markdown)" : "Description (Japanese, Markdown)")
+          }
+          textarea(
+            .name("descriptionJa"),
+            .custom(name: "rows", value: "6")
+          ) {}
+        }
+
+        p(
+          .id("organizer-conference-form-status"),
+          .class("inline-status submit-form-full"),
+          .hidden
+        ) {}
+
+        div(.class("organizer-conference-form-actions submit-form-full")) {
+          button(
+            .type(.submit),
+            .id("organizer-conference-form-submit"),
+            .class("button primary")
+          ) {
+            HTMLText(language == .ja ? "保存" : "Save")
+          }
+          button(
+            .type(.button),
+            .id("organizer-conference-form-cancel"),
+            .class("button neutral")
+          ) {
+            HTMLText(language == .ja ? "キャンセル" : "Cancel")
+          }
+          button(
+            .type(.button),
+            .id("organizer-conference-form-delete"),
+            .class("button danger"),
+            .hidden
+          ) {
+            HTMLText(language == .ja ? "削除" : "Delete")
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

- これまで Organizer 管理ページで触れたのは公開トグルと CfP 受付トグルだけで、新規 Conference の作成や typo の修正は admin API を直叩きするしかなかった
- 既存の `POST/PUT/DELETE /api/v1/conferences` を使ってフォーム UI を追加し、ブラウザだけで CRUD を完結させる

## Changes

### CfPWeb
- 「カンファレンスを追加」ツールバーボタンを追加（form を create モードで開く）
- 各行に「編集」ボタンを追加（form を edit モードで開く、`originalPath` を保持して PUT のターゲットにする）
- 編集モード時のみ「削除」ボタンを表示。`window.confirm()` で確認後に DELETE
- 日時はすべて UTC で扱う:
  - `<input type="date">` → `YYYY-MM-DDT00:00:00Z` で送信、表示は UTC components で復元
  - 締切は text input で `YYYY-MM-DDTHH:mm` を受け取り、`Z` を付けて送信
- 説明欄 (en/ja) は Markdown を直接編集可能（home の event card 描画と整合）
- form エラー / 成功時は inline status で feedback、操作後に table を refresh

### Server / SharedModels
- 変更なし。既存の `POST /api/v1/conferences`, `PUT /api/v1/conferences/:path`, `DELETE /api/v1/conferences/:path` をそのまま利用

## Test plan

- [x] `cd CfPWeb && swift build` 成功
- [x] `swift run CfPWeb` で `/organizer/conferences/index.html` に form 要素が出力される
- [x] `node --check` で app.js 構文 OK
- [ ] ステージング環境で:
  - [ ] 「カンファレンスを追加」→ 新規作成（未公開のドラフト）
  - [ ] 各行の「編集」→ 値が事前ロードされ、保存で PUT が反映される
  - [ ] 編集モードからの「削除」→ confirm 後に DELETE で消える
  - [ ] 必須欄（path / displayName / year）の検証
  - [ ] Markdown 説明欄が home に正しく描画される

## Backward compatibility

- API スキーマは変えていないので既存クライアントに影響なし
- 既存の publish / CfP open トグルは引き続き動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)