### PR TITLE
Phase 3b: sponsor inquiry / magic-link / verify JSON endpoints

### DIFF
--- a/Server/Sources/Server/Sponsor/Controllers/SponsorAPIController.swift
+++ b/Server/Sources/Server/Sponsor/Controllers/SponsorAPIController.swift
@@ -7,18 +7,26 @@ import Vapor
 /// JSON endpoints powering the (planned) static sponsor.tryswift.jp portal on
 /// Cloudflare Pages. Mounted by `routes.swift` under `/api/v1/sponsor/`.
 ///
-/// Phase 3a ships the read-only public endpoints only:
-///   - `GET /api/v1/sponsor/me`     — auth-state probe; 401 when no cookie
-///   - `GET /api/v1/sponsor/plans`  — public plan list for the LP
-///   - `POST /api/v1/sponsor/logout` — clears the sponsor auth cookie
+/// Phase 3a/3b ship the public surface:
+///   - `GET  /api/v1/sponsor/me`            — auth-state probe; 401 when no cookie
+///   - `GET  /api/v1/sponsor/plans`         — public plan list for the LP
+///   - `POST /api/v1/sponsor/logout`        — clears the sponsor auth cookie
+///   - `POST /api/v1/sponsor/inquiries`     — sponsor inquiry intake; sends magic
+///                                            link + materials email, notifies Slack
+///   - `POST /api/v1/sponsor/login`         — magic-link issue for an existing user
+///   - `GET  /api/v1/sponsor/auth/verify`   — single-use token verify; sets
+///                                            `sponsor_auth_token` cookie and
+///                                            returns JSON
 ///
