### PR TITLE
Copy LocalizationGenerated into Docker build to unblock prod deploy

### DIFF
--- a/.github/workflows/deploy-api-server-prod.yml
+++ b/.github/workflows/deploy-api-server-prod.yml
@@ -9,8 +9,11 @@ on:
       - "DataClient/**"
       # Server links WebShared and WebSponsor libraries from the Web package
       # and copies Web/Assets/images into the production image, so any change
-      # under Web/ should redeploy.
+      # under Web/ should redeploy. LocalizationGenerated is a transitive dep
+      # of Web's WebConference target and must also be available for
+      # `swift package resolve` to succeed inside the Docker build stage.
       - "Web/**"
+      - "LocalizationGenerated/**"
       - "fly.production.toml"
   workflow_dispatch:
 

--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -18,6 +18,9 @@ COPY ./DataClient ./DataClient
 # Copy Web package (Server links WebShared and WebSponsor libraries)
 COPY ./Web ./Web
 
+# Copy LocalizationGenerated package (transitive dep of Web's WebConference target)
+COPY ./LocalizationGenerated ./LocalizationGenerated
+
 # Copy Server package manifest and resolved file for reproducible builds
 COPY ./Server/Package.swift ./Server/Package.swift
 COPY ./Server/Package.resolved ./Server/Package.resolved


### PR DESCRIPTION
## Summary

Follow-up to #470. After adding `COPY ./Web ./Web`, the next prod deploy failed at the *next* link in the local-path-dependency chain:

```
error: 'localizationgenerated': the package at '/build/LocalizationGenerated' cannot be accessed (/build/LocalizationGenerated doesn't exist in file system)
```

`Web/Package.swift` declares `LocalizationGenerated` as a sibling-path package and `WebConference` consumes it. Even though the `Server` target doesn't link `WebConference`, `swift package resolve` walks the full dependency graph of `Web` and needs the directory to exist on disk inside the Docker build context.

## Changes

- **`Server/Dockerfile`**: `COPY ./LocalizationGenerated ./LocalizationGenerated` next to `Web/`.
- **`.github/workflows/deploy-api-server-prod.yml`**: include `LocalizationGenerated/**` in the path filter so edits there also trigger a redeploy.

## Test plan

- [ ] CI: `Test Server` and `swift-format` pass on this PR.
- [ ] After merge: `Deploy API Server (Production)` (run id will be the new push to main) succeeds. Previously failing run for #470: https://github.com/tryswift/try-swift-tokyo/actions/runs/25503649693

🤖 Generated with [Claude Code](https://claude.com/claude-code)