### PR TITLE
Phase 3d-1: organizer admin JSON endpoints for sponsor portal

### DIFF
--- a/Server/Sources/Server/Sponsor/Controllers/SponsorAPIController.swift
+++ b/Server/Sources/Server/Sponsor/Controllers/SponsorAPIController.swift
@@ -32,6 +32,15 @@ import Vapor
 ///   - `DELETE /api/v1/sponsor/team/members/:userID`           — owner removes a member
 ///   - `GET    /api/v1/sponsor/invitations/:token`             — public invitation lookup
 ///   - `POST   /api/v1/sponsor/invitations/:token/accept`      — public accept (creates user + membership + magic link)
+///
+/// Phase 3d-1 adds the organizer-admin surface (cfp `auth_token` cookie):
+///   - `GET    /api/v1/sponsor/admin/organizations`            — list with member/application counts
+///   - `GET    /api/v1/sponsor/admin/organizations/:id`        — detail with members + applications
+///   - `GET    /api/v1/sponsor/admin/inquiries`                — all sponsor inquiries (newest first)
+///   - `GET    /api/v1/sponsor/admin/applications`             — all applications (newest first)
+///   - `GET    /api/v1/sponsor/admin/applications/:id`         — application detail
+///   - `POST   /api/v1/sponsor/admin/applications/:id/approve` — approve and notify
+///   - `POST   /api/v1/sponsor/admin/applications/:id/reject`  — reject (with reason) and notify
 struct SponsorAPIController: RouteCollection {
   func boot(routes: RoutesBuilder) throws {
     routes.get("me", use: me)
@@ -55,6 +64,20 @@ struct SponsorAPIController: RouteCollection {
     authed.get("team", use: getTeam)
     authed.post("team", "invitations", use: createInvitation)
     authed.delete("team", "members", ":userID", use: removeMember)
+
+    // Organizer-admin subgroup. Reuses the cfp `auth_token` cookie via
+    // OrganizerOnlyMiddleware, but with `.abortUnauthorized` so a missing
+    // cookie returns 401 JSON instead of redirecting to the SSR login page.
+    let admin =
+      routes.grouped("admin")
+      .grouped(OrganizerOnlyMiddleware(unauthenticatedAction: .abortUnauthorized))
+    admin.get("organizations", use: adminListOrganizations)
+    admin.get("organizations", ":id", use: adminOrganizationDetail)
+    admin.get("inquiries", use: adminListInquiries)
+    admin.get("applications", use: adminListApplications)
+    admin.get("applications", ":id", use: adminApplicationDetail)
+    admin.post("applications", ":id", "approve", use: adminApprove)
+    admin.post("applications", ":id", "reject", use: adminReject)
   }
 
   // MARK: - GET /api/v1/sponsor/me
@@ -753,6 +776,193 @@ struct SponsorAPIController: RouteCollection {
 
     let response = Response(status: .ok)
     try response.content.encode(["ok": true])
+    return response
+  }
+
+  // MARK: - GET /api/v1/sponsor/admin/organizations
+
+  /// Lists every sponsor organization with summary counts so the static
+  /// organizer dashboard can render a roster without a per-row fan-out.
+  func adminListOrganizations(_ req: Request) async throws -> Response {
+    struct Row: Content {
+      let id: UUID
+      let displayName: String
+      let memberCount: Int
+      let applicationCount: Int
+    }
+    struct ListResponse: Content {
+      let organizations: [Row]
+    }
+
+    let orgs = try await SponsorOrganization.query(on: req.db)
+      .with(\.$memberships)
+      .with(\.$applications)
+      .all()
+    let rows: [Row] = try orgs.map { o in
+      Row(
+        id: try o.requireID(),
+        displayName: o.displayName,
+        memberCount: o.memberships.count,
+        applicationCount: o.applications.count
+      )
+    }
+    let response = Response(status: .ok)
+    try response.content.encode(ListResponse(organizations: rows))
+    return response
+  }
+
+  // MARK: - GET /api/v1/sponsor/admin/organizations/:id
+
+  /// One organization plus the email list of its members and a compact
+  /// summary of every application it has filed.
+  func adminOrganizationDetail(_ req: Request) async throws -> Response {
+    struct ApplicationRow: Content {
+      let id: UUID
+      let planSlug: String
+      let status: SponsorApplicationStatus
+    }
+    struct DetailResponse: Content {
+      let organization: SponsorOrganizationDTO
+      let memberEmails: [String]
+      let applications: [ApplicationRow]
+    }
+
+    guard let id = req.parameters.get("id", as: UUID.self) else { throw Abort(.badRequest) }
+    let org = try await SponsorOrganization.query(on: req.db)
+      .filter(\.$id == id)
+      .with(\.$memberships) { $0.with(\.$user) }
+      .with(\.$applications) { $0.with(\.$plan) }
+      .first()
+    guard let org else { throw Abort(.notFound) }
+
+    let memberEmails = org.memberships.map { $0.user.email }
+    let applications: [ApplicationRow] = try org.applications.map { app in
+      ApplicationRow(
+        id: try app.requireID(), planSlug: app.plan.slug, status: app.status)
+    }
+    let response = Response(status: .ok)
+    try response.content.encode(
+      DetailResponse(
+        organization: try org.toDTO(),
+        memberEmails: memberEmails,
+        applications: applications
+      )
+    )
+    return response
+  }
+
+  // MARK: - GET /api/v1/sponsor/admin/inquiries
+
+  func adminListInquiries(_ req: Request) async throws -> Response {
+    struct ListResponse: Content {
+      let inquiries: [SponsorInquiryDTO]
+    }
+    let inquiries = try await SponsorInquiry.query(on: req.db)
+      .sort(\.$createdAt, .descending)
+      .all()
+    let response = Response(status: .ok)
+    try response.content.encode(
+      ListResponse(inquiries: try inquiries.map { try $0.toDTO() })
+    )
+    return response
+  }
+
+  // MARK: - GET /api/v1/sponsor/admin/applications
+
+  func adminListApplications(_ req: Request) async throws -> Response {
+    struct Row: Content {
+      let id: UUID
+      let orgName: String
+      let planSlug: String
+      let status: SponsorApplicationStatus
+    }
+    struct ListResponse: Content {
+      let applications: [Row]
+    }
+    let applications = try await SponsorApplication.query(on: req.db)
+      .with(\.$organization)
+      .with(\.$plan)
+      .sort(\.$createdAt, .descending)
+      .all()
+    let rows: [Row] = try applications.map { app in
+      Row(
+        id: try app.requireID(),
+        orgName: app.organization.displayName,
+        planSlug: app.plan.slug,
+        status: app.status
+      )
+    }
+    let response = Response(status: .ok)
+    try response.content.encode(ListResponse(applications: rows))
+    return response
+  }
+
+  // MARK: - GET /api/v1/sponsor/admin/applications/:id
+
+  func adminApplicationDetail(_ req: Request) async throws -> Response {
+    struct DetailResponse: Content {
+      let application: SponsorApplicationDTO
+      let orgName: String
+      let planName: String
+    }
+
+    guard let id = req.parameters.get("id", as: UUID.self) else { throw Abort(.badRequest) }
+    let application = try await SponsorApplication.query(on: req.db)
+      .filter(\.$id == id)
+      .with(\.$organization)
+      .with(\.$plan) { $0.with(\.$localizations) }
+      .first()
+    guard let application else { throw Abort(.notFound) }
+
+    let locale: SponsorPortalLocale =
+      SponsorPortalLocale(rawValue: req.headers.first(name: "X-Locale") ?? "") ?? .ja
+    let planName =
+      application.plan.localizations
+      .first(where: { $0.locale == locale })?.name ?? application.plan.slug
+
+    let response = Response(status: .ok)
+    try response.content.encode(
+      DetailResponse(
+        application: try application.toDTO(),
+        orgName: application.organization.displayName,
+        planName: planName
+      )
+    )
+    return response
+  }
+
+  // MARK: - POST /api/v1/sponsor/admin/applications/:id/approve
+
+  /// Approves an application via SponsorApplicationService (which also
+  /// emails the applicant and pings Slack). Returns the updated DTO so the
+  /// dashboard can refresh in place.
+  func adminApprove(_ req: Request) async throws -> Response {
+    guard let id = req.parameters.get("id", as: UUID.self) else { throw Abort(.badRequest) }
+    guard let payload = req.organizerJWT, let userID = payload.userID else {
+      throw Abort(.forbidden)
+    }
+    let application = try await SponsorApplicationService.approve(
+      applicationID: id, decidedByUserID: userID,
+      on: req.db, client: req.client, logger: req.logger)
+    let response = Response(status: .ok)
+    try response.content.encode(try application.toDTO())
+    return response
+  }
+
+  // MARK: - POST /api/v1/sponsor/admin/applications/:id/reject
+
+  /// Rejects an application with an optional reason.
+  func adminReject(_ req: Request) async throws -> Response {
+    guard let id = req.parameters.get("id", as: UUID.self) else { throw Abort(.badRequest) }
+    guard let payload = req.organizerJWT, let userID = payload.userID else {
+      throw Abort(.forbidden)
+    }
+    let body = try req.content.decode(OrganizerRejectPayload.self)
+    let application = try await SponsorApplicationService.reject(
+      applicationID: id, reason: body.reason, decidedByUserID: userID,
+      on: req.db, client: req.client, logger: req.logger)
+    let response = Response(status: .ok)
+    try response.content.encode(try application.toDTO())
     return response
   }
 

--- a/Server/Sources/Server/Sponsor/DTOs/SponsorDTOs+Content.swift
+++ b/Server/Sources/Server/Sponsor/DTOs/SponsorDTOs+Content.swift
@@ -6,6 +6,7 @@ import Vapor
 // on top; we add the conformance here so `SponsorAPIController` can call
 // `response.content.encode(dto)` directly.
 extension SponsorApplicationDTO: @retroactive Content {}
+extension SponsorInquiryDTO: @retroactive Content {}
 extension SponsorOrganizationDTO: @retroactive Content {}
 extension SponsorPlanDTO: @retroactive Content {}
 extension SponsorUserDTO: @retroactive Content {}

--- a/Server/Sources/Server/Sponsor/Middleware/OrganizerOnlyMiddleware.swift
+++ b/Server/Sources/Server/Sponsor/Middleware/OrganizerOnlyMiddleware.swift
@@ -3,11 +3,32 @@ import SharedModels
 import Vapor
 
 struct OrganizerOnlyMiddleware: AsyncMiddleware {
+  /// What to do when the request lacks a valid `auth_token` cookie.
+  /// SSR routes redirect to the cfp login page so the user can sign in;
+  /// JSON API routes (Cloudflare Pages clients) want a 401 instead so a
+  /// browser `fetch` can surface a proper error instead of landing on
+  /// an HTML page.
+  enum UnauthenticatedAction: Sendable {
+    case redirectToCfPLogin
+    case abortUnauthorized
+  }
+
+  let unauthenticatedAction: UnauthenticatedAction
+
+  init(unauthenticatedAction: UnauthenticatedAction = .redirectToCfPLogin) {
+    self.unauthenticatedAction = unauthenticatedAction
+  }
+
   func respond(to request: Request, chainingTo next: AsyncResponder) async throws -> Response {
     guard let raw = request.cookies["auth_token"]?.string,
       let payload = try? await request.jwt.verify(raw, as: UserJWTPayload.self)
     else {
-      return request.redirect(to: organizerLoginURL())
+      switch unauthenticatedAction {
+      case .redirectToCfPLogin:
+        return request.redirect(to: organizerLoginURL())
+      case .abortUnauthorized:
+        throw Abort(.unauthorized)
+      }
     }
     guard payload.role == .admin else { throw Abort(.forbidden) }
     request.storage[OrganizerJWTStorageKey.self] = payload

--- a/Server/Tests/ServerTests/Sponsor/SponsorOrganizerAPIFlowTests.swift
+++ b/Server/Tests/ServerTests/Sponsor/SponsorOrganizerAPIFlowTests.swift
@@ -1,0 +1,251 @@
+import Fluent
+import Foundation
+import JWT
+import Testing
+import Vapor
+import VaporTesting
+
+import struct SharedModels.SponsorApplicationDTO
+import struct SharedModels.SponsorApplicationFormPayload
+import enum SharedModels.SponsorApplicationStatus
+import struct SharedModels.SponsorInquiryDTO
+import struct SharedModels.SponsorOrganizationDTO
+import enum SharedModels.SponsorPortalLocale
+import enum SharedModels.UserRole
+
+@testable import Server
+
+@Suite("SponsorOrganizerAPIFlow")
+struct SponsorOrganizerAPIFlowTests {
+  // MARK: - Local response shapes
+
+  struct OrgRow: Content {
+    let id: UUID
+    let displayName: String
+    let memberCount: Int
+    let applicationCount: Int
+  }
+  struct OrganizationsListBody: Content {
+    let organizations: [OrgRow]
+  }
+
+  struct ApplicationListRow: Content {
+    let id: UUID
+    let orgName: String
+    let planSlug: String
+    let status: SponsorApplicationStatus
+  }
+  struct ApplicationsListBody: Content {
+    let applications: [ApplicationListRow]
+  }
+
+  struct InquiriesListBody: Content {
+    let inquiries: [SponsorInquiryDTO]
+  }
+
+  struct OrganizationDetailRow: Content {
+    let id: UUID
+    let planSlug: String
+    let status: SponsorApplicationStatus
+  }
+  struct OrganizationDetailBody: Content {
+    let organization: SponsorOrganizationDTO
+    let memberEmails: [String]
+    let applications: [OrganizationDetailRow]
+  }
+
+  // MARK: - Auth gating
+
+  @Test("Admin endpoints return 401 without an auth_token cookie")
+  func adminUnauthenticated() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    try await app.testing().test(.GET, "api/v1/sponsor/admin/organizations") { res in
+      #expect(res.status == .unauthorized)
+    }
+    try await app.testing().test(.GET, "api/v1/sponsor/admin/inquiries") { res in
+      #expect(res.status == .unauthorized)
+    }
+    try await app.testing().test(.GET, "api/v1/sponsor/admin/applications") { res in
+      #expect(res.status == .unauthorized)
+    }
+  }
+
+  @Test("Admin endpoints return 403 when the auth_token is non-admin")
+  func adminForbiddenForNonAdmin() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    let cookie = try await organizerCookie(app, role: .speaker)
+    try await app.testing().test(
+      .GET, "api/v1/sponsor/admin/organizations",
+      beforeRequest: { req in
+        req.headers.replaceOrAdd(name: .cookie, value: cookie)
+      }
+    ) { res in
+      #expect(res.status == .forbidden)
+    }
+  }
+
+  // MARK: - Organizations
+
+  @Test("GET /api/v1/sponsor/admin/organizations lists every org with counts")
+  func listOrganizations() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    _ = try await SponsorTestEnv.organization(app, ownerEmail: "owner@example.com")
+    _ = try await SponsorTestEnv.organization(app, ownerEmail: "second@example.com")
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    let cookie = try await organizerCookie(app, role: .admin)
+    try await app.testing().test(
+      .GET, "api/v1/sponsor/admin/organizations",
+      beforeRequest: { req in
+        req.headers.replaceOrAdd(name: .cookie, value: cookie)
+      }
+    ) { res in
+      #expect(res.status == .ok)
+      let body = try res.content.decode(OrganizationsListBody.self)
+      #expect(body.organizations.count == 2)
+      #expect(body.organizations.allSatisfy { $0.memberCount == 1 })
+    }
+  }
+
+  @Test("GET /api/v1/sponsor/admin/organizations/:id returns members + applications")
+  func organizationDetail() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    let conference = try await SponsorTestEnv.conference(app)
+    let (org, owner) = try await SponsorTestEnv.organization(
+      app, ownerEmail: "owner@example.com")
+    let plan = try await SponsorTestEnv.plan(app, conference: conference, slug: "gold")
+    _ = try await seedApplication(app, org: org, plan: plan, conference: conference)
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    let cookie = try await organizerCookie(app, role: .admin)
+    try await app.testing().test(
+      .GET, "api/v1/sponsor/admin/organizations/\(try org.requireID())",
+      beforeRequest: { req in
+        req.headers.replaceOrAdd(name: .cookie, value: cookie)
+      }
+    ) { res in
+      #expect(res.status == .ok)
+      let body = try res.content.decode(OrganizationDetailBody.self)
+      #expect(body.memberEmails.contains("owner@example.com"))
+      #expect(body.applications.count == 1)
+      #expect(body.applications.first?.planSlug == "gold")
+      _ = owner  // silence unused warning
+    }
+  }
+
+  // MARK: - Inquiries / Applications listing
+
+  @Test("GET /api/v1/sponsor/admin/inquiries returns every inquiry newest-first")
+  func listInquiries() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    let conference = try await SponsorTestEnv.conference(app)
+    try await SponsorInquiry(
+      conferenceID: try conference.requireID(),
+      companyName: "Acme",
+      contactName: "Alice",
+      email: "alice@example.com",
+      message: "interested",
+      locale: .ja
+    ).save(on: app.db)
+    try await SponsorInquiry(
+      conferenceID: try conference.requireID(),
+      companyName: "Beta",
+      contactName: "Bob",
+      email: "bob@example.com",
+      message: "",
+      locale: .ja
+    ).save(on: app.db)
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    let cookie = try await organizerCookie(app, role: .admin)
+    try await app.testing().test(
+      .GET, "api/v1/sponsor/admin/inquiries",
+      beforeRequest: { req in
+        req.headers.replaceOrAdd(name: .cookie, value: cookie)
+      }
+    ) { res in
+      #expect(res.status == .ok)
+      let body = try res.content.decode(InquiriesListBody.self)
+      #expect(body.inquiries.count == 2)
+    }
+  }
+
+  @Test("GET /api/v1/sponsor/admin/applications returns rows with org + plan info")
+  func listApplications() async throws {
+    let app = try await SponsorTestEnv.makeApp()
+    defer { Task { try? await app.asyncShutdown() } }
+    let conference = try await SponsorTestEnv.conference(app)
+    let (org, _) = try await SponsorTestEnv.organization(
+      app, ownerEmail: "owner@example.com")
+    let plan = try await SponsorTestEnv.plan(app, conference: conference, slug: "gold")
+    _ = try await seedApplication(app, org: org, plan: plan, conference: conference)
+
+    try app.grouped("api", "v1", "sponsor").register(collection: SponsorAPIController())
+
+    let cookie = try await organizerCookie(app, role: .admin)
+    try await app.testing().test(
+      .GET, "api/v1/sponsor/admin/applications",
+      beforeRequest: { req in
+        req.headers.replaceOrAdd(name: .cookie, value: cookie)
+      }
+    ) { res in
+      #expect(res.status == .ok)
+      let body = try res.content.decode(ApplicationsListBody.self)
+      #expect(body.applications.count == 1)
+      let row = body.applications.first!
+      #expect(row.orgName == "Acme")
+      #expect(row.planSlug == "gold")
+      #expect(row.status == .submitted)
+    }
+  }
+
+  // MARK: - Helpers
+
+  private func organizerCookie(
+    _ app: Application, role: UserRole
+  ) async throws -> String {
+    let payload = UserJWTPayload(userID: UUID(), role: role, username: "tester")
+    let token = try await app.jwt.keys.sign(payload)
+    return "auth_token=\(token)"
+  }
+
+  private func seedApplication(
+    _ app: Application,
+    org: SponsorOrganization,
+    plan: SponsorPlan,
+    conference: Conference
+  ) async throws -> SponsorApplication {
+    let payload = SponsorApplicationFormPayload(
+      billingContactName: "Owner",
+      billingEmail: "billing@example.com",
+      invoicingNotes: nil,
+      logoNote: nil,
+      acceptedTerms: true,
+      locale: .ja
+    )
+    let application = SponsorApplication(
+      organizationID: try org.requireID(),
+      planID: try plan.requireID(),
+      conferenceID: try conference.requireID(),
+      status: .submitted,
+      payload: payload,
+      submittedAt: Date()
+    )
+    try await application.save(on: app.db)
+    return application
+  }
+}