-/// Inquiry intake, magic-link issue/verify, and the sponsor + organizer
-/// authenticated endpoints land in subsequent PRs (Phase 3b/3c).
+/// The authenticated portal endpoints land in Phase 3c.
 struct SponsorAPIController: RouteCollection {
   func boot(routes: RoutesBuilder) throws {
     routes.get("me", use: me)
     routes.get("plans", use: plans)
     routes.post("logout", use: logout)
+    routes.post("inquiries", use: createInquiry)
+    routes.post("login", use: requestMagicLink)
+    routes.get("auth", "verify", use: verifyMagicLink)
   }
 
   // MARK: - GET /api/v1/sponsor/me
@@ -100,5 +108,181 @@ struct SponsorAPIController: RouteCollection {
     response.cookies[SponsorAuthCookie.name] = cookie
     try response.content.encode(["ok": true])
     return response
+  }
+
+  // MARK: - POST /api/v1/sponsor/inquiries
+
+  /// Records a SponsorInquiry, finds-or-creates the SponsorUser, sends the
+  /// materials email + magic-link login email, and notifies Slack. Returns
+  /// `{ok: true}` so the static client can route the user to a thanks view
+  /// without depending on a server-issued redirect.
+  func createInquiry(_ req: Request) async throws -> Response {
+    let payload = try req.content.decode(SponsorInquiryFormPayload.self)
+    let locale = inquiryLocale(req)
+    guard
+      let conference = try await Conference.query(on: req.db)
+        .filter(\.$isAcceptingSponsors == true)
+        .sort(\.$year, .descending)
+        .first()
+    else {
+      throw Abort(.serviceUnavailable, reason: "No conference is accepting sponsors")
+    }
+
+    let inquiry = SponsorInquiry(
+      conferenceID: try conference.requireID(),
+      companyName: payload.companyName,
+      contactName: payload.contactName,
+      email: payload.email,
+      message: payload.message ?? "",
+      locale: locale
+    )
+    try await inquiry.save(on: req.db)
+
+    let user = try await SponsorPublicController.findOrCreateUser(
+      email: payload.email,
+      displayName: payload.contactName,
+      locale: locale,
+      on: req.db
+    )
+
+    let issued = try await MagicLinkService.issue(for: user, on: req.db)
+    let baseURL = sponsorBaseURL()
+    guard let verifyURL = URL(string: "\(baseURL)/auth/verify?token=\(issued.rawToken)") else {
+      throw Abort(.internalServerError, reason: "Invalid SPONSOR_BASE_URL")
+    }
+    let materialsURL =
+      URL(
+        string: Environment.get("SPONSOR_MATERIALS_URL")
+          ?? "\(baseURL)/sponsor/materials/sponsor-pack-2026.pdf") ?? verifyURL
+    let from = Environment.get("RESEND_FROM_EMAIL") ?? "Sponsorship <sponsorship@mail.tryswift.jp>"
+
+    let mat = SponsorEmailTemplates.render(
+      .inquiryReceived(materialsURL: materialsURL),
+      locale: locale,
+      recipientName: payload.contactName)
+    _ = await ResendClient.send(
+      to: payload.email,
+      from: from,
+      subject: mat.subject,
+      html: mat.htmlBody,
+      text: mat.textBody,
+      client: req.client,
+      logger: req.logger)
+
+    let login = SponsorEmailTemplates.render(
+      .magicLink(verifyURL: verifyURL, ttlMinutes: 30),
+      locale: locale,
+      recipientName: payload.contactName)
+    _ = await ResendClient.send(
+      to: payload.email,
+      from: from,
+      subject: login.subject,
+      html: login.htmlBody,
+      text: login.textBody,
+      client: req.client,
+      logger: req.logger)
+
+    await SponsorSlackNotifier.notifyInquiry(
+      companyName: payload.companyName,
+      planSlug: nil,
+      client: req.client,
+      logger: req.logger)
+
+    let response = Response(status: .ok)
+    try response.content.encode(["ok": true])
+    return response
+  }
+
+  // MARK: - POST /api/v1/sponsor/login
+
+  /// Issues a magic-link email for an existing SponsorUser. Always returns
+  /// `{ok: true}` regardless of whether the email matched, so the response
+  /// shape doesn't leak which addresses are registered.
+  func requestMagicLink(_ req: Request) async throws -> Response {
+    let payload = try req.content.decode(MagicLinkRequestPayload.self)
+    if let user = try await SponsorUser.query(on: req.db)
+      .filter(\.$email == payload.email.lowercased()).first()
+    {
+      let issued = try await MagicLinkService.issue(for: user, on: req.db)
+      let baseURL = sponsorBaseURL()
+      if let url = URL(string: "\(baseURL)/auth/verify?token=\(issued.rawToken)") {
+        let from =
+          Environment.get("RESEND_FROM_EMAIL") ?? "Sponsorship <sponsorship@mail.tryswift.jp>"
+        let mail = SponsorEmailTemplates.render(
+          .magicLink(verifyURL: url, ttlMinutes: 30),
+          locale: user.locale,
+          recipientName: user.displayName)
+        _ = await ResendClient.send(
+          to: user.email,
+          from: from,
+          subject: mail.subject,
+          html: mail.htmlBody,
+          text: mail.textBody,
+          client: req.client,
+          logger: req.logger)
+      }
+    }
+    let response = Response(status: .ok)
+    try response.content.encode(["ok": true])
+    return response
+  }
+
+  // MARK: - GET /api/v1/sponsor/auth/verify
+
+  /// Verifies a single-use magic-link token, mints a sponsor JWT, and sets
+  /// the `sponsor_auth_token` cookie. Returns JSON describing the resulting
+  /// session so the static client can decide where to navigate.
+  func verifyMagicLink(_ req: Request) async throws -> Response {
+    struct VerifyResponse: Content {
+      let id: UUID
+      let email: String
+      let role: SponsorMemberRole?
+      let organization: SponsorOrganizationDTO?
+    }
+
+    let token = try req.query.get(String.self, at: "token")
+    guard let user = try await MagicLinkService.verify(rawToken: token, on: req.db) else {
+      throw Abort(.unauthorized, reason: "Invalid or expired token")
+    }
+    let membership = try await SponsorMembership.query(on: req.db)
+      .filter(\.$user.$id == (try user.requireID()))
+      .first()
+
+    let jwtPayload = SponsorJWTPayload(
+      userID: try user.requireID(),
+      orgID: membership?.$organization.id,
+      role: membership?.role,
+      locale: user.locale
+    )
+    let signed = try await req.jwt.sign(jwtPayload)
+
+    var organization: SponsorOrganizationDTO?
+    if let orgID = membership?.$organization.id,
+      let org = try await SponsorOrganization.find(orgID, on: req.db)
+    {
+      organization = try org.toDTO()
+    }
+
+    let response = Response(status: .ok)
+    response.cookies[SponsorAuthCookie.name] = SponsorAuthCookie.make(value: signed)
+    try response.content.encode(
+      VerifyResponse(
+        id: try user.requireID(),
+        email: user.email,
+        role: membership?.role,
+        organization: organization
+      )
+    )
+    return response
+  }
+
+  // MARK: - Helpers
+
+  private func sponsorBaseURL() -> String {
+    Environment.get("SPONSOR_BASE_URL") ?? "https://sponsor.tryswift.jp"
+  }
+
+  private func inquiryLocale(_ req: Request) -> SponsorPortalLocale {
+    SponsorPortalLocale(rawValue: req.headers.first(name: "X-Locale") ?? "") ?? .ja
   }
 }

