### PR TITLE
Phase 3c: sponsor-authenticated application endpoints

### DIFF
--- a/Server/Sources/Server/Sponsor/Controllers/SponsorAPIController.swift
+++ b/Server/Sources/Server/Sponsor/Controllers/SponsorAPIController.swift
@@ -18,7 +18,11 @@ import Vapor
 ///                                            `sponsor_auth_token` cookie and
 ///                                            returns JSON
 ///
-/// The authenticated portal endpoints land in Phase 3c.
+/// Phase 3c adds the sponsor-authenticated application surface:
+///   - `GET  /api/v1/sponsor/me/application`        — current latest application
+///   - `POST /api/v1/sponsor/applications`          — submit a new application
+///   - `GET  /api/v1/sponsor/applications/:id`      — detail (membership-gated)
+///   - `POST /api/v1/sponsor/applications/:id/withdraw` — owner-only withdraw
 struct SponsorAPIController: RouteCollection {
   func boot(routes: RoutesBuilder) throws {
     routes.get("me", use: me)
@@ -27,6 +31,14 @@ struct SponsorAPIController: RouteCollection {
     routes.post("inquiries", use: createInquiry)
     routes.post("login", use: requestMagicLink)
     routes.get("auth", "verify", use: verifyMagicLink)
+
+    // Sponsor-authenticated subgroup. We pass `nil` so missing/invalid
+    // cookies surface as 401 JSON instead of redirecting to the SSR /login.
+    let authed = routes.grouped(SponsorAuthMiddleware(onMissingRedirectTo: nil))
+    authed.get("me", "application", use: myApplication)
+    authed.post("applications", use: createApplication)
+    authed.get("applications", ":id", use: applicationDetail)
+    authed.post("applications", ":id", "withdraw", use: withdrawApplication)
   }
 
   // MARK: - GET /api/v1/sponsor/me
@@ -276,6 +288,188 @@ struct SponsorAPIController: RouteCollection {
     return response
   }
 
+  // MARK: - GET /api/v1/sponsor/me/application
+
+  /// Returns the currently-signed-in sponsor user's latest application for
+  /// the active conference, or 404 if they have not yet applied.
+  func myApplication(_ req: Request) async throws -> Response {
+    guard let user = req.sponsorUser else { throw Abort(.unauthorized) }
+
+    guard
+      let membership = try await SponsorMembership.query(on: req.db)
+        .filter(\.$user.$id == (try user.requireID()))
+        .first()
+    else { throw Abort(.notFound) }
+
+    let conference = try await currentConference(on: req.db)
+    guard
+      let application = try await SponsorApplication.query(on: req.db)
+        .filter(\.$organization.$id == membership.$organization.id)
+        .filter(\.$conference.$id == (try conference.requireID()))
+        .sort(\.$createdAt, .descending)
+        .first()
+    else { throw Abort(.notFound) }
+
+    let response = Response(status: .ok)
+    try response.content.encode(try application.toDTO())
+    return response
+  }
+
+  // MARK: - POST /api/v1/sponsor/applications
+
+  /// JSON-friendly application intake. Mirrors the SSR form-post flow but
+  /// expects `acceptedTerms: Bool` instead of the form-encoded "true"/"on"
+  /// string the SSR controller has to coerce.
+  func createApplication(_ req: Request) async throws -> Response {
+    struct CreatePayload: Content {
+      let planSlug: String
+      let billingContactName: String
+      let billingEmail: String
+      let invoicingNotes: String?
+      let logoNote: String?
+      let acceptedTerms: Bool
+    }
+
+    guard let user = req.sponsorUser else { throw Abort(.unauthorized) }
+    let payload = try req.content.decode(CreatePayload.self)
+    guard payload.acceptedTerms else {
+      throw Abort(.badRequest, reason: "Terms must be accepted")
+    }
+
+    guard
+      let membership = try await SponsorMembership.query(on: req.db)
+        .filter(\.$user.$id == (try user.requireID()))
+        .with(\.$organization)
+        .first()
+    else { throw Abort(.forbidden, reason: "No organization") }
+
+    let conference = try await currentConference(on: req.db)
+    guard
+      let plan = try await SponsorPlan.query(on: req.db)
+        .filter(\.$conference.$id == (try conference.requireID()))
+        .filter(\.$slug == payload.planSlug)
+        .first()
+    else { throw Abort(.notFound, reason: "Plan not found") }
+
+    let locale = req.sponsorJWT?.locale ?? user.locale
+    let formPayload = SponsorApplicationFormPayload(
+      billingContactName: payload.billingContactName,
+      billingEmail: payload.billingEmail,
+      invoicingNotes: payload.invoicingNotes,
+      logoNote: payload.logoNote,
+      acceptedTerms: payload.acceptedTerms,
+      locale: locale
+    )
+    let application = SponsorApplication(
+      organizationID: try membership.organization.requireID(),
+      planID: try plan.requireID(),
+      conferenceID: try conference.requireID(),
+      status: .submitted,
+      payload: formPayload,
+      submittedAt: Date()
+    )
+    try await application.save(on: req.db)
+
+    let planName =
+      (try await SponsorPlanLocalization.query(on: req.db)
+      .filter(\.$plan.$id == (try plan.requireID()))
+      .filter(\.$locale == locale)
+      .first())?.name ?? plan.slug
+
+    let mail = SponsorEmailTemplates.render(
+      .applicationReceived(planName: planName),
+      locale: locale, recipientName: payload.billingContactName)
+    let from =
+      Environment.get("RESEND_FROM_EMAIL") ?? "Sponsorship <sponsorship@mail.tryswift.jp>"
+    _ = await ResendClient.send(
+      to: payload.billingEmail, from: from,
+      subject: mail.subject, html: mail.htmlBody, text: mail.textBody,
+      client: req.client, logger: req.logger)
+    await SponsorSlackNotifier.notifyApplicationSubmitted(
+      orgName: membership.organization.displayName, planName: planName,
+      client: req.client, logger: req.logger)
+
+    let response = Response(status: .created)
+    try response.content.encode(try application.toDTO())
+    return response
+  }
+
+  // MARK: - GET /api/v1/sponsor/applications/:id
+
+  /// Returns one application's details if the caller is a member of the
+  /// owning organization. Includes a `canWithdraw` hint so the client can
+  /// gate the withdraw button without a second request.
+  func applicationDetail(_ req: Request) async throws -> Response {
+    struct DetailResponse: Content {
+      let application: SponsorApplicationDTO
+      let planName: String
+      let canWithdraw: Bool
+    }
+
+    guard let user = req.sponsorUser else { throw Abort(.unauthorized) }
+    guard let id = req.parameters.get("id", as: UUID.self) else { throw Abort(.badRequest) }
+
+    let application = try await SponsorApplication.query(on: req.db)
+      .filter(\.$id == id)
+      .with(\.$plan) { $0.with(\.$localizations) }
+      .first()
+    guard let application else { throw Abort(.notFound) }
+
+    let memberships = try await SponsorMembership.query(on: req.db)
+      .filter(\.$organization.$id == application.$organization.id)
+      .filter(\.$user.$id == (try user.requireID()))
+      .all()
+    guard !memberships.isEmpty else { throw Abort(.forbidden) }
+
+    let isOwner = memberships.contains { $0.role == .owner }
+    let canWithdraw = isOwner && application.status == .submitted
+
+    let locale = req.sponsorJWT?.locale ?? user.locale
+    let planName =
+      application.plan.localizations
+      .first(where: { $0.locale == locale })?.name ?? application.plan.slug
+
+    let response = Response(status: .ok)
+    try response.content.encode(
+      DetailResponse(
+        application: try application.toDTO(),
+        planName: planName,
+        canWithdraw: canWithdraw
+      )
+    )
+    return response
+  }
+
+  // MARK: - POST /api/v1/sponsor/applications/:id/withdraw
+
+  /// Owners can withdraw an application that is still in `.submitted`. Any
+  /// other status (already in review, approved, etc.) returns 409 to signal
+  /// the operation is no longer valid.
+  func withdrawApplication(_ req: Request) async throws -> Response {
+    guard let user = req.sponsorUser else { throw Abort(.unauthorized) }
+    guard let id = req.parameters.get("id", as: UUID.self) else { throw Abort(.badRequest) }
+    guard let application = try await SponsorApplication.find(id, on: req.db)
+    else { throw Abort(.notFound) }
+
+    let isOwner =
+      try await SponsorMembership.query(on: req.db)
+      .filter(\.$organization.$id == application.$organization.id)
+      .filter(\.$user.$id == (try user.requireID()))
+      .filter(\.$role == .owner)
+      .first() != nil
+    guard isOwner else { throw Abort(.forbidden) }
+    guard application.status == .submitted else {
+      throw Abort(.conflict, reason: "Cannot withdraw — already in review")
+    }
+
+    application.status = .withdrawn
+    try await application.save(on: req.db)
+
+    let response = Response(status: .ok)
+    try response.content.encode(try application.toDTO())
+    return response
+  }
+
   // MARK: - Helpers
 
   private func sponsorBaseURL() -> String {
@@ -284,5 +478,17 @@ struct SponsorAPIController: RouteCollection {
 
   private func inquiryLocale(_ req: Request) -> SponsorPortalLocale {
     SponsorPortalLocale(rawValue: req.headers.first(name: "X-Locale") ?? "") ?? .ja
+  }
+
+  private func currentConference(on db: Database) async throws -> Conference {
+    guard
+      let conference = try await Conference.query(on: db)
+        .filter(\.$isAcceptingSponsors == true)
+        .sort(\.$year, .descending)
+        .first()
+    else {
+      throw Abort(.serviceUnavailable, reason: "No conference is accepting sponsors")
+    }
+    return conference
   }
 }

--- a/Server/Sources/Server/Sponsor/DTOs/SponsorDTOs+Content.swift
+++ b/Server/Sources/Server/Sponsor/DTOs/SponsorDTOs+Content.swift
@@ -1,0 +1,11 @@
+import SharedModels
+import Vapor
+
+// SharedModels intentionally has no Vapor dependency, so the DTOs are plain
+// `Codable`. Vapor's `Content` protocol layers request/response coding helpers
+// on top; we add the conformance here so `SponsorAPIController` can call
+// `response.content.encode(dto)` directly.
+extension SponsorApplicationDTO: @retroactive Content {}
+extension SponsorOrganizationDTO: @retroactive Content {}
+extension SponsorPlanDTO: @retroactive Content {}
+extension SponsorUserDTO: @retroactive Content {}

--- a/Server/Tests/ServerTests/Sponsor/SponsorApplicationAPIFlowTests.swift
+++ b/Server/Tests/ServerTests/Sponsor/SponsorApplicationAPIFlowTests.swift
@@ -1,0 +1,339 @@
+import Fluent
+import Foundation
+import JWT
+import Testing
+import Vapor
+import VaporTesting
+
+import struct SharedModels.SponsorApplicationDTO
+import struct SharedModels.SponsorApplicationFormPayload
+import enum SharedModels.SponsorApplicationStatus
+import enum SharedModels.SponsorMemberRole
+import enum SharedModels.SponsorPortalLocale
+
+@testable import Server
+
+@Suite("SponsorApplicationAPIFlow")
+struct SponsorApplicationAPIFlowTests {
+  // Local Codable mirror of the controller-private response shape.
+  struct DetailResponseBody: Content {
+    let application: SponsorApplicationDTO
+    let planName: String
+    let canWithdraw: Bool
+  }
+
+  // MARK: - GET /me/application
+
+  @Test("GET /api/v1/sponsor/me/application returns 401 without cookie")
+  func myApplicationUnauthenticated() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    _ = try await SponsorTestEnv.conference(app)
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    try await app.testing().test(.GET, "api/v1/sponsor/me/application") { res in
+      #expect(res.status == .unauthorized)
+    }
+  }
+
+  @Test("GET /api/v1/sponsor/me/application returns 404 when user has no organization")
+  func myApplicationNoOrg() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    _ = try await SponsorTestEnv.conference(app)
+    let user = try await SponsorTestEnv.sponsorUser(app, email: "lonely@example.com")
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    let cookie = try await signSponsorCookie(app, userID: try user.requireID())
+    try await app.testing().test(
+      .GET, "api/v1/sponsor/me/application",
+      beforeRequest: { req in
+        req.headers.replaceOrAdd(name: .cookie, value: cookie)
+      }
+    ) { res in
+      #expect(res.status == .notFound)
+    }
+  }
+
+  @Test("GET /api/v1/sponsor/me/application returns the latest application for the user's org")
+  func myApplicationHappyPath() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    let conference = try await SponsorTestEnv.conference(app)
+    let (org, owner) = try await SponsorTestEnv.organization(
+      app, ownerEmail: "owner@example.com")
+    let plan = try await SponsorTestEnv.plan(app, conference: conference, slug: "gold")
+    let saved = try await seedApplication(
+      app, organization: org, plan: plan, conference: conference)
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    let cookie = try await signSponsorCookie(
+      app, userID: try owner.requireID(), orgID: try org.requireID(), role: .owner)
+    try await app.testing().test(
+      .GET, "api/v1/sponsor/me/application",
+      beforeRequest: { req in
+        req.headers.replaceOrAdd(name: .cookie, value: cookie)
+      }
+    ) { res in
+      #expect(res.status == .ok)
+      let body = try res.content.decode(SponsorApplicationDTO.self)
+      #expect(body.id == (try saved.requireID()))
+      #expect(body.status == .submitted)
+    }
+  }
+
+  // MARK: - POST /applications
+
+  @Test("POST /api/v1/sponsor/applications creates a SponsorApplication and returns 201")
+  func createApplicationHappyPath() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    let conference = try await SponsorTestEnv.conference(app)
+    let (org, owner) = try await SponsorTestEnv.organization(
+      app, ownerEmail: "owner@example.com")
+    _ = try await SponsorTestEnv.plan(app, conference: conference, slug: "gold")
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    struct CreatePayload: Content {
+      let planSlug: String
+      let billingContactName: String
+      let billingEmail: String
+      let invoicingNotes: String?
+      let logoNote: String?
+      let acceptedTerms: Bool
+    }
+
+    let cookie = try await signSponsorCookie(
+      app, userID: try owner.requireID(), orgID: try org.requireID(), role: .owner)
+
+    try await app.testing().test(
+      .POST, "api/v1/sponsor/applications",
+      beforeRequest: { req in
+        req.headers.replaceOrAdd(name: .cookie, value: cookie)
+        try req.content.encode(
+          CreatePayload(
+            planSlug: "gold",
+            billingContactName: "Owner",
+            billingEmail: "billing@example.com",
+            invoicingNotes: nil,
+            logoNote: nil,
+            acceptedTerms: true
+          )
+        )
+      }
+    ) { res in
+      #expect(res.status == .created)
+      let body = try res.content.decode(SponsorApplicationDTO.self)
+      #expect(body.status == .submitted)
+    }
+
+    let saved = try await SponsorApplication.query(on: app.db).all()
+    #expect(saved.count == 1)
+  }
+
+  @Test("POST /api/v1/sponsor/applications rejects when acceptedTerms is false")
+  func createApplicationTermsRequired() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    let conference = try await SponsorTestEnv.conference(app)
+    let (org, owner) = try await SponsorTestEnv.organization(
+      app, ownerEmail: "owner@example.com")
+    _ = try await SponsorTestEnv.plan(app, conference: conference, slug: "gold")
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    struct CreatePayload: Content {
+      let planSlug: String
+      let billingContactName: String
+      let billingEmail: String
+      let invoicingNotes: String?
+      let logoNote: String?
+      let acceptedTerms: Bool
+    }
+
+    let cookie = try await signSponsorCookie(
+      app, userID: try owner.requireID(), orgID: try org.requireID(), role: .owner)
+
+    try await app.testing().test(
+      .POST, "api/v1/sponsor/applications",
+      beforeRequest: { req in
+        req.headers.replaceOrAdd(name: .cookie, value: cookie)
+        try req.content.encode(
+          CreatePayload(
+            planSlug: "gold",
+            billingContactName: "Owner",
+            billingEmail: "billing@example.com",
+            invoicingNotes: nil,
+            logoNote: nil,
+            acceptedTerms: false
+          )
+        )
+      }
+    ) { res in
+      #expect(res.status == .badRequest)
+    }
+  }
+
+  // MARK: - GET /applications/:id
+
+  @Test("GET /api/v1/sponsor/applications/:id returns detail with canWithdraw=true for owner")
+  func detailOwnerCanWithdraw() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    let conference = try await SponsorTestEnv.conference(app)
+    let (org, owner) = try await SponsorTestEnv.organization(
+      app, ownerEmail: "owner@example.com")
+    let plan = try await SponsorTestEnv.plan(app, conference: conference, slug: "gold")
+    let saved = try await seedApplication(
+      app, organization: org, plan: plan, conference: conference)
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    let cookie = try await signSponsorCookie(
+      app, userID: try owner.requireID(), orgID: try org.requireID(), role: .owner)
+
+    try await app.testing().test(
+      .GET, "api/v1/sponsor/applications/\(try saved.requireID())",
+      beforeRequest: { req in
+        req.headers.replaceOrAdd(name: .cookie, value: cookie)
+      }
+    ) { res in
+      #expect(res.status == .ok)
+      let body = try res.content.decode(DetailResponseBody.self)
+      #expect(body.application.status == .submitted)
+      #expect(body.canWithdraw == true)
+      #expect(body.planName == "Gold")
+    }
+  }
+
+  @Test("GET /api/v1/sponsor/applications/:id returns 403 for non-member")
+  func detailForbiddenForNonMember() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    let conference = try await SponsorTestEnv.conference(app)
+    let (org, _) = try await SponsorTestEnv.organization(
+      app, ownerEmail: "owner@example.com")
+    let plan = try await SponsorTestEnv.plan(app, conference: conference, slug: "gold")
+    let saved = try await seedApplication(
+      app, organization: org, plan: plan, conference: conference)
+    let outsider = try await SponsorTestEnv.sponsorUser(app, email: "outsider@example.com")
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    let cookie = try await signSponsorCookie(app, userID: try outsider.requireID())
+    try await app.testing().test(
+      .GET, "api/v1/sponsor/applications/\(try saved.requireID())",
+      beforeRequest: { req in
+        req.headers.replaceOrAdd(name: .cookie, value: cookie)
+      }
+    ) { res in
+      #expect(res.status == .forbidden)
+    }
+  }
+
+  // MARK: - POST /applications/:id/withdraw
+
+  @Test("POST /api/v1/sponsor/applications/:id/withdraw flips status to withdrawn for owner")
+  func withdrawHappyPath() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    let conference = try await SponsorTestEnv.conference(app)
+    let (org, owner) = try await SponsorTestEnv.organization(
+      app, ownerEmail: "owner@example.com")
+    let plan = try await SponsorTestEnv.plan(app, conference: conference, slug: "gold")
+    let saved = try await seedApplication(
+      app, organization: org, plan: plan, conference: conference)
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    let cookie = try await signSponsorCookie(
+      app, userID: try owner.requireID(), orgID: try org.requireID(), role: .owner)
+
+    try await app.testing().test(
+      .POST, "api/v1/sponsor/applications/\(try saved.requireID())/withdraw",
+      beforeRequest: { req in
+        req.headers.replaceOrAdd(name: .cookie, value: cookie)
+      }
+    ) { res in
+      #expect(res.status == .ok)
+      let body = try res.content.decode(SponsorApplicationDTO.self)
+      #expect(body.status == .withdrawn)
+    }
+
+    let reloaded = try await SponsorApplication.find(try saved.requireID(), on: app.db)
+    #expect(reloaded?.status == .withdrawn)
+  }
+
+  @Test("POST /api/v1/sponsor/applications/:id/withdraw returns 409 once review has begun")
+  func withdrawConflictAfterReview() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    let conference = try await SponsorTestEnv.conference(app)
+    let (org, owner) = try await SponsorTestEnv.organization(
+      app, ownerEmail: "owner@example.com")
+    let plan = try await SponsorTestEnv.plan(app, conference: conference, slug: "gold")
+    let saved = try await seedApplication(
+      app, organization: org, plan: plan, conference: conference)
+    saved.status = .approved
+    try await saved.save(on: app.db)
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    let cookie = try await signSponsorCookie(
+      app, userID: try owner.requireID(), orgID: try org.requireID(), role: .owner)
+
+    try await app.testing().test(
+      .POST, "api/v1/sponsor/applications/\(try saved.requireID())/withdraw",
+      beforeRequest: { req in
+        req.headers.replaceOrAdd(name: .cookie, value: cookie)
+      }
+    ) { res in
+      #expect(res.status == .conflict)
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func signSponsorCookie(
+    _ app: Application,
+    userID: UUID,
+    orgID: UUID? = nil,
+    role: SponsorMemberRole? = nil,
+    locale: SponsorPortalLocale = .ja
+  ) async throws -> String {
+    let payload = SponsorJWTPayload(
+      userID: userID, orgID: orgID, role: role, locale: locale)
+    let token = try await app.jwt.keys.sign(payload)
+    return "\(SponsorAuthCookie.name)=\(token)"
+  }
+
+  private func seedApplication(
+    _ app: Application,
+    organization: SponsorOrganization,
+    plan: SponsorPlan,
+    conference: Conference
+  ) async throws -> SponsorApplication {
+    let formPayload = SponsorApplicationFormPayload(
+      billingContactName: "Owner",
+      billingEmail: "billing@example.com",
+      invoicingNotes: nil,
+      logoNote: nil,
+      acceptedTerms: true,
+      locale: .ja
+    )
+    let application = SponsorApplication(
+      organizationID: try organization.requireID(),
+      planID: try plan.requireID(),
+      conferenceID: try conference.requireID(),
+      status: .submitted,
+      payload: formPayload,
+      submittedAt: Date()
+    )
+    try await application.save(on: app.db)
+    return application
+  }
+}


