### PR TITLE
Cap swift build to -j 2 to fit Fly remote-builder RAM

### DIFF
--- a/Server/Dockerfile
+++ b/Server/Dockerfile
@@ -37,8 +37,12 @@ RUN swift package resolve
 COPY ./Server/Sources ./Sources
 COPY ./Server/Tests ./Tests
 
-# Build Server with release configuration
-RUN swift build -c release --static-swift-stdlib \
+# Build Server with release configuration.
+# Cap parallelism to 2 jobs: with the Web package (Elementary, WebSponsor,
+# WebShared, etc.) pulled into the dependency graph, a fully-parallel
+# `swift build -c release` peaks above the Fly remote-builder RAM and the
+# compiler is killed with SIGKILL (`signal 9`) near the end of the build.
+RUN swift build -c release -j 2 --static-swift-stdlib \
     -Xlinker -ljemalloc
 
 # Switch to staging area


### PR DESCRIPTION
## Summary

Production deploys are still failing after #470 + #471 with **OOM kill** during the Linux release build:

```
[1019/1026] Compiling AsyncKit ConnectionPoolError.swift
error: compile command failed due to signal 9 (use -v to see invocation)
error releasing builder: deadline_exceeded: context deadline exceeded
```

Adding the `Web` package (Elementary, WebShared, WebSponsor, transitively LocalizationGenerated and Ignite resolution) bloated the dependency graph enough that a fully-parallel `swift build -c release` peaks above the Fly remote-builder VM's available RAM during the final codegen / link phase. The compiler is killed with SIGKILL near the very end (1019/1026 files).

## Change

- `Server/Dockerfile`: pass `-j 2` to `swift build -c release` to cap the build parallelism. Memory now stays bounded and the build can finish.

## Trade-off

Build wall-clock will be ~1.5–2x longer (~10–13 minutes instead of ~7), which is fine for a once-per-merge production deploy. If we want to win that back later, the alternative is upgrading the Fly remote builder VM size (`fly remote-builder update --vm-size shared-cpu-4x`) or splitting the Server target into smaller modules.

## Failing run for reference

https://github.com/tryswift/try-swift-tokyo/actions/runs/25503996304 (and the post-#472 retry 25507818293 will likely OOM the same way)

## Test plan

- [ ] CI: `Test Server`, `swift-format` pass on this PR.
- [ ] After merge: `Deploy API Server (Production)` finally goes green.
- [ ] After merge: `curl -sSI https://api.tryswift.jp/health` returns 200 and the `Image` reported by `fly status -a tryswift-api-prod` updates from the Apr-21 deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)