### PR TITLE
Fix sponsor benefits column type (jsonb → text[])

### DIFF
--- a/Server/Sources/Server/Sponsor/Migrations/AlterSponsorPlanLocalizationBenefitsToStringArray.swift
+++ b/Server/Sources/Server/Sponsor/Migrations/AlterSponsorPlanLocalizationBenefitsToStringArray.swift
@@ -1,0 +1,47 @@
+import Fluent
+import SQLKit
+
+/// Convert `sponsor_plan_localizations.benefits` from `jsonb` to `text[]`.
+///
+/// `CreateSponsorPlanLocalization` originally created the column as `.json`
+/// (jsonb in Postgres), but the model writes it as `[String]`, which Fluent
+/// serialises as a Postgres text array. Production startup fails with
+/// `column "benefits" is of type jsonb but expression is of type text[]` while
+/// running `SeedSponsorPlans2026`. New environments will get `.array(of: .string)`
+/// directly from the updated `CreateSponsorPlanLocalization`; this migration
+/// brings already-migrated databases in line.
+struct AlterSponsorPlanLocalizationBenefitsToStringArray: AsyncMigration {
+  func prepare(on database: Database) async throws {
+    // Postgres-only ALTER. On SQLite (used in tests) this migration is a
+    // no-op because CreateSponsorPlanLocalization already creates the
+    // column as `.array(of: .string)` after this PR; SQLite stores arrays
+    // as JSON strings regardless of the declared type.
+    guard let sql = database as? SQLDatabase, sql.dialect.name == "postgresql" else { return }
+    // The SeedSponsorPlans2026 migration could not insert any rows yet, so
+    // the table is empty in practice. Still emit a USING expression so the
+    // ALTER works even if rows somehow exist.
+    try await sql.raw(
+      """
+      ALTER TABLE sponsor_plan_localizations
+      ALTER COLUMN benefits TYPE text[]
+      USING (
+        CASE
+          WHEN benefits IS NULL THEN ARRAY[]::text[]
+          ELSE ARRAY(SELECT jsonb_array_elements_text(benefits))
+        END
+      )
+      """
+    ).run()
+  }
+
+  func revert(on database: Database) async throws {
+    guard let sql = database as? SQLDatabase, sql.dialect.name == "postgresql" else { return }
+    try await sql.raw(
+      """
+      ALTER TABLE sponsor_plan_localizations
+      ALTER COLUMN benefits TYPE jsonb
+      USING to_jsonb(benefits)
+      """
+    ).run()
+  }
+}

--- a/Server/Sources/Server/Sponsor/Migrations/CreateSponsorPlanLocalization.swift
+++ b/Server/Sources/Server/Sponsor/Migrations/CreateSponsorPlanLocalization.swift
@@ -8,7 +8,7 @@ struct CreateSponsorPlanLocalization: AsyncMigration {
       .field("locale", .string, .required)
       .field("name", .string, .required)
       .field("summary", .string, .required)
-      .field("benefits", .json, .required)
+      .field("benefits", .array(of: .string), .required)
       .unique(on: "plan_id", "locale")
       .create()
   }

--- a/Server/Sources/Server/configure.swift
+++ b/Server/Sources/Server/configure.swift
@@ -79,6 +79,9 @@ enum AppConfiguration {
     app.migrations.add(CreateSponsorApplication())
     app.migrations.add(CreateMagicLinkToken())
     app.migrations.add(CreateSponsorInvitation())
+    // Fix benefits column type for environments where
+    // CreateSponsorPlanLocalization has already run with `.json`.
+    app.migrations.add(AlterSponsorPlanLocalizationBenefitsToStringArray())
     app.migrations.add(SeedSponsorPlans2026())
 
     // Auto-migrate on startup (safe for production as Fluent tracks completed migrations)


### PR DESCRIPTION
## Summary

Production deploys were silently bricking the API after the new image rolled out: machines exited with code 132 (Swift runtime fatalError → SIGILL) and clients saw 502s. The Postgres log explained why:

```
ERROR: column "benefits" is of type jsonb but expression is of type text[] at character 129
```

`SponsorPlanLocalization` writes the field as `@Field(key: "benefits") var benefits: [String]`, which Fluent serialises as a Postgres text array, but `CreateSponsorPlanLocalization` declared the schema as `.field("benefits", .json, .required)` (jsonb). `CreateSponsorPlanLocalization` could finish (CREATE TABLE doesn't care about row data), but `SeedSponsorPlans2026` then aborted on its first `INSERT`, taking `app.autoMigrate()` and the whole startup sequence down with it.

## Changes

- `Server/Sources/Server/Sponsor/Migrations/CreateSponsorPlanLocalization.swift`: declare `benefits` as `.array(of: .string)` (text[]) so freshly-migrated environments match the model from day one.
- `Server/Sources/Server/Sponsor/Migrations/AlterSponsorPlanLocalizationBenefitsToStringArray.swift` (new): Postgres-only migration that runs `ALTER TABLE sponsor_plan_localizations ALTER COLUMN benefits TYPE text[] USING ...` for environments where the original migration has already run (production DB). It's a no-op on SQLite (test backend) — guarded by `sql.dialect.name == "postgresql"`.
- `Server/Sources/Server/configure.swift`: register the alter migration immediately before `SeedSponsorPlans2026`, so the seed insert succeeds on the next deploy attempt.

## Why two migrations and not one

Fluent records `CreateSponsorPlanLocalization` as completed in the migration log table once it returns successfully, so editing it in place doesn't re-run it on production. The Alter migration is the only way to bring the existing column in line without manually surgery.

## Test plan

- [x] `cd Server && swift test` → 120/120 pass.
- [x] CI green on this PR.
- [ ] After rollback restores prod and this lands, the next deploy completes the sponsor migration sequence and machines stay `started`.

## Related

Stems from the deploy stack #470 → #471 → #472 → #473 chasing OOM/build fixes; this is the application-level issue that surfaced once those builder issues were resolved and the image actually shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)