### PR TITLE
Point Website CfP page at try! Swift Tokyo 2027

### DIFF
--- a/Website/Sources/Components/CallForProposalComponent.swift
+++ b/Website/Sources/Components/CallForProposalComponent.swift
@@ -175,8 +175,8 @@ struct CallForProposalComponent: HTML {
 
   private var heroEyebrow: String {
     switch language {
-    case .ja: "try! Swift Tokyo 2026"
-    case .en: "try! Swift Tokyo 2026"
+    case .ja: "try! Swift Tokyo 2027"
+    case .en: "try! Swift Tokyo 2027"
     }
   }
 
@@ -190,9 +190,9 @@ struct CallForProposalComponent: HTML {
   private var heroDescription: String {
     switch language {
     case .ja:
-      "世界中の Swift 開発者に向けて、あなたの知見を共有しませんか。try! Swift Tokyo 2026 のセッション提案を募集しています。"
+      "世界中の Swift 開発者に向けて、あなたの知見を共有しませんか。try! Swift Tokyo 2027 をはじめとする来年度の各イベントで、セッション提案を募集しています。"
     case .en:
-      "Share your Swift expertise with developers from around the world. Submit your talk proposal for try! Swift Tokyo 2026."
+      "Share your Swift expertise with developers from around the world. Submit your talk proposal for try! Swift Tokyo 2027 and our other upcoming events."
     }
   }
 
@@ -257,17 +257,17 @@ struct CallForProposalComponent: HTML {
     switch language {
     case .ja:
       [
-        .init(id: "open", title: "CfP 開始", date: "2026年1月15日"),
-        .init(id: "deadline", title: "提出締切", date: "2026年2月1日"),
-        .init(id: "notification", title: "結果通知", date: "2026年2月8日"),
-        .init(id: "conference", title: "カンファレンス", date: "2026年4月12日 - 14日"),
+        ImportantDate(id: "open", title: "CfP 開始", date: "未定"),
+        ImportantDate(id: "deadline", title: "提出締切", date: "未定"),
+        ImportantDate(id: "notification", title: "結果通知", date: "未定"),
+        ImportantDate(id: "conference", title: "カンファレンス", date: "2027 年春予定"),
       ]
     case .en:
       [
-        .init(id: "open", title: "CfP Opens", date: "January 15, 2026"),
-        .init(id: "deadline", title: "Submission Deadline", date: "February 1, 2026"),
-        .init(id: "notification", title: "Notifications", date: "February 8, 2026"),
-        .init(id: "conference", title: "Conference", date: "April 12-14, 2026"),
+        ImportantDate(id: "open", title: "CfP Opens", date: "TBA"),
+        ImportantDate(id: "deadline", title: "Submission Deadline", date: "TBA"),
+        ImportantDate(id: "notification", title: "Notifications", date: "TBA"),
+        ImportantDate(id: "conference", title: "Conference", date: "Spring 2027"),
       ]
     }
   }

--- a/Website/Sources/Components/CallForProposalComponent.swift
+++ b/Website/Sources/Components/CallForProposalComponent.swift
@@ -257,17 +257,17 @@ struct CallForProposalComponent: HTML {
     switch language {
     case .ja:
       [
-        ImportantDate(id: "open", title: "CfP 開始", date: "未定"),
-        ImportantDate(id: "deadline", title: "提出締切", date: "未定"),
-        ImportantDate(id: "notification", title: "結果通知", date: "未定"),
-        ImportantDate(id: "conference", title: "カンファレンス", date: "2027 年春予定"),
+        .init(id: "open", title: "CfP 開始", date: "未定"),
+        .init(id: "deadline", title: "提出締切", date: "未定"),
+        .init(id: "notification", title: "結果通知", date: "未定"),
+        .init(id: "conference", title: "カンファレンス", date: "2027年春予定"),
       ]
     case .en:
       [
-        ImportantDate(id: "open", title: "CfP Opens", date: "TBA"),
-        ImportantDate(id: "deadline", title: "Submission Deadline", date: "TBA"),
-        ImportantDate(id: "notification", title: "Notifications", date: "TBA"),
-        ImportantDate(id: "conference", title: "Conference", date: "Spring 2027"),
+        .init(id: "open", title: "CfP Opens", date: "TBA"),
+        .init(id: "deadline", title: "Submission Deadline", date: "TBA"),
+        .init(id: "notification", title: "Notifications", date: "TBA"),
+        .init(id: "conference", title: "Conference", date: "Spring 2027"),
       ]
     }
   }


### PR DESCRIPTION
## Summary

- Website のトップにある `/cfp` ページの hero / 重要日程セクションが、もう終了した 2026 イベントを案内し続けていたので、`try! Swift Tokyo 2027` 向けに更新
- 具体的な日程は未確定のため TBA / 未定 プレースホルダで表示。確定したら同ファイルを書き換えるだけで反映可能
- `ConferenceYear` enum や DataClient JSON は変更せず、過去年度の Schedule / Sponsors / Organizers はそのまま 2026 のデータを表示し続ける（このページは CfP の宣伝のみ）

## Changes

- `Website/Sources/Components/CallForProposalComponent.swift`
  - `heroEyebrow`: `try! Swift Tokyo 2026` → `try! Swift Tokyo 2027`
  - `heroDescription`: マルチイベントを意識した「2027 をはじめとする来年度の各イベント」「try! Swift Tokyo 2027 and our other upcoming events」に書き換え
  - `importantDates`: CfP 開始 / 締切 / 結果通知 を `未定` / `TBA` に置換、カンファレンス行は `2027 年春予定` / `Spring 2027` に

## Out of scope

- `ConferenceYear.year2027` の追加 → iOS / Android の `selectedYear = .latest` がデータの無い 2027 を指して空 schedule を出すため、別 PR で慎重に対応
- `Home.swift` / `HomeSections.swift` などの 2026 終了イベント記述 → アーカイブとして 2026 を表示し続ける形なのでそのまま
- DataClient JSON 追加 → 2027 のデータが揃ってから

## Test plan

- [x] `cd Website && swift build` 成功
- [ ] CI: format / Build Website
- [ ] デプロイ後、`/cfp` ページで hero / 重要日程が 2027 / TBA 表示になることを確認
- [ ] CfPWeb 側 (`https://cfp.tryswift.jp`) は引き続き Conference DB ベースで複数イベントを表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)