--- a/Server/Tests/ServerTests/Sponsor/SponsorPublicAPIFlowTests.swift
+++ b/Server/Tests/ServerTests/Sponsor/SponsorPublicAPIFlowTests.swift
@@ -10,6 +10,35 @@ import VaporTesting
 
 @Suite("SponsorPublicAPIFlow")
 struct SponsorPublicAPIFlowTests {
+  // Local Codable mirrors of the controller-private response shapes so tests
+  // assert on decoded values (Copilot review feedback on #479) instead of
+  // raw JSON substrings.
+
+  struct MeResponseBody: Content {
+    let id: UUID
+    let email: String
+    let displayName: String?
+    let role: SponsorMemberRole?
+    let organization: SponsorOrganizationDTO?
+  }
+
+  struct PlansResponseBody: Content {
+    let plans: [SponsorPlanDTO]
+  }
+
+  struct OkResponseBody: Content {
+    let ok: Bool
+  }
+
+  struct VerifyResponseBody: Content {
+    let id: UUID
+    let email: String
+    let role: SponsorMemberRole?
+    let organization: SponsorOrganizationDTO?
+  }
+
+  // MARK: - GET /me
+
   @Test("GET /api/v1/sponsor/me returns 401 without cookie, 200 with valid JWT")
   func meEndpoint() async throws {
     let app = try await SponsorTestEnv.makeApp()
@@ -19,15 +48,12 @@ struct SponsorPublicAPIFlowTests {
 
     try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
 
-    // No cookie → 401.
     try await app.testing().test(.GET, "api/v1/sponsor/me") { res in
       #expect(res.status == .unauthorized)
     }
 
-    // With a valid sponsor JWT cookie → 200.
-    let payload = SponsorJWTPayload(
-      userID: try user.requireID(), orgID: nil, role: nil, locale: .ja)
-    let token = try await app.jwt.keys.sign(payload)
+    let token = try await app.jwt.keys.sign(
+      SponsorJWTPayload(userID: try user.requireID(), orgID: nil, role: nil, locale: .ja))
     let cookieHeader = "\(SponsorAuthCookie.name)=\(token)"
 
     try await app.testing().test(
@@ -37,8 +63,10 @@ struct SponsorPublicAPIFlowTests {
       }
     ) { res in
       #expect(res.status == .ok)
-      let body = res.body.string
-      #expect(body.contains("\"email\":\"alice@example.com\""))
+      let body = try res.content.decode(MeResponseBody.self)
+      #expect(body.email == "alice@example.com")
+      #expect(body.role == nil)
+      #expect(body.organization == nil)
     }
   }
 
@@ -52,12 +80,12 @@ struct SponsorPublicAPIFlowTests {
 
     try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
 
-    let payload = SponsorJWTPayload(
-      userID: try owner.requireID(),
-      orgID: try org.requireID(),
-      role: .owner,
-      locale: .ja)
-    let token = try await app.jwt.keys.sign(payload)
+    let token = try await app.jwt.keys.sign(
+      SponsorJWTPayload(
+        userID: try owner.requireID(),
+        orgID: try org.requireID(),
+        role: .owner,
+        locale: .ja))
     let cookieHeader = "\(SponsorAuthCookie.name)=\(token)"
 
     try await app.testing().test(
@@ -67,11 +95,14 @@ struct SponsorPublicAPIFlowTests {
       }
     ) { res in
       #expect(res.status == .ok)
-      let body = res.body.string
-      #expect(body.contains("\"role\":\"owner\""))
-      #expect(body.contains("\"legalName\":\"Acme Inc.\""))
+      let body = try res.content.decode(MeResponseBody.self)
+      #expect(body.email == "owner@example.com")
+      #expect(body.role == .owner)
+      #expect(body.organization?.legalName == "Acme Inc.")
     }
   }
+
+  // MARK: - GET /plans
 
   @Test("GET /api/v1/sponsor/plans lists active plans for the accepting conference")
   func plansEndpoint() async throws {
@@ -85,9 +116,9 @@ struct SponsorPublicAPIFlowTests {
 
     try await app.testing().test(.GET, "api/v1/sponsor/plans") { res in
       #expect(res.status == .ok)
-      let body = res.body.string
-      #expect(body.contains("\"slug\":\"gold\""))
-      #expect(body.contains("\"slug\":\"silver\""))
+      let body = try res.content.decode(PlansResponseBody.self)
+      let slugs = Set(body.plans.map(\.slug))
+      #expect(slugs == ["gold", "silver"])
     }
   }
 
@@ -104,7 +135,9 @@ struct SponsorPublicAPIFlowTests {
     }
   }
 
-  @Test("POST /api/v1/sponsor/logout returns 200 and emits an expired Set-Cookie")
+  // MARK: - POST /logout
+
+  @Test("POST /api/v1/sponsor/logout returns 200 and emits an expired cookie")
   func logoutEndpoint() async throws {
     let app = try await SponsorTestEnv.makeApp()
     defer { Task { try? await app.asyncShutdown() } }
@@ -113,11 +146,215 @@ struct SponsorPublicAPIFlowTests {
 
     try await app.testing().test(.POST, "api/v1/sponsor/logout") { res in
       #expect(res.status == .ok)
+      let body = try res.content.decode(OkResponseBody.self)
+      #expect(body.ok == true)
+
       let setCookie = res.headers.first(name: .setCookie) ?? ""
-      #expect(setCookie.contains(SponsorAuthCookie.name))
-      // Either Max-Age=0 or an Expires in the past must be emitted so the
-      // browser drops the cookie immediately.
-      #expect(setCookie.contains("Max-Age=0") || setCookie.contains("Expires=Thu, 01 Jan 1970"))
+      let parsed = parseSetCookie(setCookie)
+      #expect(parsed.name == SponsorAuthCookie.name)
+      #expect(parsed.value.isEmpty)
+      // Either Max-Age=0 *or* an Expires in the past — both are valid ways
+      // to invalidate the cookie. We don't assert the date format here.
+      #expect(parsed.maxAge == 0 || (parsed.expires.map { $0 <= Date() } ?? false))
     }
   }
+
+  // MARK: - POST /inquiries
+
+  @Test("POST /api/v1/sponsor/inquiries creates SponsorInquiry + SponsorUser + MagicLink")
+  func createInquiry() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    _ = try await SponsorTestEnv.conference(app)
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    try await app.testing().test(
+      .POST, "api/v1/sponsor/inquiries",
+      beforeRequest: { req in
+        try req.content.encode(
+          SponsorInquiryFormPayload(
+            companyName: "Acme",
+            contactName: "Alice",
+            email: "alice@example.com",
+            message: "interested in Gold"
+          ))
+      }
+    ) { res in
+      #expect(res.status == .ok)
+      let body = try res.content.decode(OkResponseBody.self)
+      #expect(body.ok == true)
+    }
+
+    let inquiry = try await SponsorInquiry.query(on: app.db).first()
+    #expect(inquiry?.companyName == "Acme")
+    let user = try await SponsorUser.query(on: app.db).first()
+    #expect(user?.email == "alice@example.com")
+    let tokens = try await MagicLinkToken.query(on: app.db).all()
+    #expect(tokens.count == 1)
+  }
+
+  @Test("POST /api/v1/sponsor/inquiries returns 503 when no accepting conference")
+  func createInquiryNoAcceptingConference() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    _ = try await SponsorTestEnv.conference(app, isAcceptingSponsors: false)
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    try await app.testing().test(
+      .POST, "api/v1/sponsor/inquiries",
+      beforeRequest: { req in
+        try req.content.encode(
+          SponsorInquiryFormPayload(
+            companyName: "Acme",
+            contactName: "Alice",
+            email: "alice@example.com",
+            message: nil
+          ))
+      }
+    ) { res in
+      #expect(res.status == .serviceUnavailable)
+    }
+  }
+
+  // MARK: - POST /login
+
+  @Test("POST /api/v1/sponsor/login issues a magic-link token for an existing user")
+  func requestMagicLinkExistingUser() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    _ = try await SponsorTestEnv.conference(app)
+    _ = try await SponsorTestEnv.sponsorUser(app, email: "bob@example.com")
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    try await app.testing().test(
+      .POST, "api/v1/sponsor/login",
+      beforeRequest: { req in
+        try req.content.encode(MagicLinkRequestPayload(email: "bob@example.com"))
+      }
+    ) { res in
+      #expect(res.status == .ok)
+      let body = try res.content.decode(OkResponseBody.self)
+      #expect(body.ok == true)
+    }
+
+    let tokens = try await MagicLinkToken.query(on: app.db).all()
+    #expect(tokens.count == 1)
+  }
+
+  @Test("POST /api/v1/sponsor/login returns 200 even when user does not exist (no enumeration)")
+  func requestMagicLinkUnknownUser() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    _ = try await SponsorTestEnv.conference(app)
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    try await app.testing().test(
+      .POST, "api/v1/sponsor/login",
+      beforeRequest: { req in
+        try req.content.encode(MagicLinkRequestPayload(email: "nobody@example.com"))
+      }
+    ) { res in
+      #expect(res.status == .ok)
+    }
+
+    let tokens = try await MagicLinkToken.query(on: app.db).all()
+    #expect(tokens.isEmpty)
+    let users = try await SponsorUser.query(on: app.db).all()
+    #expect(users.isEmpty)
+  }
+
+  // MARK: - GET /auth/verify
+
+  @Test("GET /api/v1/sponsor/auth/verify sets sponsor cookie and returns user info")
+  func verifyMagicLinkSetsCookie() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    _ = try await SponsorTestEnv.conference(app)
+    let user = try await SponsorTestEnv.sponsorUser(app, email: "carol@example.com")
+    let issued = try await MagicLinkService.issue(for: user, on: app.db)
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    try await app.testing().test(
+      .GET, "api/v1/sponsor/auth/verify?token=\(issued.rawToken)"
+    ) { res in
+      #expect(res.status == .ok)
+      let body = try res.content.decode(VerifyResponseBody.self)
+      #expect(body.email == "carol@example.com")
+      #expect(body.role == nil)
+      #expect(body.organization == nil)
+
+      let setCookie = res.headers.first(name: .setCookie) ?? ""
+      let parsed = parseSetCookie(setCookie)
+      #expect(parsed.name == SponsorAuthCookie.name)
+      #expect(parsed.value.isEmpty == false)
+    }
+  }
+
+  @Test("GET /api/v1/sponsor/auth/verify rejects invalid token with 401")
+  func verifyMagicLinkInvalidToken() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    _ = try await SponsorTestEnv.conference(app)
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    try await app.testing().test(
+      .GET, "api/v1/sponsor/auth/verify?token=not-a-real-token"
+    ) { res in
+      #expect(res.status == .unauthorized)
+      #expect(res.headers.first(name: .setCookie) == nil)
+    }
+  }
+}
+
+// MARK: - Set-Cookie parsing helper
+
+/// Lightweight parser for the Set-Cookie response header so the tests can
+/// assert on cookie value / max-age / expires without depending on the exact
+/// date format used by the framework.
+private struct ParsedCookie {
+  let name: String
+  let value: String
+  let maxAge: Int?
+  let expires: Date?
+}
+
+private func parseSetCookie(_ header: String) -> ParsedCookie {
+  var name = ""
+  var value = ""
+  var maxAge: Int?
+  var expires: Date?
+
+  let attributes = header.components(separatedBy: ";").map {
+    $0.trimmingCharacters(in: .whitespaces)
+  }
+  for (index, attribute) in attributes.enumerated() {
+    if index == 0 {
+      let pair = attribute.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+      if pair.count >= 1 { name = String(pair[0]) }
+      if pair.count >= 2 { value = String(pair[1]) }
+    } else {
+      let pair = attribute.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+      let key = pair.first.map { $0.lowercased() } ?? ""
+      let raw = pair.count >= 2 ? String(pair[1]) : ""
+      switch key {
+      case "max-age":
+        maxAge = Int(raw)
+      case "expires":
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE, dd MMM yyyy HH:mm:ss zzz"
+        expires = formatter.date(from: raw)
+      default:
+        break
+      }
+    }
+  }
+  return ParsedCookie(name: name, value: value, maxAge: maxAge, expires: expires)
 }


