### PR TITLE
Fix benefits ALTER migration (subquery not allowed in USING)

### DIFF
--- a/Server/Sources/Server/Sponsor/Migrations/AlterSponsorPlanLocalizationBenefitsToStringArray.swift
+++ b/Server/Sources/Server/Sponsor/Migrations/AlterSponsorPlanLocalizationBenefitsToStringArray.swift
@@ -17,31 +17,33 @@ struct AlterSponsorPlanLocalizationBenefitsToStringArray: AsyncMigration {
     // column as `.array(of: .string)` after this PR; SQLite stores arrays
     // as JSON strings regardless of the declared type.
     guard let sql = database as? SQLDatabase, sql.dialect.name == "postgresql" else { return }
-    // The SeedSponsorPlans2026 migration could not insert any rows yet, so
-    // the table is empty in practice. Still emit a USING expression so the
-    // ALTER works even if rows somehow exist.
+    // The original ALTER attempted `USING (... ARRAY(SELECT jsonb_array_elements_text(benefits)) ...)`,
+    // but Postgres rejects that with "cannot use subquery in transform expression"
+    // (sqlState 0A000): subqueries are not allowed inside an `ALTER COLUMN ... USING`
+    // expression. We work around it by dropping the column and re-adding it as
+    // `text[]`. SeedSponsorPlans2026 has never finished on production, so the
+    // table is empty there; SQLite tests skip this migration entirely via the
+    // dialect guard above.
+    try await sql.raw("ALTER TABLE sponsor_plan_localizations DROP COLUMN benefits").run()
     try await sql.raw(
       """
       ALTER TABLE sponsor_plan_localizations
-      ALTER COLUMN benefits TYPE text[]
-      USING (
-        CASE
-          WHEN benefits IS NULL THEN ARRAY[]::text[]
-          ELSE ARRAY(SELECT jsonb_array_elements_text(benefits))
-        END
-      )
+      ADD COLUMN benefits text[] NOT NULL DEFAULT ARRAY[]::text[]
       """
+    ).run()
+    try await sql.raw(
+      "ALTER TABLE sponsor_plan_localizations ALTER COLUMN benefits DROP DEFAULT"
     ).run()
   }
 
   func revert(on database: Database) async throws {
     guard let sql = database as? SQLDatabase, sql.dialect.name == "postgresql" else { return }
+    try await sql.raw("ALTER TABLE sponsor_plan_localizations DROP COLUMN benefits").run()
     try await sql.raw(
-      """
-      ALTER TABLE sponsor_plan_localizations
-      ALTER COLUMN benefits TYPE jsonb
-      USING to_jsonb(benefits)
-      """
+      "ALTER TABLE sponsor_plan_localizations ADD COLUMN benefits jsonb NOT NULL DEFAULT '[]'::jsonb"
+    ).run()
+    try await sql.raw(
+      "ALTER TABLE sponsor_plan_localizations ALTER COLUMN benefits DROP DEFAULT"
     ).run()
   }
 }


### PR DESCRIPTION
## Summary

The fix shipped in #475 (`AlterSponsorPlanLocalizationBenefitsToStringArray`) crashed Vapor on every production boot. The Fly logs caught the real cause:

```
PSQLError(code: server, serverInfo: [
  sqlState: 0A000,
  message: cannot use subquery in transform expression,
  file: parse_expr.c, line: 1874,
  routine: transformSubLink, ...
],
query: ALTER TABLE sponsor_plan_localizations
       ALTER COLUMN benefits TYPE text[]
       USING ( CASE
         WHEN benefits IS NULL THEN ARRAY[]::text[]
         ELSE ARRAY(SELECT jsonb_array_elements_text(benefits))
       END ))
```

Postgres explicitly forbids subqueries inside an `ALTER COLUMN ... USING` transform expression (parse_expr.c:1874). The migration threw, `try await app.autoMigrate()` aborted at the top level, the Vapor process died with SIGILL (exit code 132), and Fly looped restarts until backoff. End result: the prod API returned 502/524 for hours.

## Why we don't need the USING in the first place

`SeedSponsorPlans2026` has never completed on production, so `sponsor_plan_localizations` is empty there. There's no data to convert — only the column *shape* is wrong.

## Change

Replace the single ALTER COLUMN TYPE with a DROP + ADD sequence that doesn't use a `USING` clause at all:

```sql
ALTER TABLE sponsor_plan_localizations DROP COLUMN benefits;
ALTER TABLE sponsor_plan_localizations
  ADD COLUMN benefits text[] NOT NULL DEFAULT ARRAY[]::text[];
ALTER TABLE sponsor_plan_localizations
  ALTER COLUMN benefits DROP DEFAULT;
```

- No subquery, so Postgres accepts it.
- `NOT NULL` is preserved.
- The transient `DEFAULT` exists only so the `NOT NULL` add can succeed; it's dropped immediately after to keep the schema lined up with the model (`@Field var benefits: [String]` doesn't supply a default).
- Revert path mirrors back to jsonb the same way.

SQLite (test backend) keeps skipping this migration via the existing `dialect.name == "postgresql"` guard.

## Test plan

- [x] `cd Server && swift test` → 137/137 pass.
- [ ] CI green on this PR.
- [ ] After merge: prod deploy completes, `AlterSponsorPlanLocalizationBenefitsToStringArray` succeeds, `SeedSponsorPlans2026` then runs, machines stay `started`, `curl https://api.tryswift.jp/health` returns 200.

## Related

Tail of the broken sequence: #470 → #471 → #472 → #473 → #474 → #475 → #300. This is the final piece — once it lands, the Sponsor + Scholarship migrations should reach a stable state on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)