### PR TITLE
Fix production deploy by copying Web package into Docker build

### DIFF
--- a/.github/workflows/deploy-api-server-prod.yml
+++ b/.github/workflows/deploy-api-server-prod.yml
@@ -7,10 +7,10 @@ on:
       - "Server/**"
       - "SharedModels/**"
       - "DataClient/**"
-      # Server/Dockerfile copies static images from Web/Assets/images into the
-      # production image. Trigger a redeploy when those assets change so prod
-      # never serves stale images.
-      - "Web/Assets/images/**"
+      # Server links WebShared and WebSponsor libraries from the Web package
+      # and copies Web/Assets/images into the production image, so any change
+      # under Web/ should redeploy.
+      - "Web/**"
       - "fly.production.toml"
   workflow_dispatch:
 

--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -15,6 +15,9 @@ COPY ./SharedModels ./SharedModels
 # Copy DataClient package (speaker data for timetable export)
 COPY ./DataClient ./DataClient
 
+# Copy Web package (Server links WebShared and WebSponsor libraries)
+COPY ./Web ./Web
+
 # Copy Server package manifest and resolved file for reproducible builds
 COPY ./Server/Package.swift ./Server/Package.swift
 COPY ./Server/Package.resolved ./Server/Package.resolved

--- a/fly.production.toml
+++ b/fly.production.toml
@@ -1,6 +1,8 @@
 # fly.production.toml - Fly.io configuration for trySwift API Server (Production)
 # Deploy from project root: fly deploy --config fly.production.toml
-# Custom domain: api.tryswift.jp (via Cloudflare proxy)
+# Custom domains (both routed to this single Fly app via Cloudflare):
+#   - api.tryswift.jp     -> JSON API
+#   - sponsor.tryswift.jp -> Sponsor portal SSR (host-routed by HostRoutingMiddleware)
 
 app = 'tryswift-api-prod'
 primary_region = 'nrt'
@@ -10,6 +12,9 @@ primary_region = 'nrt'
 
 [env]
   LOG_LEVEL = 'info'
+  APP_ENV = 'production'
+  SPONSOR_HOST = 'sponsor.tryswift.jp'
+  SPONSOR_BASE_URL = 'https://sponsor.tryswift.jp'
 
 [http_service]
   internal_port = 8080


### PR DESCRIPTION
## Summary

- `Server/Package.swift` links `WebShared` and `WebSponsor` from the local `Web` package, but `Server/Dockerfile` never copied `Web/` into the build stage. `swift package resolve` has failed in CI with `error: 'web': the package at '/build/Web' cannot be accessed` since #465 merged — every production deploy run since then is red.
- This means the new `sponsor.tryswift.jp` routes (host-gated by `HostRoutingMiddleware`) and the `MagicLinkService` Linux fix from #469 are *not* on production yet.

## Changes

- **`Server/Dockerfile`**: `COPY ./Web ./Web` next to `SharedModels` and `DataClient`, before `swift package resolve`.
- **`.github/workflows/deploy-api-server-prod.yml`**: widen the path filter from `Web/Assets/images/**` to `Web/**` so changes under `Web/Sources/WebSponsor/`, `Web/Package.swift`, etc. also trigger a redeploy.
- **`fly.production.toml`**: document the second host binding (`sponsor.tryswift.jp`) and pin `APP_ENV=production`, `SPONSOR_HOST`, `SPONSOR_BASE_URL` in `[env]` so cookies are `Secure` and the host gate is explicit. (Code already defaults to these values; this just makes them visible in the production config.)

## Why these go together

All three are needed to actually serve `sponsor.tryswift.jp`. The Dockerfile fix unblocks the deploy; the workflow filter ensures the deploy is triggered when the sponsor SSR code changes; the fly env makes the production host binding self-documenting.

## Follow-ups (out of scope, ops side)

After this lands and `Deploy API Server (Production)` goes green:

1. `fly secrets set RESEND_API_KEY=…` on `tryswift-api-prod` (magic-link delivery).
2. `fly certs add sponsor.tryswift.jp -a tryswift-api-prod` and add the Cloudflare CNAME `sponsor → tryswift-api-prod.fly.dev` (same Cloudflare proxy setting as `api.tryswift.jp`).
3. Smoke test: `curl -I https://sponsor.tryswift.jp/` should return 200 SSR HTML; `curl -I https://sponsor.tryswift.jp/api/v1/conferences` should return 404 (host isolation).

## Test plan

- [x] `cd Server && swift test` — 120 tests passing locally
- [ ] CI: `Deploy API Server (Production)` succeeds when this merges to main
- [ ] After ops follow-ups: `curl -I https://sponsor.tryswift.jp/` → 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)