### PR DESCRIPTION
## Summary

Adds the public-write surface to `/api/v1/sponsor/*` so the upcoming Cloudflare Pages sponsor site can submit inquiries, request magic links, and verify them — without depending on the SSR redirect-based flows in `SponsorPublicController`. The SSR routes stay live for now.

## New endpoints (`SponsorAPIController`)

| Method | Path | Purpose |
| --- | --- | --- |
| `POST` | `/api/v1/sponsor/inquiries` | Save a `SponsorInquiry`, find-or-create the `SponsorUser`, issue a `MagicLinkToken`, send the materials + magic-link emails, ping the sponsor Slack webhook. Returns `{ok: true}`. |
| `POST` | `/api/v1/sponsor/login` | Issue a magic-link email for an existing `SponsorUser`. **Returns `{ok: true}` regardless of whether the address matches**, so the response shape doesn't enumerate registered emails. |
| `GET`  | `/api/v1/sponsor/auth/verify?token=...` | Verify a single-use token, mint `SponsorJWTPayload`, set the `sponsor_auth_token` cookie via `SponsorAuthCookie.make`, and return the resulting session as JSON (`{id, email, role, organization}`). The client decides where to navigate next instead of relying on a server redirect. |

All three reuse existing services as-is: `MagicLinkService`, `SponsorEmailTemplates`, `ResendClient`, `SponsorSlackNotifier`, and `SponsorPublicController.findOrCreateUser` (the race-safe helper for concurrent inserts).

