### PR TITLE
Serialize production deploys to avoid Fly builder RAM thrash

### DIFF
--- a/.github/workflows/deploy-api-server-prod.yml
+++ b/.github/workflows/deploy-api-server-prod.yml
@@ -17,6 +17,15 @@ on:
       - "fly.production.toml"
   workflow_dispatch:
 
+# Serialize prod deploys: the Fly.io remote builder is shared per-app, and
+# running two `flyctl deploy` jobs in parallel makes them fight for builder
+# RAM and OOM-kill the Swift compiler partway through the build. Cancel the
+# in-progress run when a newer commit lands on main so only the latest deploy
+# proceeds.
+concurrency:
+  group: deploy-api-server-prod
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Yesterday's stack of failed `Deploy API Server (Production)` runs (25503996304, 25507818293, 25508164728) all OOM-killed the Swift compiler with `signal 9`. The third one died unusually early (~103/975 files into compilation) because **two deploy runs were racing on the same Fly remote-builder VM**, fighting each other for RAM. Run 25507818293 had been triggered by the merge of #472 while 25503996304 (from #471) was still building, and both got pushed onto the same `fly-builder-tryswift-api-prod` machine.

## Change

`.github/workflows/deploy-api-server-prod.yml`: add a workflow-level concurrency group so any new commit to main cancels the in-flight deploy instead of stacking up on the builder.

```yaml
concurrency:
  group: deploy-api-server-prod
  cancel-in-progress: true
```

cfp's deploy workflow already uses this pattern (`cfpweb-deploy` group).

## Test plan

- [ ] CI passes on this PR.
- [ ] After merge: trigger two pushes in quick succession (or rely on CI re-runs); only the latest run should reach `flyctl deploy`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)