### PR DESCRIPTION
## Summary

Adds the cfp-organizer-authenticated JSON surface so the upcoming static Cloudflare Pages site (paired with #481 / #482's sponsor-side endpoints) can be backed by an organizer dashboard reading JSON instead of `OrganizerSponsorController`'s SSR redirect flow.

## New endpoints (behind `OrganizerOnlyMiddleware(.abortUnauthorized)`)

| Method | Path | Purpose |
| --- | --- | --- |
| `GET` | `/api/v1/sponsor/admin/organizations` | Roster: `[{id, displayName, memberCount, applicationCount}]` |
| `GET` | `/api/v1/sponsor/admin/organizations/:id` | Detail: `{organization, memberEmails, applications}` |
| `GET` | `/api/v1/sponsor/admin/inquiries` | Every `SponsorInquiry`, newest-first |
| `GET` | `/api/v1/sponsor/admin/applications` | `[{id, orgName, planSlug, status}]` |
| `GET` | `/api/v1/sponsor/admin/applications/:id` | `{application, orgName, planName}` (planName respects `X-Locale`) |
| `POST` | `/api/v1/sponsor/admin/applications/:id/approve` | Reuses `SponsorApplicationService.approve` (sends applicant email + Slack), returns the updated DTO |
| `POST` | `/api/v1/sponsor/admin/applications/:id/reject` | Reuses `SponsorApplicationService.reject` with the existing `OrganizerRejectPayload { reason }`, returns updated DTO |

## Middleware change (small)

`OrganizerOnlyMiddleware` now has an `unauthenticatedAction` enum. Default keeps the existing SSR behaviour:

```swift
enum UnauthenticatedAction { case redirectToCfPLogin, abortUnauthorized }
init(unauthenticatedAction: UnauthenticatedAction = .redirectToCfPLogin)
```

The new admin subgroup uses `.abortUnauthorized` so cross-origin browser fetches from the static portal see a clean 401 instead of an HTML redirect to `cfp.tryswift.jp/login`. SSR call site (`SponsorRoutes`) is untouched.

`SponsorInquiryDTO` joins the other sponsor DTOs in `SponsorDTOs+Content.swift` for `@retroactive Content` conformance so admin/inquiries can encode directly.

## Tests

`SponsorOrganizerAPIFlowTests` (6 cases):

- 401 without `auth_token` / 403 when `role != .admin`
- list organizations with member + application counts
- organization detail with member emails + applications array
- list inquiries returns all rows
- list applications with org name + plan slug + status

## Test plan

- [x] `cd Server && swift test --filter SponsorOrganizerAPIFlow` → 6/6 pass.
- [x] `cd Server && swift test` → 175/175 pass (was 169).
- [ ] CI green.

## Out of scope (next PRs)

- **Phase 3d-2**: WebSponsorBuilder static-page skeletons (Sponsor portal + Organizer admin pages — strip CSRF / SSR data deps, add `data-sponsor-bind` hooks).
- **Phase 3d-3**: `Web/Public/scripts/sponsor.js` client implementation.
- **Phase 3d-4**: `deploy-websponsor.yml` + Cloudflare Pages project setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)