### PR TITLE
Phase 3a: scaffold SponsorAPIController (public read endpoints)

### DIFF
--- a/Server/Sources/Server/Sponsor/Controllers/SponsorAPIController.swift
+++ b/Server/Sources/Server/Sponsor/Controllers/SponsorAPIController.swift
@@ -1,0 +1,104 @@
+import Fluent
+import Foundation
+import JWT
+import SharedModels
+import Vapor
+
+/// JSON endpoints powering the (planned) static sponsor.tryswift.jp portal on
+/// Cloudflare Pages. Mounted by `routes.swift` under `/api/v1/sponsor/`.
+///
+/// Phase 3a ships the read-only public endpoints only:
+///   - `GET /api/v1/sponsor/me`     — auth-state probe; 401 when no cookie
+///   - `GET /api/v1/sponsor/plans`  — public plan list for the LP
+///   - `POST /api/v1/sponsor/logout` — clears the sponsor auth cookie
+///
+/// Inquiry intake, magic-link issue/verify, and the sponsor + organizer
+/// authenticated endpoints land in subsequent PRs (Phase 3b/3c).
+struct SponsorAPIController: RouteCollection {
+  func boot(routes: RoutesBuilder) throws {
+    routes.get("me", use: me)
+    routes.get("plans", use: plans)
+    routes.post("logout", use: logout)
+  }
+
+  // MARK: - GET /api/v1/sponsor/me
+
+  func me(_ req: Request) async throws -> Response {
+    struct MeResponse: Content {
+      let id: UUID
+      let email: String
+      let displayName: String?
+      let role: SponsorMemberRole?
+      let organization: SponsorOrganizationDTO?
+    }
+
+    guard
+      let raw = req.cookies[SponsorAuthCookie.name]?.string,
+      let payload = try? await req.jwt.verify(raw, as: SponsorJWTPayload.self),
+      let userID = payload.sponsorUserID,
+      let user = try await SponsorUser.find(userID, on: req.db)
+    else {
+      throw Abort(.unauthorized)
+    }
+
+    var organization: SponsorOrganizationDTO?
+    if let orgID = payload.orgID,
+      let org = try await SponsorOrganization.find(orgID, on: req.db)
+    {
+      organization = try org.toDTO()
+    }
+
+    let response = Response(status: .ok)
+    try response.content.encode(
+      MeResponse(
+        id: try user.requireID(),
+        email: user.email,
+        displayName: user.displayName,
+        role: payload.role,
+        organization: organization
+      )
+    )
+    return response
+  }
+
+  // MARK: - GET /api/v1/sponsor/plans
+
+  func plans(_ req: Request) async throws -> Response {
+    struct PlansResponse: Content {
+      let plans: [SponsorPlanDTO]
+    }
+
+    guard
+      let conference = try await Conference.query(on: req.db)
+        .filter(\.$isAcceptingSponsors == true)
+        .sort(\.$year, .descending)
+        .first()
+    else {
+      throw Abort(.serviceUnavailable, reason: "No conference is accepting sponsors")
+    }
+
+    let conferenceID = try conference.requireID()
+    let plans = try await SponsorPlan.query(on: req.db)
+      .filter(\.$conference.$id == conferenceID)
+      .filter(\.$isActive == true)
+      .sort(\.$sortOrder, .ascending)
+      .with(\.$localizations)
+      .all()
+
+    let response = Response(status: .ok)
+    try response.content.encode(PlansResponse(plans: try plans.map { try $0.toDTO() }))
+    return response
+  }
+
+  // MARK: - POST /api/v1/sponsor/logout
+
+  func logout(_ req: Request) async throws -> Response {
+    let response = Response(status: .ok)
+    var cookie = SponsorAuthCookie.make(value: "", ttl: 0)
+    cookie.expires = Date(timeIntervalSince1970: 0)
+    cookie.maxAge = 0
+    response.cookies[SponsorAuthCookie.name] = cookie
+    try response.content.encode(["ok": true])
+    return response
+  }
+}

--- a/Server/Sources/Server/routes.swift
+++ b/Server/Sources/Server/routes.swift
@@ -33,6 +33,11 @@ enum AppRoutes {
     // by the static student.tryswift.jp site hosted on Cloudflare Pages.
     try api.grouped("scholarship").register(collection: ScholarshipAPIController())
 
+    // Sponsor portal — JSON endpoints that the (in-progress) static
+    // sponsor.tryswift.jp Cloudflare Pages site will consume. Lives alongside
+    // the existing SSR sponsor routes; both sources of truth for now.
+    try api.grouped("sponsor").register(collection: SponsorAPIController())
+
     // Sponsor portal routes (host-filtered to sponsor.tryswift.jp)
     try app.register(collection: SponsorRoutes())
   }


### PR DESCRIPTION
## Summary

First slice of the sponsor SSR → static-site migration plan: stand up a JSON API surface at `/api/v1/sponsor/` that mirrors what `ScholarshipAPIController` already does for `student.tryswift.jp`. The existing SSR sponsor routes are unchanged — both surfaces coexist until WebSponsorBuilder is wired up to Cloudflare Pages and the SSR routes are retired (Phase 6).

## Endpoints in this PR

| Method | Path | Purpose |
| ------ | ---- | ------- |
| `GET`  | `/api/v1/sponsor/me`     | auth-state probe for client JS bootstrap; 401 when cookie absent |
| `GET`  | `/api/v1/sponsor/plans`  | public sponsor-plan list (with locale rows) for the LP |
| `POST` | `/api/v1/sponsor/logout` | clears `sponsor_auth_token` cookie |

These are all read-only / safe to ship before the static site exists; they're enough to let the planned `sponsor.js` bootstrap toggle auth UI and render the plans grid.

## Subsequent PRs

- **Phase 3b**: `POST /inquiries` (intake), `POST /login` (magic-link issue), `GET /auth/verify` (cookie-set redirect)
- **Phase 3c**: authenticated portal — `/me/application`, `/team/*`, `/applications/*`
- **Phase 3d**: organizer admin endpoints + WebSponsorBuilder static pages + `sponsor.js` + `deploy-websponsor.yml`

## Reuse

- `SponsorAuthCookie` (existing) — already domain-scoped to `.tryswift.jp`, no change needed for cross-subdomain XHR.
- `SponsorJWTPayload` (existing) — verification path identical to `StudentJWTPayload` in `ScholarshipAPIController.me`.
- `SponsorPlan.toDTO()` + `SponsorOrganization.toDTO()` (existing) — same DTOs the iOS / SSR layers consume.

## Test plan

- [x] `cd Server && swift test` → 137/137 pass.
- [ ] CI green.
- [ ] After merge + redeploy: `curl -sSI https://api.tryswift.jp/api/v1/sponsor/plans` returns 200 JSON; `/me` returns 401 without cookie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)