### PR TITLE
Stop stretching organizer-page checkboxes to full width

### DIFF
--- a/Web/Public/styles/app.css
+++ b/Web/Public/styles/app.css
@@ -1466,6 +1466,17 @@ body.modal-open {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  cursor: pointer;
+}
+
+/* The base .form-field input rule stretches inputs to 100% width, which
+   pushes checkbox/radio inputs out of place inside .organizer-checkbox-row.
+   Restore the natural intrinsic width so the box sits next to its label. */
+.organizer-checkbox-row input[type="checkbox"],
+.organizer-checkbox-row input[type="radio"] {
+  width: auto;
+  flex: 0 0 auto;
+  margin: 0;
 }
 
 .form-actions.split {


### PR DESCRIPTION
## Summary

- Override `.form-field input { width: 100% }` for checkbox/radio inputs inside `.organizer-checkbox-row` so they keep their natural intrinsic width
- Add `cursor: pointer` on the row to match the clickable label affordance

The organizer conference form's "公開する / Publish" and "受付中 / Open" checkboxes were rendering as full-width bars because the generic `.form-field input` rule stretched every input. Restoring `width: auto` puts the box back next to its label.

## Test plan

- [x] `swift build` in `CfPWeb/`
- [x] Visual check on `/ja/organizer/conferences` and `/organizer/conferences` — checkboxes render at intrinsic size, label sits to the right
- [ ] CI: format.yml passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)