### PR DESCRIPTION
## Summary

Adds the sponsor-portal **application** surface to `/api/v1/sponsor/*` so the upcoming Cloudflare Pages site can list, submit, view, and withdraw applications without depending on `SponsorApplicationController`'s SSR redirect flow. The SSR routes stay live for now.

## New endpoints (all behind `SponsorAuthMiddleware(onMissingRedirectTo: nil)`)

| Method | Path | Purpose |
| --- | --- | --- |
| `GET`  | `/api/v1/sponsor/me/application` | Latest application for the active conference belonging to the signed-in user's organization. 401 without cookie, 404 when the user has no organization or has not yet applied. |
| `POST` | `/api/v1/sponsor/applications` | Submit a new application. JSON body `{planSlug, billingContactName, billingEmail, invoicingNotes?, logoNote?, acceptedTerms: Bool}`. Mirrors the SSR flow (insert `SponsorApplication`, send Resend email, ping Slack) and returns 201 with the `SponsorApplicationDTO`. |
| `GET`  | `/api/v1/sponsor/applications/:id` | Detail for a single application. 403 if the caller is not a member of the owning org. Response includes `{application, planName, canWithdraw}` so the client can gate the withdraw button without a second request. |
| `POST` | `/api/v1/sponsor/applications/:id/withdraw` | Owner-only. Flips status to `.withdrawn` iff still `.submitted`; otherwise 409. |