## Test refactor + new coverage (Copilot follow-up to #479)

The previous `SponsorPublicAPIFlowTests` asserted with `body.contains(...)` substring matches and raw `Set-Cookie` header inspection — both flagged as flaky in Copilot's review of #479. This PR rewrites those assertions and adds tests for the new endpoints in the same robust shape:

- **Codable response decoding**: introduced local `MeResponseBody`, `PlansResponseBody`, `OkResponseBody`, `VerifyResponseBody` and assertions now go through `res.content.decode(...)`. No more substring matching.
- **Cookie assertions**: a small private `parseSetCookie` helper extracts `{name, value, maxAge, expires}` from the `Set-Cookie` header so logout / verify tests can check semantic invariants (`maxAge == 0` *or* `expires <= now()`, value empty / non-empty) without depending on the raw `Expires=` date format.
- **6 new tests**: `createInquiry` happy path + 503-when-no-conference, `requestMagicLink` existing user + unknown user (no-enumeration assertion), `verifyMagicLink` success + invalid-token rejection.

`TestingHTTPResponse` (VaporTesting) doesn't expose `.cookies`, hence the manual `Set-Cookie` parser. Same approach Copilot suggested in spirit (read structured fields, don't string-match), just done at the test-helper layer.

## Test plan

- [x] `cd Server && swift test --filter SponsorPublicAPIFlow` → 11/11 pass.
- [x] `cd Server && swift test` → 148/148 pass (was 142).
- [ ] CI green.
- [ ] After merge + redeploy: `curl -X POST -H 'Content-Type: application/json' -d '{"email":"x@x.x"}' https://api.tryswift.jp/api/v1/sponsor/login` returns 200 `{"ok":true}`.

## Out of scope (next PRs)

- **Phase 3c**: authenticated portal — `/me/application`, `/team/*`, `/applications/*`.
- **Phase 3d**: organizer admin endpoints + `WebSponsorBuilder` static pages + `sponsor.js` + `deploy-websponsor.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)