## DTO `Content` conformance

`Server/Sources/Server/Sponsor/DTOs/SponsorDTOs+Content.swift` mirrors the Scholarship pattern: SharedModels DTOs are plain `Codable` (no Vapor dependency), so we add `@retroactive Content` conformances on the Server side once for the four sponsor DTOs the API surface returns. This lets `response.content.encode(dto)` work directly.

## Tests

`SponsorApplicationAPIFlowTests` (9 cases):

- 401 without cookie / 404 without org / 200 happy path on `/me/application`
- happy path `POST /applications` returning 201
- 400 when `acceptedTerms` is false
- detail with `canWithdraw: true` for owner
- detail 403 for non-member
- withdraw flips to `.withdrawn` for owner
- withdraw 409 once status has moved past `.submitted`

Selective imports (`import enum SharedModels.SponsorMemberRole` etc.) are used to keep the `Conference` symbol unambiguous between the SharedModels struct and the Server Fluent model in the test target.

## Test plan

- [x] `cd Server && swift test --filter SponsorApplicationAPIFlow` → 9/9 pass.
- [x] `cd Server && swift test` → 157/157 pass (was 148).
- [ ] CI green.

## Out of scope (next PRs)

- **Phase 3c-2**: team / profile authenticated endpoints (members CRUD, organization profile update)
- **Phase 3d**: organizer admin endpoints + `WebSponsorBuilder` static pages + `sponsor.js` + `deploy-websponsor.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)